### PR TITLE
r12.x: upmix engaged 時の routing diagnostic を 1 行サマリに

### DIFF
--- a/indra/newview/llpositionalstreammgr.cpp
+++ b/indra/newview/llpositionalstreammgr.cpp
@@ -1317,6 +1317,23 @@ void LLPositionalStreamMgr::emitRoutingDiagnostic(DistributedStereoBinding& b)
         ChannelKind::FL, ChannelKind::FR, ChannelKind::C,
         ChannelKind::LFE, ChannelKind::SL, ChannelKind::SR,
     };
+
+    // r12: when upmix is engaged on a 2ch source, the 5.1 prims are not in
+    // compat fallback — they receive their canonical band via the upmix DSP.
+    // Replace the six per-prim "silent / playing X" lines with one summary
+    // (mirrors emitUpmixAutoBypassNotice symmetry: one line per non-default
+    // upmix outcome).
+    if (b.upmix_effective_applied && source_channels == 2)
+    {
+        bool any_5_1 = false;
+        for (auto pc : kPrim51) { if (ch_count[pc] > 0) { any_5_1 = true; break; } }
+        if (any_5_1)
+        {
+            notifyStream3D("5.1 prims fed by stereo\xe2\x86\x92" "6ch upmix DSP");
+        }
+        return;
+    }
+
     for (auto pc : kPrim51)
     {
         if (ch_count[pc] == 0) continue;


### PR DESCRIPTION
upmix=on + source 2ch のとき、5.1 prim (FL/FR/C/LFE/SL/SR) は compat fallback ではなく upmix DSP から正規バンドを受け取る。にもかかわらず
従来の 6 行通知 (ch:LFE prim silent (source is 2ch) など) がそのまま 表示され、upmix が無効化されているように見える誤解を招いていた。

emitRoutingDiagnostic の section (b) で upmix_effective_applied && source_channels == 2 を判定し、5.1 prim が 1 つ以上ある場合は
"5.1 prims fed by stereo→6ch upmix DSP" を 1 行通知して per-prim ループを skip する。

throttle key (last_diagnostic_key) は rebuild 時に clear されるので upmix タグを toggle すると再通知される。emitUpmixAutoBypassNotice (upmix=on + 6ch native の auto-bypass 通知) と対称な 1 行サマリ。

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
