### PR TITLE
fix: Opus codec を built-in 後段 (priority=10000) に登録

### DIFF
--- a/indra/llaudio/llaudioengine_fmodstudio.cpp
+++ b/indra/llaudio/llaudioengine_fmodstudio.cpp
@@ -377,11 +377,22 @@ bool LLAudioEngine_FMODSTUDIO::init(void* userdata, const std::string &app_title
     LL_INFOS("AppInit") << "LLAudioEngine_FMODSTUDIO::init() FMOD Studio initialized correctly" << LL_ENDL;
 
     {
+        // Register below every FMOD built-in codec so the built-ins win first
+        // for any non-Opus content. opusOpen() consumes bytes from the source
+        // during its Ogg sync probe; on a non-seekable HTTP stream those bytes
+        // can't be replayed, so a built-in codec that runs after Opus gets a
+        // truncated head and fails with FMOD_ERR_FILE_COULDNOTSEEK (this broke
+        // Parcel Music + 3D Stream HTTP MP3 the moment r9-opus shipped).
+        //
+        // Per FMOD staff (qa.fmod.com/t/18597), built-in priorities top out at
+        // USER=2600 in 2.02.06 (MPEG=2400). 10000 leaves comfortable headroom
+        // for future additions while staying numerically tame.
+        constexpr unsigned int kOpusCodecPriority = 10000;
         unsigned int opus_codec_handle = 0;
-        FMOD_RESULT codec_result = mSystem->registerCodec(FMODGetCodecDescriptionOpus(), &opus_codec_handle, 100);
+        FMOD_RESULT codec_result = mSystem->registerCodec(FMODGetCodecDescriptionOpus(), &opus_codec_handle, kOpusCodecPriority);
         if (codec_result == FMOD_OK)
         {
-            LL_INFOS("AppInit") << "LLAudioEngine_FMODSTUDIO::init() Opus codec registered (handle=" << opus_codec_handle << ")" << LL_ENDL;
+            LL_INFOS("AppInit") << "LLAudioEngine_FMODSTUDIO::init() Opus codec registered (handle=" << opus_codec_handle << ", priority=" << kOpusCodecPriority << ")" << LL_ENDL;
         }
         else
         {


### PR DESCRIPTION
r9-opus で priority=100 のまま登録したため、built-in MP3 codec より 先に Opus codec が呼ばれ、opusOpen() の Ogg sync probe が HTTP non-seekable stream から bytes を消費 → 後続 MP3 codec が seek-back できず FMOD_ERR_FILE_COULDNOTSEEK で全滅。Parcel Music + 3D Stream の HTTP MP3 配信が全部鳴らなくなっていた。

FMOD 公式 (qa.fmod.com/t/18597) によれば built-in の MPEG=2400 / USER=2600 が最大。10000 にして built-in 全部の後ろに回す。standalone test で 4 KB 消費 stub codec を priority=2000/2500/10000/UINT_MAX で 比較し、>=2500 で MP3 codec が先勝ちすることを実証。

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
