### PR TITLE
AYAChatWindowStyle: ensure LL IM tab on existing-session open

### DIFF
--- a/indra/newview/llavataractions.cpp
+++ b/indra/newview/llavataractions.cpp
@@ -282,8 +282,16 @@ static void on_avatar_name_cache_start_im(const LLUUID& agent_id,
         // <FS:AYA> Phase 3: Route to LL or FS based on AYAChatWindowStyle
         if (ayastorm_is_ll_style())
         {
-            LLFloaterIMContainer* ll_container = LLFloaterReg::findTypedInstance<LLFloaterIMContainer>("ll_im_container");
-            if (ll_container) ll_container->showConversation(session_id);
+            // For an existing LLIMModel session, addSession() above only fires
+            // sessionActivated (which does not create the list item or the
+            // hosted tab), so explicitly call sessionAdded() before showing —
+            // addConversationListItem and addToHost are both idempotent.
+            LLFloaterIMContainer* ll_container = LLFloaterIMContainer::getInstance();
+            if (ll_container)
+            {
+                ll_container->sessionAdded(session_id, name, agent_id, false);
+                ll_container->showConversation(session_id);
+            }
         }
         else
         {
@@ -467,8 +475,16 @@ const LLUUID LLAvatarActions::startConference(const uuid_vec_t& ids, const LLUUI
     // <FS:AYA> Phase 3: Route to LL or FS based on AYAChatWindowStyle
     if (ayastorm_is_ll_style())
     {
-        LLFloaterIMContainer* ll_container = LLFloaterReg::findTypedInstance<LLFloaterIMContainer>("ll_im_container");
-        if (ll_container) ll_container->showConversation(session_id);
+        // See on_avatar_name_cache_start_im(): for an existing LLIMModel
+        // session, addSession() only fires sessionActivated, leaving the LL
+        // container without a tab. Call sessionAdded() explicitly (idempotent)
+        // before showing so the conference becomes addressable.
+        LLFloaterIMContainer* ll_container = LLFloaterIMContainer::getInstance();
+        if (ll_container)
+        {
+            ll_container->sessionAdded(session_id, title, ids[0], false);
+            ll_container->showConversation(session_id);
+        }
     }
     else
     {


### PR DESCRIPTION
When the LL chat-window style was active and the user clicked IM on a Friends-list entry that already had an LLIMModel session, the LL ll_im_container neither raised nor produced a tab. addSession() takes the existing-session path (notifyObserverSessionActivated), and LLFloaterIMContainer::sessionActivated only does selectConversationPair — it does not call addConversationListItem or addToHost — so the tab was never created. The follow-up findTypedInstance lookup also returned NULL whenever the LL container had not been instantiated yet, so the showConversation() call was a no-op.

Switch the LL branch in on_avatar_name_cache_start_im() and LLAvatarActions::startConference() to LLFloaterIMContainer::getInstance() (creates on demand) and explicitly call sessionAdded() before showConversation(). addConversationListItem and addToHost are both idempotent, so this is safe whether addSession() produced a new session or activated an existing one.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
