### PR TITLE
macos: improve DMG layout and sanitize build docs

### DIFF
--- a/doc/building_ayastorm_macos.md
+++ b/doc/building_ayastorm_macos.md
@@ -23,7 +23,7 @@ Output example: `Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-80834.dmg`
 export WORK="$HOME/work_ayastorm"
 export REPO="$WORK/phoenix-firestorm"
 export FS_BUILD_VARIABLES="$WORK/fs-build-variables/variables"
-export FMOD_REPO="/Users/takayukinoami/Desktop/WorkNOW/Firestorm_Develop/3p-fmodstudio"
+export FMOD_REPO="$WORK/3p-fmodstudio"
 export TARGET_REF="feature/macos-arm64-build-on-latest"
 export AYA_BUILD_ID="80834"
 ```
@@ -73,7 +73,7 @@ FMOD Studio API は FMOD 公式サイトから macOS 版を取得します。FMO
 この作業環境では FMOD package 作成に既存の local clone を使います。
 
 ```bash
-export FMOD_REPO="/Users/takayukinoami/Desktop/WorkNOW/Firestorm_Develop/3p-fmodstudio"
+export FMOD_REPO="$WORK/3p-fmodstudio"
 test -d "$FMOD_REPO/.git"
 git -C "$FMOD_REPO" remote -v
 ```

--- a/indra/newview/installers/darwin/installer-dmg.applescript
+++ b/indra/newview/installers/darwin/installer-dmg.applescript
@@ -13,6 +13,16 @@ on run (volumeName)
 			set theWidth to 340
 			set theHeight to 240
 			set iconSize to 55
+			set appPosition to {50, 90}
+			set applicationsPosition to {200, 90}
+
+			if volumeName starts with "AYAstorm Installer" then
+				set theWidth to 760
+				set theHeight to 460
+				set iconSize to 128
+				set appPosition to {190, 210}
+				set applicationsPosition to {570, 210}
+			end if
 
 			set theBottomRightX to (theXOrigin + theWidth)
 			set theBottomRightY to (theYOrigin + theHeight)
@@ -28,9 +38,9 @@ on run (volumeName)
 				set file_list to every file
 				repeat with i in file_list
 					if the name of i is "Applications" then
-						set the position of i to {200, 90}
+						set the position of i to applicationsPosition
 					else if the name of i ends with ".app" then
-						set the position of i to {50, 90}
+						set the position of i to appPosition
 					end if
 				end repeat
 			-- This close-open hack is nessesary to save positions on 10.6 Snow Leopard
@@ -44,7 +54,9 @@ on run (volumeName)
 				set arrangement to not arranged
 			end tell
 
-			set background picture of opts to file "background.png"
+			try
+				set background picture of opts to file "background.png"
+			end try
 
 			update without registering applications
 			-- Force saving of the size


### PR DESCRIPTION
## Summary
- Improve the AYAstorm DMG Finder layout for the longer app name and larger icon presentation.
- Replace local macOS FMOD path examples with WORK/3p-fmodstudio style documentation.
- Verify that personal local paths are no longer present under doc/.

## Verification
- Searched doc/ for takayukinoami, WorkNOW, Firestorm_Develop, phoenix-firestorm-mayatonton, and /Users/takayukinoami. No matches remain.
- hdiutil verify passed for the layout-fixed DMG.
- codesign --verify --deep --strict passed for the app inside the layout-fixed DMG.