### PR TITLE
Sound prefs: expose AYAstream as "3D Stream" volume row

### DIFF
--- a/indra/newview/skins/default/xui/en/floater_fs_volume_controls.xml
+++ b/indra/newview/skins/default/xui/en/floater_fs_volume_controls.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <floater
  name="volume_controls"
- height="170"
+ height="191"
  width="225"
  layout="topleft"
  background_opaque="false"
@@ -20,7 +20,7 @@
 	 name="global_volume_controls_panel"
 	 top="20"
 	 left="0"
-	 height="155"
+	 height="176"
 	 width="225"
 	 follows="all"
 	 layout="topleft"

--- a/indra/newview/skins/default/xui/en/panel_preferences_sound.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_sound.xml
@@ -593,6 +593,35 @@
          left_pad="5"
          name="enable_voice_check_volume"
          width="110"/>
+        <slider
+         control_name="AYAStreamVolumeMaster"
+         disabled_control="MuteAudio"
+         follows="left|top"
+         height="16"
+         increment="0.025"
+         initial_value="0.5"
+         label="3D Stream"
+         label_width="120"
+         layout="topleft"
+         left="0"
+         top_pad="2"
+         name="AYAStream Volume"
+         show_text="false"
+         slider_label.halign="right"
+         volume="true"
+         width="300"/>
+        <check_box
+         label_text.halign="left"
+         follows="left|top"
+         height="16"
+         control_name="AYAStreamEnabled"
+         label="Enabled"
+         layout="topleft"
+         top_delta="2"
+         left_pad="26"
+         name="enable_ayastream_check_volume"
+         tool_tip="Positional 3D audio streams that prims publish via Description tags. Unlike parcel music, these streams start automatically based on what is in-world."
+         width="110"/>
 
         <text
          type="string"

--- a/indra/newview/skins/default/xui/en/panel_volume_pulldown.xml
+++ b/indra/newview/skins/default/xui/en/panel_volume_pulldown.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <panel
  name="volumepulldown_floater"
- height="155"
+ height="176"
  width="225"
  follows="bottom"
  layout="topleft"
@@ -342,6 +342,35 @@
 	 layout="topleft"
 	 control_name="EnableVoiceChat"
 	 disabled_control="CmdLineDisableVoice"
+	 label_text.halign="left"
+	/>
+	<slider
+	 name="AYAStream Volume"
+	 label="3D Stream"
+	 top_pad="4"
+	 left="10"
+	 height="15"
+	 width="160"
+	 follows="left|top"
+	 layout="topleft"
+	 control_name="AYAStreamVolumeMaster"
+	 disabled_control="MuteAudio"
+	 increment="0.025"
+	 initial_value="0.5"
+	 label_width="60"
+	 show_text="false"
+	 volume="true"
+	/>
+	<check_box
+	 name="enable_ayastream_check"
+	 tool_tip="Positional 3D audio streams from prims (AYAstream)"
+	 top_delta="2"
+	 left_pad="26"
+	 height="16"
+	 width="16"
+	 follows="left|top"
+	 layout="topleft"
+	 control_name="AYAStreamEnabled"
 	 label_text.halign="left"
 	/>
 </panel>

--- a/indra/newview/skins/metaharper/xui/en/panel_volume_pulldown.xml
+++ b/indra/newview/skins/metaharper/xui/en/panel_volume_pulldown.xml
@@ -7,7 +7,7 @@
  border="false"
  chrome="true"
  follows="bottom"
- height="155"
+ height="176"
  layout="topleft"
  name="volumepulldown_floater"
  width="210">
@@ -312,5 +312,32 @@
         top_delta="2"
         left_pad="5"
         name="enable_voice_check"
+        width="110"/>
+    <slider
+        control_name="AYAStreamVolumeMaster"
+        disabled_control="MuteAudio"
+        follows="left|top"
+        height="15"
+        increment="0.025"
+        initial_value="0.5"
+        label="3D Stream"
+        label_width="60"
+        left="10"
+        width="150"
+        layout="topleft"
+        top_pad="4"
+        name="AYAStream Volume"
+        show_text="false"
+        volume="true"/>
+    <check_box
+        label_text.halign="left"
+        follows="left|top"
+        height="16"
+        control_name="AYAStreamEnabled"
+        tool_tip="Positional 3D audio streams from prims (AYAstream)"
+        layout="topleft"
+        top_delta="2"
+        left_pad="26"
+        name="enable_ayastream_check"
         width="110"/>
 </panel>


### PR DESCRIPTION
Surface AYAStreamVolumeMaster + AYAStreamEnabled in two existing audio UIs:

- Preferences > Sound & Media: new "3D Stream" slider + Enabled checkbox under the Voice row, matching the Music/Media/Voice layout. Drops the standalone checkbox previously added under the Music sub-panel.
- Speaker-icon volume pulldown (and FS volume controls floater): new "3D Stream" slider + enable checkbox row after Voice; panel height bumped to fit. Mirrored in the metaharper skin override.

No C++ wiring needed - both controls already have signal listeners from M7/M8.

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
