### PR TITLE
fix: remove Mode_34 default declarations from shipped settings XML

### DIFF
--- a/indra/newview/animationexplorer.cpp
+++ b/indra/newview/animationexplorer.cpp
@@ -248,14 +248,21 @@ bool AnimationExplorer::postBuild()
     mNoOwnedAnimationsCheckBox->setCommitCallback(boost::bind(&AnimationExplorer::onOwnedCheckToggled, this));
 
     mExportButton->setEnabled(false);
-    mExportButton->setVisible(gSavedSettings.getBOOL("Mode_34"));
 
-    mExportSettingConnection = gSavedSettings.getControl("Mode_34")->getSignal()->connect(
-        [this](LLControlVariable*, const LLSD& new_val, const LLSD&)
-        {
-            mExportButton->setVisible(new_val.asBoolean());
-        }
-    );
+    // <FS:AYA> Mode_34 is intentionally not declared in shipped settings XML.
+    // Treat missing control as false (button hidden, no signal hookup).
+    LLControlVariable* mode34 = gSavedSettings.getControl("Mode_34");
+    mExportButton->setVisible(mode34 && mode34->getValue().asBoolean());
+
+    if (mode34)
+    {
+        mExportSettingConnection = mode34->getSignal()->connect(
+            [this](LLControlVariable*, const LLSD& new_val, const LLSD&)
+            {
+                mExportButton->setVisible(new_val.asBoolean());
+            }
+        );
+    }
 
     mPreviewCtrl = findChild<LLView>("animation_preview");
     if (mPreviewCtrl)

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -21532,17 +21532,6 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>Value</key>
     <integer>0</integer>
   </map>
-  <key>Mode_34</key>
-  <map>
-    <key>Comment</key>
-    <string>Show Export button in Animation Explorer.</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Boolean</string>
-    <key>Value</key>
-    <integer>0</integer>
-  </map>
   <key>MouseLookEnabled</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/app_settings/settings_firestorm.xml
+++ b/indra/newview/app_settings/settings_firestorm.xml
@@ -313,17 +313,6 @@
 	<integer>0</integer>
   </map>
 
-  <key>Mode_34</key>
-  <map>
-    <key>Comment</key>
-    <string>Enable CheckTexture in Developer menu (saves selected object mesh+textures without permission checks)</string>
-    <key>Persist</key>
-    <integer>1</integer>
-    <key>Type</key>
-    <string>Boolean</string>
-    <key>Value</key>
-    <integer>0</integer>
-  </map>
 
 </map>
 </llsd>


### PR DESCRIPTION
Mode_34 gates the Animation Explorer Export button and the Developer menu CheckTexture entry (which exports selected object mesh+textures without permission checks). Drop the default declarations from settings.xml and settings_firestorm.xml so the gates stay closed in shipped builds.

Guard AnimationExplorer construction so an undeclared control is treated as false (button hidden, no signal connect) instead of null-dereferencing on getControl()->getSignal(). llviewermenu.cpp's getBOOL path is already null-safe.

Users who want to re-enable can manually add the Mode_34 entry back to settings.xml on their installed copy.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
