### PR TITLE
Fix Windows crash from missing AYA chat settings

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -9884,7 +9884,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <real>0.9</real>
     </map>
 
-   <key>PlainTextChatHistory</key>
+    <key>PlainTextChatHistory</key>
     <map>
       <key>Comment</key>
       <string>Enable/Disable plain text chat transcript style</string>
@@ -9895,6 +9895,31 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>1</integer>
     </map>
+
+    <!-- <FS:AYA> Phase 3: Chat window style selection (0=FS V1, 1=FS V7, 2=LL Style) -->
+    <key>AYAChatWindowStyle</key>
+    <map>
+      <key>Comment</key>
+      <string>Chat window style: 0=FS V1 (plain text), 1=FS V7 (modern headers), 2=LL Style</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>S32</string>
+      <key>Value</key>
+      <integer>2</integer>
+    </map>
+    <key>AYALLChatCompactView</key>
+    <map>
+      <key>Comment</key>
+      <string>LL Style chat window: true=Compact View, false=Expanded View (independent from FS PlainTextChatHistory)</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <!-- </FS:AYA> -->
 
     <key>PluginInstancesLow</key>
     <map>

--- a/indra/newview/app_settings/settings_hybrid.xml
+++ b/indra/newview/app_settings/settings_hybrid.xml
@@ -195,6 +195,31 @@
     <integer>1</integer>
   </map>
 
+  <!-- <FS:AYA> Phase 3: Chat window style selection (0=FS V1, 1=FS V7, 2=LL Style) -->
+  <key>AYAChatWindowStyle</key>
+  <map>
+    <key>Comment</key>
+    <string>Chat window style: 0=FS V1 (plain text), 1=FS V7 (modern headers), 2=LL Style</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
+  <key>AYALLChatCompactView</key>
+  <map>
+    <key>Comment</key>
+    <string>LL Style chat window: true=Compact View, false=Expanded View (independent from FS PlainTextChatHistory)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <!-- </FS:AYA> -->
+
   <key>ShowChatMiniIcons</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/app_settings/settings_phoenix.xml
+++ b/indra/newview/app_settings/settings_phoenix.xml
@@ -207,6 +207,31 @@
     <integer>1</integer>
   </map>
 
+  <!-- <FS:AYA> Phase 3: Chat window style selection (0=FS V1, 1=FS V7, 2=LL Style) -->
+  <key>AYAChatWindowStyle</key>
+  <map>
+    <key>Comment</key>
+    <string>Chat window style: 0=FS V1 (plain text), 1=FS V7 (modern headers), 2=LL Style</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
+  <key>AYALLChatCompactView</key>
+  <map>
+    <key>Comment</key>
+    <string>LL Style chat window: true=Compact View, false=Expanded View (independent from FS PlainTextChatHistory)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <!-- </FS:AYA> -->
+
   <key>ShowChatMiniIcons</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/app_settings/settings_text.xml
+++ b/indra/newview/app_settings/settings_text.xml
@@ -183,6 +183,31 @@
     <integer>1</integer>
   </map>
 
+  <!-- <FS:AYA> Phase 3: Chat window style selection (0=FS V1, 1=FS V7, 2=LL Style) -->
+  <key>AYAChatWindowStyle</key>
+  <map>
+    <key>Comment</key>
+    <string>Chat window style: 0=FS V1 (plain text), 1=FS V7 (modern headers), 2=LL Style</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>0</integer>
+  </map>
+  <key>AYALLChatCompactView</key>
+  <map>
+    <key>Comment</key>
+    <string>LL Style chat window: true=Compact View, false=Expanded View (independent from FS PlainTextChatHistory)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <!-- </FS:AYA> -->
+
   <key>ShowChatMiniIcons</key>
   <map>
     <key>Comment</key>

--- a/indra/newview/app_settings/settings_v3.xml
+++ b/indra/newview/app_settings/settings_v3.xml
@@ -231,6 +231,31 @@
     <integer>0</integer>
   </map>
 
+  <!-- <FS:AYA> Phase 3: Chat window style selection (0=FS V1, 1=FS V7, 2=LL Style) -->
+  <key>AYAChatWindowStyle</key>
+  <map>
+    <key>Comment</key>
+    <string>Chat window style: 0=FS V1 (plain text), 1=FS V7 (modern headers), 2=LL Style</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>S32</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <key>AYALLChatCompactView</key>
+  <map>
+    <key>Comment</key>
+    <string>LL Style chat window: true=Compact View, false=Expanded View (independent from FS PlainTextChatHistory)</string>
+    <key>Persist</key>
+    <integer>1</integer>
+    <key>Type</key>
+    <string>Boolean</string>
+    <key>Value</key>
+    <integer>1</integer>
+  </map>
+  <!-- </FS:AYA> -->
+
   <key>ShowChatMiniIcons</key>
   <map>
     <key>Comment</key>


### PR DESCRIPTION
## Summary
- add AYAChatWindowStyle and AYALLChatCompactView to the base app settings
- add the same controls to legacy chat session mode settings files
- keep legacy mode defaults aligned with their existing PlainTextChatHistory behavior

## Verification
- xmllint --noout on updated app_settings XML files

This fixes startup crashes when a Windows build uses a legacy SessionSettingsFile that did not define AYAChatWindowStyle before llviewercontrol.cpp registers its settings listeners.