### PR TITLE
r21.1: GPU self-rigged picker (CPU stage 廃止 / GPU 一本化)

### DIFF
--- a/docs/ayastorm-r21-release-note.en.md
+++ b/docs/ayastorm-r21-release-note.en.md
@@ -1,0 +1,43 @@
+# AYAstorm r21 — Release Announcement Draft
+
+Short text intended to be pasted into the GitHub release page. **r21 is a single-feature UX release** outside the visual-realism chapter (r14-r20) — a complete redesign of the right-click picker for the user's own rigged attachments, switching from upstream CPU bind-pose mesh-ray to a GPU-rendered object-ID buffer.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r21-self-rigged-picker.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r21 — GPU self-rigged picker
+
+### Headline: right-clicking your own attachments now picks what you see
+
+Until r20, right-clicking on your own rigged attachments (Mesh body / clothing / hair) used Firestorm / Linden's upstream picker, which intersects a world ray against the **CPU bind-pose mesh**. That produced three structural symptoms:
+
+- **Closeup zoom** click on a shirt → resolved to your avatar body instead of the shirt
+- **Alpha-cutout hair** in front of the face → ray pierces the discarded triangles and grabs the hair
+- **Idle animation frames** with skin drift → CPU bind-pose and GPU skinning diverge by ~4-5 cm, ray misses entirely
+
+r21 routes self attachment picking through a **dedicated GPU object-ID buffer** (`mObjectIDBuffer`) that re-renders `gAgentAvatarp`'s rigged attachments with the **same skinning matrices used by the visible scene**, packing each prim's LocalID into four 8-bit channels. The right-click handler reads back the byte quad at the mouse pixel and resolves it by walking the local attachment tree. CPU/GPU drift, alpha-cutout mismatch, and idle skin lag **cannot occur by construction** — the picker sees exactly what the screen shows.
+
+Details → spec `docs/ayastorm-r21-self-rigged-picker.md`
+
+### Settings
+
+| Key | Default | Purpose |
+|---|---|---|
+| `FSSelfRiggedPickerEnable` | `1` | Master switch for the picker. `0` reverts to pre-r21 upstream behaviour entirely |
+| `FSSelfRiggedPickerGPU` | `0` (M5 flip → `1`) | Kill-switch for the GPU buffer pass. `0` = picker no-op, upstream worldray is used unchanged. Provided as escape hatch for environments where the GPU pass misbehaves (Mac software OpenGL etc.) |
+
+> **CPU fallback is intentionally not provided.** Either the GPU pass is active (`GPU=1`) or the picker is disabled (`GPU=0`, equivalent to pre-r21 behaviour). This is a deliberate design choice — see memory `feedback_root_cause_not_dump.md` (no half-working workarounds) and `feedback_feature_value_in_main_usecase.md` (judge features by the main use case).
+
+### Known limitations
+
+- **Alpha-blended hair in front of the face**: GPU buffer relies on depth, so alpha-discarded triangles don't reach the picker — but truly alpha-blended hair that doesn't write depth still pierces. AYA-evaluated and accepted (2026-05-14).
+- **HUD attachments**: bypassed (HUD camera is screen-space, not present in `mObjectIDBuffer`).
+- **Non-rigged self attachments** (piercings, single jewelry prims): the GPU buffer only covers `PASS_*_RIGGED`, so non-rigged attachments fall back to the upstream worldray result. Handled transparently via `isRiggedMesh()` guard in `lltoolpie`.
+- **Other avatars' rigged attachments**: out of scope for r21 (self-only). May be considered in r22+.
+
+### Documentation
+
+- r21 spec / architecture / known limits / risk register: `docs/ayastorm-r21-self-rigged-picker.md`
+- BoM body rig-hash collision rationale (M4.17): memory `project_skin_hash_collision_bom_body.md`
+- Deferred shader routing reference: `docs/ayastorm-deferred-shader-routing.md`

--- a/docs/ayastorm-r21-release-note.ja.md
+++ b/docs/ayastorm-r21-release-note.ja.md
@@ -1,0 +1,43 @@
+# AYAstorm r21 — リリース告知文案
+
+GitHub release ページ貼り付け用の文案。**r21 は視覚的リアリティ章 (r14-r20) の外側にある UX 修正系の単機能リリース**で、自分の rigged attachment に対する右クリック picker を「上流 CPU bind-pose mesh ray」から「GPU 専用 object-ID buffer」に作り直したものを 1 本で提供します。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r21-self-rigged-picker.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r21 — GPU self-rigged picker
+
+### r21 の柱: 自分の rigged attachment を右クリックすると「画面で見えているもの」が選べる
+
+r20 までは自分の rigged attachment (Mesh body / 服 / 髪) を右クリックした時、Firestorm / Linden 標準の picker が動いて world ray と **CPU bind-pose mesh** の交差を取っていました。これは構造的に以下 3 症状を出していました:
+
+- **closeup zoom** で服をクリック → 服でなく自分のアバター本体に解決される
+- **アルファ抜き髪** が顔の前にあると、ray が透明 triangle を pierce して髪が取られる
+- **idle animation で rig が微動する frame** → CPU bind-pose と GPU skinning が ~4-5cm ズレて ray が外れる
+
+r21 では self attachment の picker を **専用 GPU object-ID buffer** (`mObjectIDBuffer`) に切り出し、`gAgentAvatarp` の rigged attachment を **視覚パスと同じ skinning matrix** で再描画して、各 prim の LocalID を 4 byte channel に pack して書き込みます。右クリック時はマウス pixel の byte quad を読み戻して LocalID を復元 → 該当 prim を attachment tree から解決します。CPU/GPU drift も alpha-discard 不一致も idle skin lag も **構造的に発生し得ません** — picker が見ているのは画面に出ているピクセルそのものだからです。
+
+詳細 → spec `docs/ayastorm-r21-self-rigged-picker.md`
+
+### 設定
+
+| キー | 既定 | 用途 |
+|---|---|---|
+| `FSSelfRiggedPickerEnable` | `1` | picker の master switch。`0` で r20 以前の上流挙動に完全に戻る |
+| `FSSelfRiggedPickerGPU` | `0` (M5 で `1` に flip 予定) | GPU buffer pass の kill-switch。`0` = picker 無効化 (上流 worldray を素通し)。Mac software OpenGL 等で GPU pass が破綻した場合の逃げ道として用意 |
+
+> **CPU fallback は意図的に提供しません。** GPU pass が動く (`GPU=1`) か、picker そのものが無効化される (`GPU=0`、= r20 以前と同じ) か、のいずれかです。これは memory `feedback_root_cause_not_dump.md` (半分動く workaround を残さない) と `feedback_feature_value_in_main_usecase.md` (主流ユースケースで機能の存在価値を判定する) に基づく設計判断です。
+
+### 既知の制約
+
+- **alpha-blend 髪越しの顔選択**: GPU buffer は深度共有なので alpha-discard 三角形は picker に届きませんが、本当に alpha-blend で描かれて depth に書かない髪は依然として貫通します。AYA 評価で「仕方ない」と確認済 (2026-05-14)。
+- **HUD attachment**: picker bypass (HUD は別 camera / screen-space で `mObjectIDBuffer` に書かれない)。
+- **非 rigged self attachment** (ピアス / 単独 jewelry prim 等): GPU buffer は `PASS_*_RIGGED` のみ走るので、非 rigged は GPU buffer の id=0 を「picker の管轄外」と扱い、上流 worldray の object をそのまま採用します (`lltoolpie` の `isRiggedMesh()` ガードで自動処理)。
+- **他者 avatar の rigged attachment**: r21 スコープ外 (self-only)。r22+ で検討予定。
+
+### ドキュメント
+
+- r21 spec / アーキテクチャ / 既知 limits / risk register: `docs/ayastorm-r21-self-rigged-picker.md`
+- BoM body の rig hash collision 解決の経緯 (M4.17): memory `project_skin_hash_collision_bom_body.md`
+- deferred shader routing reference: `docs/ayastorm-deferred-shader-routing.md`

--- a/docs/ayastorm-r21-release-note.zh.md
+++ b/docs/ayastorm-r21-release-note.zh.md
@@ -1,0 +1,43 @@
+# AYAstorm r21 — 发布公告草案
+
+用于粘贴到 GitHub release 页面的短文。**r21 是位于视觉真实感章 (r14-r20) 之外的 UX 修复型单功能 release**，把自身 rigged attachment 的右键 picker 由「上游 CPU bind-pose mesh ray」改写为「GPU 专用 object-ID buffer」并以一次发布交付。
+
+实现 / 已知限制 / 设置细节常驻于永久规格 (`docs/ayastorm-r21-self-rigged-picker.md`)。本公告仅做链接 + 差分要点。
+
+---
+
+## AYAstorm r21 — GPU self-rigged picker
+
+### r21 核心: 右键自身 rigged attachment 时「选中的就是画面上看见的那一个」
+
+r20 之前，右键自身的 rigged attachment (Mesh body / 服装 / 头发) 时走的是 Firestorm / Linden 上游 picker，求 world ray 与 **CPU bind-pose mesh** 的交点。这在结构上产生三类症状:
+
+- **近距特写** 想点衣服 → 解析为自身 avatar 主体而不是衣服
+- **alpha 抠图头发** 挡在脸前面 → ray 穿过被丢弃的三角形，把头发选中
+- **idle 动画** 让 rig 微动的 frame → CPU bind-pose 与 GPU skinning 偏差约 4-5 cm，ray 完全偏离
+
+r21 把自身 attachment 的 picker 切出到 **专用 GPU object-ID buffer** (`mObjectIDBuffer`) 中，使用 **与可见画面相同的 skinning 矩阵** 重新渲染 `gAgentAvatarp` 的 rigged attachment，将各 prim 的 LocalID 打包到四个 8-bit 通道。右键时读回鼠标像素处的 byte quad、还原 LocalID 并在 attachment 树中解析。CPU/GPU drift、alpha-discard 不一致、idle skin lag 在结构上 **不可能发生** — picker 看到的就是屏幕显示的内容。
+
+详情 → spec `docs/ayastorm-r21-self-rigged-picker.md`
+
+### 设置
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `FSSelfRiggedPickerEnable` | `1` | picker 的主开关。`0` 时完全回到 r20 之前的上游行为 |
+| `FSSelfRiggedPickerGPU` | `0` (M5 翻转为 `1`) | GPU buffer pass 的 kill-switch。`0` = picker 无效 (上游 worldray 不加修改直接使用)。为 Mac software OpenGL 等 GPU pass 不稳定环境提供逃生通道 |
+
+> **不提供 CPU fallback。** 要么 GPU pass 启用 (`GPU=1`)、要么 picker 整体禁用 (`GPU=0`，即 r20 之前的行为)。这是有意的设计选择 — 见 memory `feedback_root_cause_not_dump.md` (不留半工作的 workaround) 与 `feedback_feature_value_in_main_usecase.md` (按主流用例判定功能价值)。
+
+### 已知限制
+
+- **alpha-blend 头发挡在脸前**: GPU buffer 与场景共享深度，alpha-discard 三角形不会触达 picker，但真正以 alpha-blend 绘制而不写深度的头发仍会被「穿过」。AYA 已评估并接受 (2026-05-14)。
+- **HUD attachment**: 跳过 picker (HUD 属于另一个 screen-space camera，不出现在 `mObjectIDBuffer` 内)。
+- **非 rigged 自身 attachment** (耳钉 / 单独的 jewelry prim 等): GPU buffer 仅覆盖 `PASS_*_RIGGED`，非 rigged 部分会回退到上游 worldray 结果。`lltoolpie` 通过 `isRiggedMesh()` 守卫透明处理。
+- **他人 avatar 的 rigged attachment**: r21 范围外 (仅 self)。可能在 r22+ 中考虑。
+
+### 文档
+
+- r21 spec / 架构 / 已知 limits / 风险登记: `docs/ayastorm-r21-self-rigged-picker.md`
+- BoM body 的 rig hash 冲突缘由 (M4.17): memory `project_skin_hash_collision_bom_body.md`
+- deferred shader routing 参考: `docs/ayastorm-deferred-shader-routing.md`

--- a/docs/ayastorm-r21-self-rigged-picker.md
+++ b/docs/ayastorm-r21-self-rigged-picker.md
@@ -1,0 +1,218 @@
+# AYAstorm r21: self rigged attachment GPU picker
+
+**作成日**: 2026-05-14 (cleanup commit 直前に資料起票)
+**対象**: AYAstorm `feature/aya-r21.1-self-rigged-picker`
+**位置づけ**: r21.0 (picker initial REPLACE) と r21.1 (GPU 化 + 掃除) を **合体 1 リリース**として出荷。視覚表現章 (r14-r20) とは独立した **UX 修正系**
+
+> **本書の役割**: r21 picker の **動機 / アーキテクチャ / 実装記録 / 設定 reference / 既知 limits** の永続資料。Release Note (`docs/ayastorm-r21-release-note.{en,ja,zh}.md`) は本書へのリンク + 差分ハイライトで構成 (memory `feedback_release_notes_link_only.md` 方針)。
+
+---
+
+## 1. 動機 — 上流 worldray の不一致
+
+Firestorm / Linden 標準の右クリック picker は `LLPipeline::lineSegmentIntersectInWorld()` で **CPU bind-pose mesh × world ray** を交差判定する。これは static prim では正確だが、自分の rigged attachment (Mesh body / 服 / アクセサリ) に対して以下の症状を起こす:
+
+- **closeup zoom** で攻撃クリック (例: 顔のすぐ手前) → 服を選んでいるつもりが「自分のアバター本体」に解決される (= 上流が hit 出来ず fall-through)
+- **アルファ抜き髪** 越しに顔を選ぼうとすると、ray が髪 prim の透明 triangle を pierce してしまい「髪」が選ばれる (= 視覚と不一致)
+- **idle animation 中** に rig が微動する frame で、CPU bind-pose と GPU skin の位置が ~4-5cm ズレる → ray が外れて「ragdoll aim」感
+
+これらは CPU mesh ray の構造的限界で、tolerance を広げて誤魔化すと「漠然と当たるが何を選んでるか不明」になる (= memory `feedback_root_cause_not_dump.md` の「半分動く誤魔化し」)。
+
+### 1.1 解決方針
+
+「**画面に出ているピクセルそのもの**」が真実。であれば GPU で 1 枚 RGBA8 buffer を作り、`gAgentAvatarp` の rigged attachment を **同じ skinning matrix で再描画**して、各 prim の **LocalID を 4 byte に pack** して書き込む。右クリック時はマウス pixel の byte quad を読み戻して LocalID を復元 → 該当 prim を resolve。
+
+CPU/GPU drift も alpha-discard 不一致も idle skin lag も **構造的に発生し得ない** (visible scene と同じ skinning 結果を使う)。
+
+---
+
+## 2. アーキテクチャ
+
+```
+[deferred gbuffer pass (visible scene)]
+        │
+        │ depth finalised
+        ▼
+[renderSelfRiggedObjectIDBuffer()]            ←── pipeline.cpp:9923
+  ├ FSSelfRiggedPickerGPU で gate
+  ├ mObjectIDBuffer.bindTarget()               ←── RGBA8 / WorldViewRectRaw
+  ├ glColorMask(GL_TRUE×4) + clear (0,0,0,0)
+  ├ depth share + LEQUAL test (write off)
+  ├ glCullFace(GL_BACK)
+  ├ gFSObjectIDShader.bind()                   ←── deferred/fsObjectID{V,F}.glsl
+  └ for each PASS_*_RIGGED in kFSRiggedPasses:
+       for each LLDrawInfo info:
+         if info->mAvatar != gAgentAvatarp:      skip
+         if info->mFSPickerLocalID == 0:        skip   ←── ※M4.17 per-prim id
+         uniform object_id_packed = pack(id)
+         uploadMatrixPalette(...)               ←── 同じ GPU skinning
+         drawRange(...)
+        │
+        ▼
+[mObjectIDBuffer: 各 attachment pixel に LocalID]
+        │
+        │ 右クリック発火
+        ▼
+[FSSelfRiggedPicker::findClosestAttachment]   ←── fsselfriggedpicker.cpp
+  ├ mouse_x/y → buffer-local coord (HiDPI + UI chrome 補正)
+  ├ glReadPixels(1x1, RGBA, UNSIGNED_BYTE)
+  ├ U32 local_id = R | G<<8 | B<<16 | A<<24
+  └ findSelfAttachmentByLocalID(gAgentAvatarp tree)
+        │
+        ▼
+[lltoolpie.cpp]
+  ├ picked          → object 差し替え + handleObjectSelection
+  ├ id==0 && rigged → force-to-body (= avatar 本体)   ←── M4.18 ガード
+  └ id==0 && non-rigged → 上流 worldray の object を尊重
+```
+
+### 2.1 構成ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `indra/newview/fsselfriggedpicker.{h,cpp}` | 右クリック呼出側の GPU buffer 読み出し / LocalID 復元 / attachment tree walk |
+| `indra/newview/lltoolpie.cpp` | 右クリック handler。picker を呼ぶか / 上流結果を採るかの判定 (M4.18 rigged gate 含む) |
+| `indra/newview/pipeline.{h,cpp}` | `mObjectIDBuffer` 確保 / `renderSelfRiggedObjectIDBuffer()` 本体 |
+| `indra/newview/llspatialpartition.h` | `LLDrawInfo::mFSPickerLocalID` 新規 field (M4.17 per-prim identity) |
+| `indra/newview/llvovolume.cpp` | DrawInfo 構築時に `mFSPickerLocalID` 書込 + batching merge 条件に LocalID 一致を追加 |
+| `indra/newview/llviewershadermgr.{h,cpp}` | `gFSObjectIDShader` 登録 (vertex に `hasObjectSkinning=true`) |
+| `indra/newview/app_settings/shaders/class1/deferred/fsObjectID{V,F}.glsl` | vertex: rig skinning で clip pos のみ生成 / fragment: 4-byte LocalID を pack して書き込み |
+| `indra/newview/app_settings/settings.xml` | `FSSelfRiggedPickerEnable` (master) / `FSSelfRiggedPickerGPU` (kill-switch) |
+
+### 2.2 shader
+
+**`fsObjectIDV.glsl`** (vertex):
+```glsl
+mat4 mat = getObjectSkinnedTransform();           // 視覚パスと同じ
+mat = modelview_matrix * mat;
+gl_Position = projection_matrix * vec4(mat * vec4(position, 1.0)).xyz;
+```
+varying なし。normal なし。clip pos だけ生成して fragment へ。
+
+**`fsObjectIDF.glsl`** (fragment):
+```glsl
+uniform vec4 object_id_packed;   // host が R=byte0 .. A=byte3 で詰める
+out vec4 frag_color;
+void main() { frag_color = object_id_packed; }
+```
+
+depth は `mRT->deferredScreen` と共有、LEQUAL test (write off)。alpha-discard された pixel は元から depth に居ないので picker buffer にも到達しない → **画面で見えない triangle は picker からも見えない** が構造的に成立。
+
+### 2.3 buffer 配置と coordinate conversion
+
+`mObjectIDBuffer` は **`WorldViewRectRaw` 寸法**で確保される (`pipeline.cpp::resizeScreenTexture()`)。つまり buffer の `(0,0)` は world view rect の bottom-left を raw pixel で示す。一方マウス座標 `LLCoordGL` は window-relative の **scaled (logical) pixel**。HiDPI と UI chrome の二段補正が必要:
+
+```cpp
+sx = WindowWidthRaw / WindowWidthScaled;        // DisplayScale
+mx_win_raw = round(mouse_x * sx);
+mx_buf = mx_win_raw - WorldViewRectRaw.mLeft;   // UI chrome offset
+```
+
+どちらかを忘れると `glReadPixels` が誤った pixel を読んで「id=0 (no hit)」を返す。 (M4.1 で初期実装、M4.2 でちらつき対策完成)
+
+### 2.4 M4.17: per-DrawInfo LocalID (BoM body 衝突解決)
+
+**問題**: 初期版は `unordered_map<skin->mHash, LocalID>` を pipeline.cpp で構築し、render 時に hash 経由で LocalID を引いていた。しかし `LLMeshSkinInfo::mHash` は **rig binding のハッシュ** (頂点データではない) で、BoM body のように **複数の rigged child prim が 1 つの avatar rig を共有**するケースで全て同じ hash になる。最後に iterate された child の LocalID が map slot を独占し、**体の全 pixel が 1 個の child prim に解決される** (例: 腕クリックが足 prim に化ける)。
+
+**観測**: 2026-05-14 検証で「腕の disjoint 2 点クリックが両方とも foot prim の LocalID を返す」を log で確定。
+
+**解決**: hash 介在を完全に除去し、`LLDrawInfo` 自体に `mFSPickerLocalID` を持たせる (`llspatialpartition.h:155`)。DrawInfo 構築時 (`llvovolume.cpp:5823`) に `vobj->getLocalID()` を直接 stamp。
+
+**副次対策**: batching merge 条件 (`llvovolume.cpp:5767`) に LocalID 一致を追加。これがないと「同 rig / 同 material / 同 VB の 2 prim」が 1 つの DrawInfo にマージされて identity が再び消える。
+
+詳細経緯: memory `project_skin_hash_collision_bom_body.md`。
+
+### 2.5 M4.18: non-rigged attachment は upstream に委譲
+
+GPU buffer は `PASS_*_RIGGED` のみ dispatch されるので、**rigged ではない self attachment (ピアス / 単独 jewelry prim) は構造的に id=0 を返す**。掃除前の lltoolpie.cpp は `gpu_authoritative && upstream_picked_self_attachment` だけで force-to-body していたので、ピアスクリック → 全部 body に取られて「ピアス選択不能」になった (2026-05-14 観測)。
+
+**修正**: force-to-body 条件に `object->isRiggedMesh()` を追加 (`lltoolpie.cpp:2389`)。非 rigged は GPU buffer の id=0 を「picker の管轄外」と解釈し、upstream worldray の object を尊重する。
+
+---
+
+## 3. 設定
+
+### 3.1 `FSSelfRiggedPickerEnable` (Boolean, default 1)
+
+GPU picker 全体の **master switch**。OFF にすると lltoolpie の picker 呼び出し自体がスキップされ、上流 worldray の結果が無加工で使われる (= 完全に r20 以前の挙動)。
+
+### 3.2 `FSSelfRiggedPickerGPU` (Boolean, default 0 → M5 で 1 予定)
+
+GPU buffer pass (`renderSelfRiggedObjectIDBuffer`) と GPU readback の **kill-switch**。OFF の場合:
+
+- `renderSelfRiggedObjectIDBuffer` は early-return (buffer 描画なし、コスト 0)
+- `findClosestAttachment` も early-return `nullptr` + `out_gpu_authoritative=false`
+- lltoolpie は force-to-body 条件にも入らず、上流 object をそのまま採用 → **r20 以前と同一挙動**
+
+> **CPU fallback は廃止** (M4.7 で legacy stage を削除)。OFF = picker 無効化スイッチ、CPU 経路で picker が動くわけではない。これは memory `feedback_root_cause_not_dump.md` (半分動く誤魔化しを残さない) と `feedback_feature_value_in_main_usecase.md` (主流ユースケースで判定) に基づく設計判断。Mac 等で問題が出た場合のフォールバックは「**上流 worldray のみ**」になる。
+
+### 3.3 検証後の戻し方表 (memory `feedback_restore_debug_settings.md` 方針)
+
+| キー | 一時値 | 戻すべき default | 備考 |
+|---|---|---|---|
+| `FSSelfRiggedPickerEnable` | 0 (kill) / 1 (normal) | **1** | master、検証時に切るシナリオあり |
+| `FSSelfRiggedPickerGPU` | 1 (検証 ON) | **0** (M5 までは default OFF / M5 で 1) | M5 リリース以降は default 1 |
+
+---
+
+## 4. 既知の limits
+
+| ID | 限界 | 原因 / 回避 |
+|---|---|---|
+| L1 | **アルファ抜き髪越しの顔選択は完全には改善しない** | GPU buffer は深度共有なので alpha-discarded triangle は到達しないが、髪が **alpha-blend** の場合は depth に書かれない場面があり、これは GPU buffer も「貫通して顔を選ぶ」。AYA 評価で「仕方ない」と確認済み (2026-05-14) |
+| L2 | **HUD attachment は picker 対象外** | HUD は別 camera (screen-space) で render され `mObjectIDBuffer` には書かれない。lltoolpie は HUD 判定で早期 bypass (M4.9) |
+| L3 | **非 rigged self attachment は upstream worldray 依存** | ピアス等 — M4.18 で「id=0 でも force-to-body しない」処理を入れて upstream 結果を尊重 |
+| L4 | **CPU mode (`FSSelfRiggedPickerGPU=0`) では picker が動作しない** | 構造的判断 (memory `feedback_feature_value_in_main_usecase.md`)。Mac の software OpenGL renderer 等で問題が出た場合はこの kill-switch で OFF にして上流動作に戻す |
+| L5 | **他者 avatar の rigged attachment は対象外** | r21 スコープは self picker のみ。他者 picker は r22+ で別途検討 |
+| L6 | **closeup zoom で id=0 を引くケースが残存可能性あり** | M4.8 として task 残置 (#72) — M4.17 hash collision 解決でほぼ抑え込めた感触だが、M5 検証時に再現したら根本究明 |
+
+---
+
+## 5. 受け入れ条件 (M5 検証で確認)
+
+- [x] **rigged self attachment** (Mesh body の腕 / 頭 / 胴 / 服 / 髪): 右クリック → 正しい prim が pie menu に出る (M4.17 PASS)
+- [x] **非 rigged self attachment** (ピアス / 単独 jewelry prim): 右クリック → 該当 prim が pie menu に出る (M4.18 PASS)
+- [x] **他者 avatar / land / HUD**: picker bypass で上流挙動が壊れない (M4.9 で HUD 明示 bypass)
+- [ ] **3 OS ビルド + 起動 + 動作確認** (Linux PASS、Win / macOS は M5 で実施 — memory `project_ayastorm_three_platforms.md`)
+- [ ] **M5: `FSSelfRiggedPickerGPU` default を 1 に flip** (cleanup commit 後の別 commit)
+
+---
+
+## 6. リスク
+
+| ID | リスク | 対策 / 現ステータス |
+|---|---|---|
+| R1 | M4.17 hash collision の再発 (新たな batching merge 経路や別 DrawInfo 構築点で identity が消える) | LLDrawInfo merge 条件と construction 両方にコメント明示 (`llvovolume.cpp:5762, 5817`)、memory `project_skin_hash_collision_bom_body.md` に検出 signal 記述 (skins=N vs drawn=M 不一致) |
+| R2 | M4.18 ガードで rigged 判定が `isRiggedMesh()` virtual に依存。サブクラスで誤実装があると force-to-body が暴発 | LLViewerObject base 実装は false、LLVOVolume override が唯一の true 経路。Mesh body 以外の rigged は viewer 内に存在しないため実害は無いはず |
+| R3 | Mac software OpenGL fallback で `mObjectIDBuffer.allocate()` は成功するが draw が遅い / 不正色 | `isComplete()` check で「allocate 失敗 → 自動 no-op」は保証済み。draw 異常は事前検証不能、release 後フィードバック頼り (memory `feedback_release_with_user_feedback.md`)、kill-switch cvar が保険 |
+| R4 | `gFSObjectIDShader` の hasObjectSkinning permutation が他 platform で link 失敗 | `add_common_permutations(&gFSObjectIDShader)` で標準処理、`objectSkinV.glsl` 参照は他 shader と同形式 |
+| R5 | closeup zoom shirt の id=0 (task #72 M4.8) が M5 検証で再現 | task 残置中。再現時は LL_PROFILE 取って深く trace、当てずっぽう shader 書き換えはしない (memory `feedback_render_full_trace_first.md`) |
+
+---
+
+## 7. 関連 memory / docs
+
+- `project_skin_hash_collision_bom_body.md` — M4.17 の核心 (BoM body 複数 prim が rig hash 共有)
+- `reference_deferred_shader_routing.md` / `reference_gbuffer3_storage.md` — 描画系を触る前の必読 reference
+- `feedback_root_cause_not_dump.md` — CPU fallback 廃止の判断根拠
+- `feedback_feature_value_in_main_usecase.md` — Mac CPU mode 切り捨て判断
+- `feedback_release_with_user_feedback.md` — Mac 事前検証不能を release-feedback で補う方針
+- `feedback_render_full_trace_first.md` — 描画系 trace 優先
+- `docs/ayastorm-deferred-shader-routing.md` — deferred 経路 reference
+- `docs/ayastorm-gbuffer3-trace.md` — gbuffer3 仕様
+- `docs/ayastorm-visual-realism-roadmap.md` — 章全体 (r21 は視覚表現章の外、UX 修正系)
+
+---
+
+## 8. 更新履歴
+
+- 2026-05-08 (`940b989ca5`) **r21 起票 + initial picker REPLACE**: 上流 worldray を独立 fallback で差し替え。CPU bind-pose ray を 3 stage (depth-assist / pierce / near-miss) で組んで Linux PASS。memory `feedback_upstream_bug_replace_over_fix.md` 適用例 (上流バグ修正でなく差し替え)
+- 2026-05-14 **r21.1 起票**: closeup zoom で「肌が選べない」「服が選べない」症状残存、idle skin drift で誤選択 1/5。CPU bind-pose の構造的限界を認識し **GPU buffer 方式** に転換 (M4)
+- 2026-05-14 M4.1〜M4.6: GPU pass 初期実装 (mObjectIDBuffer 確保、shader 登録、draw pass、coord conversion、alpha-mask fix、back-face cull)
+- 2026-05-14 M4.7: legacy CPU stage 廃止判断 (GPU 一本化)
+- 2026-05-14 M4.8〜M4.13 Diag: depth 棄却 / hash collision / 画面 dump で根本原因切り分け。`skin->mHash` map collapse を確定
+- 2026-05-14 M4.16: M4.15 で入れた `root_id` 伝播が誤り → revert (child prim 本人 LocalID 書込)
+- 2026-05-14 (`f3c0829ea8`) **M4.17 Linux PASS**: `LLDrawInfo::mFSPickerLocalID` 導入で hash collision 完全解決。腕/頭/胴/服 全て正解
+- 2026-05-14 **M4.18 PASS**: non-rigged ピアス選択不能を `isRiggedMesh()` ガードで解決
+- 2026-05-14 **掃除 commit (この commit)**: CPU stage 0/1 ヘルパ ~400 行、CPU stage 関連 cvar 4 件 (`Tolerance` / `DepthAssist` / `DepthTolerance` / `DumpBuffer`)、per-click diag log、Diag-C/D PNG dump を全削除。net **-746 行**。掃除後の `findClosestAttachment` は 60 行台、GPU 1 path のみ
+- (M5 予定) cvar `FSSelfRiggedPickerGPU` default = 1 に flip、3 OS 検証完走、`v7.2.x-ayastorm-r21` tag/release

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -183,6 +183,7 @@ set(viewer_SOURCE_FILES
     fsregioncross.cpp
     fsscriptlibrary.cpp
     fsscrolllistctrl.cpp
+    fsselfriggedpicker.cpp
     fsslurlcommand.cpp
     fsvirtualtrackpad.cpp
     fsworldmapmessage.cpp
@@ -1050,6 +1051,7 @@ set(viewer_HEADER_FILES
     fsregioncross.h
     fsscriptlibrary.h
     fsscrolllistctrl.h
+    fsselfriggedpicker.h
     fsslurl.h
     fsslurlcommand.h
     fsvirtualtrackpad.h

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -23245,7 +23245,7 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>FSSelfRiggedPickerEnable</key>
     <map>
       <key>Comment</key>
-      <string>AYAstorm r21.1: when the right-click pick falls through to the self avatar (or hits nothing), run a two-stage scan against the agent's rigged attachments and redirect the pick. Stage 1 prefers any attachment the ray actually pierces (two-sided ray-triangle test); stage 2 falls back to triangle-edge near-miss within FSSelfRiggedPickerTolerance meters.</string>
+      <string>AYAstorm r21.1: when the right-click pick falls through to the self avatar (or hits nothing), run a multi-stage scan against the agent's rigged attachments and redirect the pick. Stage -1 (gated by FSSelfRiggedPickerGPU) reads the GPU-side LocalID written into mObjectIDBuffer at the mouse pixel — exact agreement with what was drawn. Stage 0 (gated by FSSelfRiggedPickerDepthAssist) unprojects the depth buffer and runs a short-ray pierce / near-miss test against CPU-skinned meshes. Stage 1 is a two-sided ray-triangle pierce on the full camera ray. Stage 2 is triangle-edge near-miss within FSSelfRiggedPickerTolerance meters.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
@@ -23253,16 +23253,60 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>FSSelfRiggedPickerGPU</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: stage -1 GPU-side picking for self rigged attachments. When enabled, the deferred pass redraws the agent's rigged attachments into mObjectIDBuffer (RGBA8) with each attachment's LocalID packed into the four bytes. The picker reads that byte quad at the mouse pixel, recombines it into a U32 LocalID, and looks up the attachment via gObjectList. This is exact — there is no CPU-skin vs GPU-skin drift because the ID image and the visible image come from the same skinning. Disable to fall back to the CPU-mesh stages 0+1+2.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
+    <key>FSSelfRiggedPickerDepthAssist</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: stage-0 depth-assist for the self rigged-attachment picker. When enabled, the picker reads the GPU depth buffer at the mouse pixel and chooses the rigged attachment whose CPU-skinned mesh is closest to that unprojected world point (within FSSelfRiggedPickerDepthTolerance). This is the only path that agrees with what is rendered on screen (alpha-discarded triangles are absent from the depth buffer). Disable to fall back to the ray-only stages 1+2.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <key>FSSelfRiggedPickerDepthTolerance</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: stage-0 depth-assist tolerance in meters. After unprojecting the depth-buffer sample to a world point, the picker runs the same pierce / near-miss test as stages 1+2 on the short ray from the camera to that point, with this value as the near-miss radius. Closest-to-camera pierce wins (so a shirt over a body wins automatically because its triangles sit at smaller pierce_t along the same ray). Default 0.10 (10cm) — generous enough to absorb the CPU-skin vs GPU-skin one-frame drift caused by idle animations.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.10</real>
+    </map>
     <key>FSSelfRiggedPickerTolerance</key>
     <map>
       <key>Comment</key>
-      <string>AYAstorm r21.1: tolerance in meters for the stage-2 near-miss path of the self rigged-attachment fallback picker. If no attachment is actually pierced by the ray (stage 1, ray-triangle test), an attachment becomes a candidate when any triangle edge of its CPU-skinned mesh is within this distance of the world ray; among candidates the surface nearest to the camera along the ray wins. Default 0.05 (5cm).</string>
+      <string>AYAstorm r21.1: tolerance in meters for the stage-2 near-miss path of the self rigged-attachment fallback picker. If stages 0+1 yield no hit (no depth coverage and no ray-triangle pierce), an attachment becomes a candidate when any triangle edge of its CPU-skinned mesh is within this distance of the world ray; among candidates the surface nearest to the camera along the ray wins. Default 0.05 (5cm).</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
       <real>0.05</real>
+    </map>
+    <key>FSSelfRiggedPickerDumpBuffer</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1 Diag-C: when set to 1, the next frame dumps mObjectIDBuffer (the GPU self-rigged picker output) to ~/.ayastorm_x64/logs/AYAstorm_picker_dump.png and auto-resets to 0. Use this to visually inspect what the picker render covers vs the on-screen avatar — bright/colored pixels are rigged attachments that the picker can recognize, black pixels return id=0 (no hit).</string>
+      <key>Persist</key>
+      <integer>0</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>0</integer>
     </map>
     <key>FSShowMutedChatHistory</key>
     <map>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -23242,6 +23242,28 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>FSSelfRiggedPickerEnable</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: when the right-click pick falls through to the self avatar (or hits nothing), run a two-stage scan against the agent's rigged attachments and redirect the pick. Stage 1 prefers any attachment the ray actually pierces (two-sided ray-triangle test); stage 2 falls back to triangle-edge near-miss within FSSelfRiggedPickerTolerance meters.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <key>FSSelfRiggedPickerTolerance</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: tolerance in meters for the stage-2 near-miss path of the self rigged-attachment fallback picker. If no attachment is actually pierced by the ray (stage 1, ray-triangle test), an attachment becomes a candidate when any triangle edge of its CPU-skinned mesh is within this distance of the world ray; among candidates the surface nearest to the camera along the ray wins. Default 0.05 (5cm).</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.05</real>
+    </map>
     <key>FSShowMutedChatHistory</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -23245,7 +23245,7 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>FSSelfRiggedPickerEnable</key>
     <map>
       <key>Comment</key>
-      <string>AYAstorm r21.1: when the right-click pick falls through to the self avatar (or hits nothing), run a multi-stage scan against the agent's rigged attachments and redirect the pick. Stage -1 (gated by FSSelfRiggedPickerGPU) reads the GPU-side LocalID written into mObjectIDBuffer at the mouse pixel — exact agreement with what was drawn. Stage 0 (gated by FSSelfRiggedPickerDepthAssist) unprojects the depth buffer and runs a short-ray pierce / near-miss test against CPU-skinned meshes. Stage 1 is a two-sided ray-triangle pierce on the full camera ray. Stage 2 is triangle-edge near-miss within FSSelfRiggedPickerTolerance meters.</string>
+      <string>AYAstorm r21.1: master enable for the GPU self rigged-attachment picker. When the right-click pick falls through to the self avatar (or upstream picked a self rigged attachment), the picker reads the GPU LocalID written into mObjectIDBuffer at the mouse pixel and redirects the selection to the correct attachment — exact pixel-level agreement with what was drawn. Requires FSSelfRiggedPickerGPU. Disable to use upstream's worldray pick unchanged.</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
@@ -23256,53 +23256,9 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>FSSelfRiggedPickerGPU</key>
     <map>
       <key>Comment</key>
-      <string>AYAstorm r21.1: stage -1 GPU-side picking for self rigged attachments. When enabled, the deferred pass redraws the agent's rigged attachments into mObjectIDBuffer (RGBA8) with each attachment's LocalID packed into the four bytes. The picker reads that byte quad at the mouse pixel, recombines it into a U32 LocalID, and looks up the attachment via gObjectList. This is exact — there is no CPU-skin vs GPU-skin drift because the ID image and the visible image come from the same skinning. Disable to fall back to the CPU-mesh stages 0+1+2.</string>
+      <string>AYAstorm r21.1: GPU stage for the self rigged-attachment picker. When enabled, the deferred pass redraws the agent's rigged attachments into mObjectIDBuffer (RGBA8) with each attachment's LocalID packed into the four bytes. The picker reads that byte quad at the mouse pixel, recombines it into a U32 LocalID, and resolves the attachment. Exact — no CPU-skin vs GPU-skin drift because the ID image and the visible image come from the same skinning. Disable to skip the picker entirely (upstream worldray pick is used).</string>
       <key>Persist</key>
       <integer>1</integer>
-      <key>Type</key>
-      <string>Boolean</string>
-      <key>Value</key>
-      <integer>0</integer>
-    </map>
-    <key>FSSelfRiggedPickerDepthAssist</key>
-    <map>
-      <key>Comment</key>
-      <string>AYAstorm r21.1: stage-0 depth-assist for the self rigged-attachment picker. When enabled, the picker reads the GPU depth buffer at the mouse pixel and chooses the rigged attachment whose CPU-skinned mesh is closest to that unprojected world point (within FSSelfRiggedPickerDepthTolerance). This is the only path that agrees with what is rendered on screen (alpha-discarded triangles are absent from the depth buffer). Disable to fall back to the ray-only stages 1+2.</string>
-      <key>Persist</key>
-      <integer>1</integer>
-      <key>Type</key>
-      <string>Boolean</string>
-      <key>Value</key>
-      <integer>1</integer>
-    </map>
-    <key>FSSelfRiggedPickerDepthTolerance</key>
-    <map>
-      <key>Comment</key>
-      <string>AYAstorm r21.1: stage-0 depth-assist tolerance in meters. After unprojecting the depth-buffer sample to a world point, the picker runs the same pierce / near-miss test as stages 1+2 on the short ray from the camera to that point, with this value as the near-miss radius. Closest-to-camera pierce wins (so a shirt over a body wins automatically because its triangles sit at smaller pierce_t along the same ray). Default 0.10 (10cm) — generous enough to absorb the CPU-skin vs GPU-skin one-frame drift caused by idle animations.</string>
-      <key>Persist</key>
-      <integer>1</integer>
-      <key>Type</key>
-      <string>F32</string>
-      <key>Value</key>
-      <real>0.10</real>
-    </map>
-    <key>FSSelfRiggedPickerTolerance</key>
-    <map>
-      <key>Comment</key>
-      <string>AYAstorm r21.1: tolerance in meters for the stage-2 near-miss path of the self rigged-attachment fallback picker. If stages 0+1 yield no hit (no depth coverage and no ray-triangle pierce), an attachment becomes a candidate when any triangle edge of its CPU-skinned mesh is within this distance of the world ray; among candidates the surface nearest to the camera along the ray wins. Default 0.05 (5cm).</string>
-      <key>Persist</key>
-      <integer>1</integer>
-      <key>Type</key>
-      <string>F32</string>
-      <key>Value</key>
-      <real>0.05</real>
-    </map>
-    <key>FSSelfRiggedPickerDumpBuffer</key>
-    <map>
-      <key>Comment</key>
-      <string>AYAstorm r21.1 Diag-C: when set to 1, the next frame dumps mObjectIDBuffer (the GPU self-rigged picker output) to ~/.ayastorm_x64/logs/AYAstorm_picker_dump.png and auto-resets to 0. Use this to visually inspect what the picker render covers vs the on-screen avatar — bright/colored pixels are rigged attachments that the picker can recognize, black pixels return id=0 (no hit).</string>
-      <key>Persist</key>
-      <integer>0</integer>
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>

--- a/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDF.glsl
@@ -1,0 +1,33 @@
+/**
+ * @file fsObjectIDF.glsl
+ * @brief AYAstorm r21.1 — GPU self-rigged picker, fragment stage.
+ *
+ * Writes the attachment's LocalID packed across four 8-bit channels into
+ * pipeline.mObjectIDBuffer at every pixel the rigged mesh covers. The
+ * picker reads the byte quad at the mouse pixel and recombines it into a
+ * U32 LocalID, then resolves it via gObjectList. Because both this pass
+ * and the visible scene share GPU skinning + depth, there is no CPU/GPU
+ * drift, and alpha-discarded triangles never reach the ID buffer.
+ *
+ * The host packs the LocalID like this:
+ *   r = ((id >>  0) & 0xff) / 255.0
+ *   g = ((id >>  8) & 0xff) / 255.0
+ *   b = ((id >> 16) & 0xff) / 255.0
+ *   a = ((id >> 24) & 0xff) / 255.0
+ * and the picker reads back the four bytes and reassembles in the same
+ * little-endian order. The clear value (0,0,0,0) decodes to LocalID 0,
+ * which we reserve as "no self rigged attachment here".
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * AYAstorm Viewer Source Code
+ * $/LicenseInfo$
+ */
+
+out vec4 frag_color;
+
+uniform vec4 object_id_packed;
+
+void main()
+{
+    frag_color = object_id_packed;
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDF.glsl
@@ -4,10 +4,11 @@
  *
  * Writes the attachment's LocalID packed across four 8-bit channels into
  * pipeline.mObjectIDBuffer at every pixel the rigged mesh covers. The
- * picker reads the byte quad at the mouse pixel and recombines it into a
- * U32 LocalID, then resolves it via gObjectList. Because both this pass
- * and the visible scene share GPU skinning + depth, there is no CPU/GPU
- * drift, and alpha-discarded triangles never reach the ID buffer.
+ * picker reads the byte quad at the mouse pixel, recombines it into a
+ * U32 LocalID, and resolves it by walking gAgentAvatarp's attachment tree
+ * (see fsselfriggedpicker.cpp). Because both this pass and the visible
+ * scene share GPU skinning + depth, there is no CPU/GPU drift, and
+ * alpha-discarded triangles never reach the ID buffer.
  *
  * The host packs the LocalID like this:
  *   r = ((id >>  0) & 0xff) / 255.0

--- a/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/fsObjectIDV.glsl
@@ -1,0 +1,30 @@
+/**
+ * @file fsObjectIDV.glsl
+ * @brief AYAstorm r21.1 — GPU self-rigged picker, vertex stage.
+ *
+ * Re-skins the rigged attachment exactly as the visible draw does, using
+ * objectSkinV.glsl's matrixPalette path. No varyings, no normals — we only
+ * need clip-space position so the fragment stage can write the object ID
+ * at the same pixels the real attachment covers. Depth is shared with
+ * mRT->deferredScreen, so the depth test naturally hides points the real
+ * scene has already occluded.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * AYAstorm Viewer Source Code
+ * $/LicenseInfo$
+ */
+
+uniform mat4 modelview_matrix;
+uniform mat4 projection_matrix;
+
+in vec3 position;
+
+mat4 getObjectSkinnedTransform();
+
+void main()
+{
+    mat4 mat = getObjectSkinnedTransform();
+    mat = modelview_matrix * mat;
+    vec3 pos = (mat * vec4(position.xyz, 1.0)).xyz;
+    gl_Position = projection_matrix * vec4(pos, 1.0);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/godraysF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/godraysF.glsl
@@ -117,7 +117,16 @@ void main()
         // sampleDirectionalShadow returns 1.0 when lit, 0.0 when shadowed.
         // We pass light_dir as the surrogate normal so the bias / PCF use
         // a light-facing offset (no real surface normal at mid-air points).
+        // Guard: hasShadows=false (shadow detail = 0) skips shadowUtil
+        // attach in llviewershadermgr, so the symbol is undefined unless
+        // HAS_SUN_SHADOW is set. Fall back to fully lit so the godrays
+        // pass still produces a halo (driven by phase only) without
+        // breaking link.
+#ifdef HAS_SUN_SHADOW
         float lit = sampleDirectionalShadow(p, light_dir, tc);
+#else
+        float lit = 1.0;
+#endif
         // shadowUtil cascade fallthrough: when a sample sits between near
         // splits and matches none of the four cascade branches, weight=0
         // and `shadow /= weight` yields NaN/+Inf. Godrays' mid-air sample

--- a/indra/newview/fsselfriggedpicker.cpp
+++ b/indra/newview/fsselfriggedpicker.cpp
@@ -1,9 +1,17 @@
 /**
  * @file fsselfriggedpicker.cpp
- * @brief Two-stage picker for the agent's own rigged attachments.
- *        Stage 1: ray-triangle pierce test (closest-to-camera pierce wins).
- *        Stage 2 (fallback): edge near-miss within tolerance (closest-to-camera
- *        edge wins). Pierce always beats near-miss.
+ * @brief Hybrid picker for the agent's own rigged attachments.
+ *        Stage 0 (depth-assist): read the GPU depth buffer at the mouse pixel,
+ *        unproject to a world point, then choose the rigged attachment whose
+ *        CPU-skinned triangle lies closest to that point. This is the only
+ *        stage that agrees with what is actually rendered on screen (alpha
+ *        discard / depth-mask hair etc. are honored by the depth buffer), and
+ *        is also immune to the CPU-skin vs GPU-skin one-frame lag that breaks
+ *        the ray stages when an idle animation moves the mesh.
+ *        Stage 1 (ray-based fallback): ray-triangle pierce test (closest-to-
+ *        camera pierce wins).
+ *        Stage 2 (ray-based fallback): edge near-miss within tolerance
+ *        (closest-to-camera edge wins). Pierce always beats near-miss.
  *
  * $LicenseInfo:firstyear=2026&license=viewerlgpl$
  * AYAstorm Viewer Source Code
@@ -14,12 +22,19 @@
 
 #include "fsselfriggedpicker.h"
 
+#include "llcontrol.h"
+#include "llrender.h"
+#include "llrendertarget.h"
+#include "llviewercontrol.h"
+
+#include "glm/ext/matrix_projection.hpp" // glm::unProject
 #include "llvoavatarself.h"
 #include "llvovolume.h"
 #include "llviewerjointattachment.h"
 #include "llviewercamera.h"
 #include "llviewerwindow.h"
 #include "llvolume.h"
+#include "pipeline.h"
 #include "v3math.h"
 #include "v4math.h"
 
@@ -30,12 +45,16 @@ namespace
     // triangle (with a small barycentric tolerance so that fitted-mesh clothing
     // — whose triangles sit only millimeters off the body surface — still
     // qualifies even when the ray clips just outside a strict u/v border).
-    // BARY_EPS = 0.02 ≈ 1mm on a 5cm triangle; far below the cm-scale
-    // separation that distinguishes e.g. hair triangles from face triangles, so
-    // it does not reintroduce the hair-steals-face problem fixed previously.
+    // `front_facing_out` distinguishes camera-facing front faces from
+    // back-facing geometry: CCW winding + det > 0 means the triangle normal
+    // opposes the ray direction (so the triangle is presenting its front side
+    // to the camera). The caller prefers front-face pierces over back-face
+    // ones; this protects shirt-over-body from CPU-skin numerical noise where
+    // a body-side back-face would otherwise win the smallest-t race against
+    // the shirt-side front-face that the user actually clicked.
     bool rayTriangleIntersect(const LLVector3& orig, const LLVector3& dir,
                               const LLVector3& v0, const LLVector3& v1, const LLVector3& v2,
-                              F32& t_out)
+                              F32& t_out, bool& front_facing_out)
     {
         const F32 EPS = 1e-8f;
         const F32 BARY_EPS = 0.02f;
@@ -47,6 +66,7 @@ namespace
         {
             return false; // parallel to triangle plane
         }
+        front_facing_out = (det > 0.f);
         F32 inv_det = 1.f / det;
         LLVector3 tvec = orig - v0;
         F32 u = (tvec * pvec) * inv_det;
@@ -129,20 +149,23 @@ namespace
         return (closest1 - closest2).lengthSquared();
     }
 
-    // Per-volume aggregation. Two metrics are computed in a single triangle pass:
-    //   (1) hits_through: did the ray actually pierce any triangle interior?
-    //       If yes, record the smallest pierce t (= closest-to-camera hit).
-    //   (2) near_miss: did any triangle edge come within `tolerance` of the ray?
+    // Per-volume aggregation. Three metrics are computed in a single triangle pass:
+    //   (1) hits_front: did the ray pierce any front-facing triangle (camera
+    //       side)? If yes, record the smallest such pierce t.
+    //   (2) hits_back: did the ray pierce any back-facing triangle (the inside
+    //       face of the mesh, looking away from camera)? Smallest t recorded.
+    //   (3) near_miss: did any triangle edge come within tolerance of the ray?
     //       If yes, record the smallest ray foot t at that edge.
-    // The caller prefers (1) over (2): a volume that the ray physically passes
-    // through always beats one that the ray merely grazes nearby. This stops
-    // a hair mesh that hangs in front of the face (its triangle edges within
-    // tolerance, but no triangle actually pierced by the ray under the nose)
-    // from stealing the click from the face mesh the ray really enters.
+    // The caller prefers (1) > (2) > (3): a volume whose camera-facing surface
+    // the ray pierces beats one that the ray only sees the back side of (which
+    // happens when CPU-skin numerical noise reorders mm-scale-overlapping mesh
+    // surfaces), which in turn beats a volume that the ray only grazes.
     struct VolumeHit
     {
-        bool hits_through = false;
-        F32 pierce_t = 1.f + 1e-3f; // smallest t among pierced triangles
+        bool hits_front = false;
+        F32 front_pierce_t = 1.f + 1e-3f; // smallest t among pierced front-facing triangles
+        bool hits_back = false;
+        F32 back_pierce_t = 1.f + 1e-3f; // smallest t among pierced back-facing triangles
         bool near_miss = false;
         F32 grazes_t = 1.f + 1e-3f; // smallest ray foot t among in-tolerance edges
     };
@@ -201,12 +224,24 @@ namespace
 
                 // (1) Pierce test.
                 F32 pierce_t;
-                if (rayTriangleIntersect(ray_a, ray_dir, v0, v1, v2, pierce_t))
+                bool front_facing;
+                if (rayTriangleIntersect(ray_a, ray_dir, v0, v1, v2, pierce_t, front_facing))
                 {
-                    if (pierce_t < hit.pierce_t)
+                    if (front_facing)
                     {
-                        hit.pierce_t = pierce_t;
-                        hit.hits_through = true;
+                        if (pierce_t < hit.front_pierce_t)
+                        {
+                            hit.front_pierce_t = pierce_t;
+                            hit.hits_front = true;
+                        }
+                    }
+                    else
+                    {
+                        if (pierce_t < hit.back_pierce_t)
+                        {
+                            hit.back_pierce_t = pierce_t;
+                            hit.hits_back = true;
+                        }
                     }
                 }
 
@@ -228,7 +263,7 @@ namespace
             }
         }
 
-        if (hit.hits_through || hit.near_miss)
+        if (hit.hits_front || hit.hits_back || hit.near_miss)
         {
             out_hit = hit;
             return true;
@@ -236,33 +271,63 @@ namespace
         return false;
     }
 
+    // Ranking categories — higher beats lower regardless of score_t.
+    enum PickCategory
+    {
+        PICK_NONE       = 0,
+        PICK_NEAR_MISS  = 1, // ray grazed an edge only
+        PICK_BACK_FACE  = 2, // ray pierced a back-facing triangle
+        PICK_FRONT_FACE = 3  // ray pierced a camera-facing triangle (preferred)
+    };
+
     struct BestPick
     {
         LLViewerObject* obj = nullptr;
-        F32 score_t = 1.f + 1e-3f; // smaller is better
-        bool from_pierce = false;  // true means score_t came from a real ray-through hit
+        F32 score_t = 1.f + 1e-3f; // smaller is better, only compared within the same category
+        PickCategory category = PICK_NONE;
     };
 
-    void considerVolume(LLVOVolume* volp, const VolumeHit& hit, BestPick& best)
+    void considerVolume(LLVOVolume* volp, const VolumeHit& hit, BestPick& best, bool allow_near_miss)
     {
-        if (hit.hits_through)
+        // Front-face pierce: highest tier. A shirt's outer surface in front of
+        // a body's outer surface wins here automatically (smaller t).
+        if (hit.hits_front)
         {
-            // Pierce always beats near-miss. Among pierces, smallest t wins.
-            if (!best.from_pierce || hit.pierce_t < best.score_t)
+            if (best.category < PICK_FRONT_FACE || hit.front_pierce_t < best.score_t)
             {
                 best.obj = volp;
-                best.score_t = hit.pierce_t;
-                best.from_pierce = true;
+                best.score_t = hit.front_pierce_t;
+                best.category = PICK_FRONT_FACE;
             }
+            return;
         }
-        else if (hit.near_miss && !best.from_pierce)
+        // Back-face pierce: only competes if nothing has a front pierce yet.
+        // This protects against CPU-skin noise where a body-side back-face
+        // would otherwise sneak under the shirt's front-face by a sub-mm
+        // pierce_t margin.
+        if (hit.hits_back && best.category <= PICK_BACK_FACE)
         {
-            // Only a near-miss; only competes against other near-misses.
-            if (hit.grazes_t < best.score_t)
+            if (best.category < PICK_BACK_FACE || hit.back_pierce_t < best.score_t)
+            {
+                best.obj = volp;
+                best.score_t = hit.back_pierce_t;
+                best.category = PICK_BACK_FACE;
+            }
+            return;
+        }
+        // Near-miss: lowest tier; only competes against other near-misses.
+        // Suppressed entirely when allow_near_miss=false (r21.1 needle-aim
+        // mode — the GPU ID buffer is the precise path, legacy stages only
+        // exist to recover pierces the GPU couldn't sample). Near-miss
+        // recoveries widen the hit zone by tolerance metres, which feels
+        // like ragdoll aiming on closeup avatars.
+        if (allow_near_miss && hit.near_miss && best.category <= PICK_NEAR_MISS)
+        {
+            if (best.category < PICK_NEAR_MISS || hit.grazes_t < best.score_t)
             {
                 best.obj = volp;
                 best.score_t = hit.grazes_t;
-                best.from_pierce = false;
+                best.category = PICK_NEAR_MISS;
             }
         }
     }
@@ -272,7 +337,8 @@ namespace
                                const LLVector3& ray_dir,
                                F32 ray_len_sq,
                                F32 tol_sq,
-                               BestPick& best)
+                               BestPick& best,
+                               bool allow_near_miss)
     {
         if (!obj || obj->isDead())
         {
@@ -284,18 +350,119 @@ namespace
             VolumeHit hit;
             if (volp && scanVolume(volp, ray_a, ray_dir, ray_len_sq, tol_sq, hit))
             {
-                considerVolume(volp, hit, best);
+                considerVolume(volp, hit, best, allow_near_miss);
             }
         }
         for (LLViewerObject* child : obj->getChildren())
         {
-            scanObjectAndChildren(child, ray_a, ray_dir, ray_len_sq, tol_sq, best);
+            scanObjectAndChildren(child, ray_a, ray_dir, ray_len_sq, tol_sq, best, allow_near_miss);
         }
     }
+
+    // ----- Stage -1 (GPU ID buffer) helper -------------------------------
+
+    // Recursive walk through gAgentAvatarp's attachment tree, looking for the
+    // child whose LocalID matches what the GPU object-ID buffer reported at
+    // the mouse pixel. We deliberately scope the search to self attachments
+    // only — Stage -1 is a self-picker; the upstream picker handles the rest
+    // of the scene. This also means we never look up by ip/port and never
+    // risk grabbing a non-self object whose LocalID happens to collide.
+    LLViewerObject* findSelfAttachmentByLocalID(LLViewerObject* obj, U32 target_id)
+    {
+        if (!obj)
+        {
+            return nullptr;
+        }
+        if (obj->getLocalID() == target_id)
+        {
+            return obj;
+        }
+        for (LLViewerObject* child : obj->getChildren())
+        {
+            if (LLViewerObject* hit = findSelfAttachmentByLocalID(child, target_id))
+            {
+                return hit;
+            }
+        }
+        return nullptr;
+    }
+
+    // ----- Stage 0 (depth-assist) helper ---------------------------------
+
+    // Read the depth buffer at (mouse_x, mouse_y) and unproject back to an
+    // agent-space world point. Returns false if depth-assist is unavailable
+    // (no deferred RT bound, or the sampled depth is at the far plane = sky).
+    bool screenDepthToAgentPoint(S32 mouse_x, S32 mouse_y, LLVector3& out_point)
+    {
+        if (!gPipeline.mRT)
+        {
+            return false;
+        }
+        LLRenderTarget& screen_rt = gPipeline.mRT->screen;
+        if (!screen_rt.isComplete())
+        {
+            return false;
+        }
+
+        // The world view rectangle (excluding UI chrome) is the viewport that
+        // the deferred geometry pass and the camera matrices were set up with.
+        LLRect wvr = gViewerWindow->getWorldViewRectRaw();
+        glm::ivec4 viewport(wvr.mLeft, wvr.mBottom, wvr.getWidth(), wvr.getHeight());
+
+        // mouse_x / mouse_y arrive here as LLCoordGL — bottom-origin window
+        // pixels in *scaled* (logical) coords. The screen RT is allocated at
+        // WorldViewRectRaw dimensions (pipeline.cpp resizeScreenTexture()), so
+        // its (0,0) is the world view rect's bottom-left in raw pixels.
+        //   1) scaled → raw via DisplayScale
+        //   2) subtract WorldViewRectRaw.mLeft/mBottom → buffer-local coord
+        // unProject(viewport = WorldViewRectRaw) likewise expects buffer-local
+        // pixels (its viewport rectangle has been translated to (mLeft,mBottom)
+        // already, so pass the buffer-local coord and unProject re-applies the
+        // offset internally).
+        const F32 sx = (F32)gViewerWindow->getWindowWidthRaw()  / (F32)gViewerWindow->getWindowWidthScaled();
+        const F32 sy = (F32)gViewerWindow->getWindowHeightRaw() / (F32)gViewerWindow->getWindowHeightScaled();
+        const S32 mx_win_raw = (S32)llround((F32)mouse_x * sx);
+        const S32 my_win_raw = (S32)llround((F32)mouse_y * sy);
+        const S32 mx_buf = mx_win_raw - wvr.mLeft;
+        const S32 my_buf = my_win_raw - wvr.mBottom;
+
+        if (mx_buf < 0 || my_buf < 0 ||
+            mx_buf >= wvr.getWidth() || my_buf >= wvr.getHeight())
+        {
+            return false;
+        }
+
+        F32 depth_sample = 1.f;
+        screen_rt.bindTarget();
+        glReadPixels(mx_buf, my_buf, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth_sample);
+        screen_rt.flush();
+
+        // depth ~= 1.0 means "no geometry written here" (sky / discarded /
+        // alpha-blend with depth-write off). Fall back to the ray stages.
+        if (depth_sample >= 0.9999f)
+        {
+            return false;
+        }
+
+        // glm::unProject expects window coords matching `viewport`. Since
+        // viewport is (wvr.mLeft, wvr.mBottom, wvr.W, wvr.H), pass the
+        // window-raw pixel here (not buffer-local) so it lies inside the
+        // viewport rect.
+        glm::vec3 win_coord((F32)mx_win_raw, (F32)my_win_raw, depth_sample);
+        glm::vec3 agent_coord = glm::unProject(win_coord,
+                                               get_current_modelview(),
+                                               get_current_projection(),
+                                               viewport);
+        out_point.setVec((F32)agent_coord.x, (F32)agent_coord.y, (F32)agent_coord.z);
+        return true;
+    }
+
 }
 
-LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance)
+LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance,
+                                                          bool& out_gpu_authoritative)
 {
+    out_gpu_authoritative = false;
     if (!isAgentAvatarValid())
     {
         return nullptr;
@@ -303,6 +470,202 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
     if (tolerance <= 0.f)
     {
         return nullptr;
+    }
+
+    // Stage -1: GPU object-ID buffer. The dedicated pass in renderDeferredLighting
+    // re-draws gAgentAvatarp's rigged attachments using the same GPU skinning the
+    // visible scene uses, packing each attachment's LocalID into RGBA8. Reading
+    // back the byte quad at the mouse pixel gives a pixel-perfect agreement with
+    // what is actually on screen — no CPU-skin vs GPU-skin drift, no ray vs
+    // skin-frame mismatch, no near-miss heuristics.
+    //
+    // r21.1 M4.7: fully authoritative. CPU bind-pose mesh ray (the legacy
+    // path below) cannot be made accurate for rigged attachments — that is
+    // exactly the upstream Linden picker problem r21.1 exists to solve.
+    // Falling back to it on GPU id=0 just reintroduces the old ragdoll aim.
+    // Outcomes:
+    //   - id != 0 + match → return it.
+    //   - id != 0 + no match (race: attachment removed mid-frame, stale
+    //     value) → out_gpu_authoritative=true, null. Caller may force-to-body.
+    //   - id == 0 → "no self rigged attachment at this pixel" is the truth.
+    //     out_gpu_authoritative=true, null. Caller may force-to-body when
+    //     upstream's worldray picked one of our attachments.
+    //
+    // Closeup-zoom shirt pixels currently return id=0 even when shirt is
+    // visually present — that is a GPU pass deficiency (cull/alpha/skin
+    // matrix/LOD state mismatch with deferred opaque) and must be fixed in
+    // the pass, NOT papered over with a CPU fallback.
+    static LLCachedControl<bool> gpu_enable(gSavedSettings, "FSSelfRiggedPickerGPU", false);
+    if (gpu_enable && gPipeline.mObjectIDBuffer.isComplete())
+    {
+        // Coordinate conversion. mObjectIDBuffer is allocated by
+        // resizeScreenTexture() at *WorldViewRectRaw* dimensions — not the
+        // full window — so the buffer's (0,0) corresponds to the world
+        // view rect's bottom-left in *raw* pixels. LLCoordGL mouse coords
+        // are window-relative *scaled* (logical) pixels.
+        //   1) scaled → raw via DisplayScale (mWindowRectRaw / mWindowRectScaled)
+        //   2) subtract WorldViewRectRaw's mLeft/mBottom origin so the
+        //      result is buffer-local.
+        // Missing either step (raw mismatch on HiDPI / UI-chrome offset)
+        // reads the wrong pixel — typically id=0.
+        const LLRect wv_raw = gViewerWindow->getWorldViewRectRaw();
+        const F32 sx = (F32)gViewerWindow->getWindowWidthRaw()  / (F32)gViewerWindow->getWindowWidthScaled();
+        const F32 sy = (F32)gViewerWindow->getWindowHeightRaw() / (F32)gViewerWindow->getWindowHeightScaled();
+        const S32 mx_win_raw = (S32)llround((F32)mouse_x * sx);
+        const S32 my_win_raw = (S32)llround((F32)mouse_y * sy);
+        const S32 mx_buf = mx_win_raw - wv_raw.mLeft;
+        const S32 my_buf = my_win_raw - wv_raw.mBottom;
+
+        // Bounds guard: a click in UI chrome (outside the world view rect)
+        // would otherwise pass a negative coord to glReadPixels (undefined).
+        if (mx_buf < 0 || my_buf < 0 ||
+            mx_buf >= gPipeline.mObjectIDBuffer.getWidth() ||
+            my_buf >= gPipeline.mObjectIDBuffer.getHeight())
+        {
+            out_gpu_authoritative = false;
+            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
+                                 << ") buf=(" << mx_buf << "," << my_buf << ") OUT OF BOUNDS"
+                                 << " wv_raw=(" << wv_raw.mLeft << "," << wv_raw.mBottom
+                                 << "," << wv_raw.getWidth() << "x" << wv_raw.getHeight() << ")"
+                                 << " bufRes=" << gPipeline.mObjectIDBuffer.getWidth()
+                                 << "x" << gPipeline.mObjectIDBuffer.getHeight()
+                                 << " -> falling through" << LL_ENDL;
+        }
+        else
+        {
+
+        GLubyte rgba[4] = {0, 0, 0, 0};
+        gPipeline.mObjectIDBuffer.bindTarget();
+        glReadPixels(mx_buf, my_buf, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+        gPipeline.mObjectIDBuffer.flush();
+        U32 local_id = ((U32)rgba[0])
+                     | ((U32)rgba[1] << 8)
+                     | ((U32)rgba[2] << 16)
+                     | ((U32)rgba[3] << 24);
+
+        // GPU is the source of truth.
+        out_gpu_authoritative = true;
+
+        if (local_id != 0)
+        {
+            for (const auto& it : gAgentAvatarp->mAttachmentPoints)
+            {
+                LLViewerJointAttachment* att = it.second;
+                if (!att || att->getIsHUDAttachment())
+                {
+                    continue;
+                }
+                for (LLViewerObject* root : att->mAttachedObjects)
+                {
+                    if (LLViewerObject* hit = findSelfAttachmentByLocalID(root, local_id))
+                    {
+                        // <AYAstorm:r21.1-diag> M4.7 / M4.13
+                        LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
+                                             << ") buf=(" << mx_buf << "," << my_buf << ")"
+                                             << " rgba=(" << (S32)rgba[0] << "," << (S32)rgba[1]
+                                             << "," << (S32)rgba[2] << "," << (S32)rgba[3]
+                                             << ") id=" << local_id
+                                             << " -> resolved id=" << hit->getID() << LL_ENDL;
+                        // </AYAstorm:r21.1-diag>
+                        return hit;
+                    }
+                }
+            }
+            // id != 0 but no matching attachment: race condition. GPU clearly
+            // sees something here, but our attachment table no longer has the
+            // owning object. authoritative empty so caller can force the body.
+            // <AYAstorm:r21.1-diag> M4.7 / M4.13
+            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
+                                 << ") buf=(" << mx_buf << "," << my_buf << ")"
+                                 << " rgba=(" << (S32)rgba[0] << "," << (S32)rgba[1]
+                                 << "," << (S32)rgba[2] << "," << (S32)rgba[3]
+                                 << ") id=" << local_id
+                                 << " -> NOT FOUND in attachment table (authoritative empty)" << LL_ENDL;
+            // </AYAstorm:r21.1-diag>
+        }
+        else
+        {
+            // id == 0: GPU says no self rigged attachment at this pixel. The
+            // truth of the visible scene. Authoritative empty.
+            // <AYAstorm:r21.1-diag> M4.7 / M4.13
+            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
+                                 << ") buf=(" << mx_buf << "," << my_buf << ")"
+                                 << " rgba=(0,0,0,0) id=0 -> authoritative empty (no rigged self at pixel)" << LL_ENDL;
+            // </AYAstorm:r21.1-diag>
+        }
+        // GPU has spoken — legacy stages would only re-introduce CPU bind-pose
+        // inaccuracy that r21.1 was built to eliminate. The legacy code below
+        // remains for diagnostic comparison if FSSelfRiggedPickerGPU is off.
+        return nullptr;
+        } // end else (in-bounds branch)
+    }
+
+    // Stage 0: depth-assist. Read the GPU depth buffer at the mouse pixel,
+    // unproject it to a world point, then run the existing ray-based pierce /
+    // near-miss machinery on a SHORT ray from the camera to that point. Why
+    // a short ray instead of "nearest triangle to the point":
+    //   - shirt-over-body: shirt triangles sit at smaller pierce_t than body
+    //     triangles along the same view ray, so the closest-to-camera pierce
+    //     naturally wins (point-to-triangle distance, by contrast, lets body
+    //     beat shirt in the mm-overlap zone via numerical noise).
+    //   - hair-over-face: the depth buffer records the face surface (the hair
+    //     mesh's alpha-discarded pixels never wrote depth there), so the ray
+    //     ends at the face and any hair triangles further along the ray are
+    //     t > 1 and excluded.
+    //   - idle-skin drift: a 10cm-class tolerance on this short ray absorbs
+    //     the CPU-vs-GPU skin frame drift that broke the long ray stages.
+    static LLCachedControl<bool> depth_assist_enable(gSavedSettings, "FSSelfRiggedPickerDepthAssist", true);
+    static LLCachedControl<F32>  depth_tol_cv(gSavedSettings, "FSSelfRiggedPickerDepthTolerance", 0.10f);
+    if (depth_assist_enable)
+    {
+        LLVector3 hit_point;
+        if (screenDepthToAgentPoint(mouse_x, mouse_y, hit_point))
+        {
+            F32 depth_tol = (F32)depth_tol_cv;
+            if (depth_tol > 0.f)
+            {
+                LLVector3 cam = LLViewerCamera::getInstance()->getOrigin();
+                // 1.001f buffers the t≈1 surface pierces so they don't get
+                // rejected by the strict t<=1 check inside rayTriangleIntersect.
+                LLVector3 short_dir = (hit_point - cam) * 1.001f;
+                F32 short_len_sq = short_dir.lengthSquared();
+                if (short_len_sq > 0.f)
+                {
+                    F32 short_tol_sq = depth_tol * depth_tol;
+                    BestPick short_best;
+                    for (const auto& it : gAgentAvatarp->mAttachmentPoints)
+                    {
+                        LLViewerJointAttachment* att = it.second;
+                        if (!att || att->getIsHUDAttachment())
+                        {
+                            continue;
+                        }
+                        for (LLViewerObject* root : att->mAttachedObjects)
+                        {
+                            // r21.1 M4.7: this code path only runs when the
+                            // GPU stage is unavailable (cvar off, or RT
+                            // allocation failed on a weak GPU / software
+                            // renderer). In that case we cannot do better
+                            // than CPU bind-pose mesh anyway, so restore the
+                            // near-miss tolerance recovery that upstream
+                            // Linden picker has historically relied on.
+                            // Users without a working GPU stage stay at
+                            // upstream-compatible "ragdoll Rigged aim" but
+                            // never lose the click outright.
+                            scanObjectAndChildren(root, cam, short_dir, short_len_sq, short_tol_sq, short_best, /*allow_near_miss*/ true);
+                        }
+                    }
+                    if (short_best.obj)
+                    {
+                        // <AYAstorm:r21.1-diag> M4.1
+                        LL_INFOS("FSPicker") << "Legacy stage 0 (depth-assist): resolved="
+                                             << short_best.obj->getID() << LL_ENDL;
+                        // </AYAstorm:r21.1-diag>
+                        return short_best.obj;
+                    }
+                }
+            }
+        }
     }
 
     // Build the world ray in the same agent-space coordinates that LLRiggedVolume
@@ -322,13 +685,11 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
     F32 tol_sq = tolerance * tolerance;
 
     // Winner selection (see VolumeHit / considerVolume in this file):
-    //   1. If any attachment is actually pierced by the ray (triangle interior),
-    //      pierces beat all near-misses, and among pierces the smallest t (the
-    //      surface nearest the camera) wins. This makes a shirt in front of the
-    //      body win over the body underneath, and makes the face mesh win over
-    //      hair that drapes nearby but doesn't actually intersect the ray.
-    //   2. If no pierce, fall back to "closest edge wins" by ray foot t (this
-    //      covers the original ~4.7cm offset rescue case).
+    //   - Front-face pierce wins, then back-face pierce. Within a category,
+    //     smallest t (closest surface) wins.
+    //   - Near-miss recovery is allowed here (M4.7 — this stage only runs
+    //     for users without a working GPU stage, where staying upstream-
+    //     compatible matters more than needle-aim precision).
     BestPick best;
 
     for (const auto& it : gAgentAvatarp->mAttachmentPoints)
@@ -340,9 +701,14 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
         }
         for (LLViewerObject* root : att->mAttachedObjects)
         {
-            scanObjectAndChildren(root, ray_a, ray_dir, ray_len_sq, tol_sq, best);
+            scanObjectAndChildren(root, ray_a, ray_dir, ray_len_sq, tol_sq, best, /*allow_near_miss*/ true);
         }
     }
 
+    // <AYAstorm:r21.1-diag> M4.4
+    LL_INFOS("FSPicker") << "Legacy stage 1 (ray pierce-only): resolved="
+                         << (best.obj ? best.obj->getID().asString() : std::string("null"))
+                         << LL_ENDL;
+    // </AYAstorm:r21.1-diag>
     return best.obj;
 }

--- a/indra/newview/fsselfriggedpicker.cpp
+++ b/indra/newview/fsselfriggedpicker.cpp
@@ -1,17 +1,13 @@
 /**
  * @file fsselfriggedpicker.cpp
- * @brief Hybrid picker for the agent's own rigged attachments.
- *        Stage 0 (depth-assist): read the GPU depth buffer at the mouse pixel,
- *        unproject to a world point, then choose the rigged attachment whose
- *        CPU-skinned triangle lies closest to that point. This is the only
- *        stage that agrees with what is actually rendered on screen (alpha
- *        discard / depth-mask hair etc. are honored by the depth buffer), and
- *        is also immune to the CPU-skin vs GPU-skin one-frame lag that breaks
- *        the ray stages when an idle animation moves the mesh.
- *        Stage 1 (ray-based fallback): ray-triangle pierce test (closest-to-
- *        camera pierce wins).
- *        Stage 2 (ray-based fallback): edge near-miss within tolerance
- *        (closest-to-camera edge wins). Pierce always beats near-miss.
+ * @brief GPU picker for the agent's own rigged attachments.
+ *
+ *        Reads the byte quad at the mouse pixel from LLPipeline::mObjectIDBuffer
+ *        (re-drawn each frame with each self rigged attachment's LocalID packed
+ *        into RGBA8) and resolves it back to the owning LLViewerObject. The
+ *        buffer is authoritative: id != 0 returns the matching attachment;
+ *        id == 0 (or no match) returns null with out_gpu_authoritative=true so
+ *        the caller can force-to-body for rigged self picks.
  *
  * $LicenseInfo:firstyear=2026&license=viewerlgpl$
  * AYAstorm Viewer Source Code
@@ -22,351 +18,20 @@
 
 #include "fsselfriggedpicker.h"
 
-#include "llcontrol.h"
-#include "llrender.h"
 #include "llrendertarget.h"
 #include "llviewercontrol.h"
-
-#include "glm/ext/matrix_projection.hpp" // glm::unProject
-#include "llvoavatarself.h"
-#include "llvovolume.h"
 #include "llviewerjointattachment.h"
-#include "llviewercamera.h"
 #include "llviewerwindow.h"
-#include "llvolume.h"
+#include "llvoavatarself.h"
 #include "pipeline.h"
-#include "v3math.h"
-#include "v4math.h"
 
 namespace
 {
-    // Two-sided ray-triangle intersect (Möller-Trumbore). Treats the ray as a
-    // segment A + t*d with t in [0, 1]. Returns true if the ray pierces the
-    // triangle (with a small barycentric tolerance so that fitted-mesh clothing
-    // — whose triangles sit only millimeters off the body surface — still
-    // qualifies even when the ray clips just outside a strict u/v border).
-    // `front_facing_out` distinguishes camera-facing front faces from
-    // back-facing geometry: CCW winding + det > 0 means the triangle normal
-    // opposes the ray direction (so the triangle is presenting its front side
-    // to the camera). The caller prefers front-face pierces over back-face
-    // ones; this protects shirt-over-body from CPU-skin numerical noise where
-    // a body-side back-face would otherwise win the smallest-t race against
-    // the shirt-side front-face that the user actually clicked.
-    bool rayTriangleIntersect(const LLVector3& orig, const LLVector3& dir,
-                              const LLVector3& v0, const LLVector3& v1, const LLVector3& v2,
-                              F32& t_out, bool& front_facing_out)
-    {
-        const F32 EPS = 1e-8f;
-        const F32 BARY_EPS = 0.02f;
-        LLVector3 e1 = v1 - v0;
-        LLVector3 e2 = v2 - v0;
-        LLVector3 pvec = dir % e2;
-        F32 det = e1 * pvec;
-        if (fabsf(det) < EPS)
-        {
-            return false; // parallel to triangle plane
-        }
-        front_facing_out = (det > 0.f);
-        F32 inv_det = 1.f / det;
-        LLVector3 tvec = orig - v0;
-        F32 u = (tvec * pvec) * inv_det;
-        if (u < -BARY_EPS || u > 1.f + BARY_EPS)
-        {
-            return false;
-        }
-        LLVector3 qvec = tvec % e1;
-        F32 v = (dir * qvec) * inv_det;
-        if (v < -BARY_EPS || (u + v) > 1.f + BARY_EPS)
-        {
-            return false;
-        }
-        F32 t = (e2 * qvec) * inv_det;
-        if (t < 0.f || t > 1.f)
-        {
-            return false;
-        }
-        t_out = t;
-        return true;
-    }
-
-    // Squared distance between two finite line segments S1=[A1, A1+d1] and S2=[A2, A2+d2].
-    // d1_sq/d2_sq are precomputed |d|^2. Closed-form clamp-to-[0,1] solution.
-    // Returns the foot parameter on S1 in `ray_t_out` (the [0,1] position along
-    // the ray where it is closest to the edge — smaller = nearer the camera).
-    F32 distSqSegToSeg(const LLVector3& A1, const LLVector3& d1, F32 d1_sq,
-                       const LLVector3& A2, const LLVector3& d2, F32 d2_sq,
-                       F32& ray_t_out)
-    {
-        const F32 EPS = 1e-8f;
-        LLVector3 r = A1 - A2;
-        F32 c = d1 * r;
-        F32 f = d2 * r;
-        F32 s, t;
-
-        if (d1_sq <= EPS && d2_sq <= EPS)
-        {
-            ray_t_out = 0.f;
-            return r.lengthSquared();
-        }
-        if (d1_sq <= EPS)
-        {
-            s = 0.f;
-            t = llclamp(f / d2_sq, 0.f, 1.f);
-        }
-        else if (d2_sq <= EPS)
-        {
-            t = 0.f;
-            s = llclamp(-c / d1_sq, 0.f, 1.f);
-        }
-        else
-        {
-            F32 b = d1 * d2;
-            F32 denom = d1_sq * d2_sq - b * b;
-            if (denom > EPS)
-            {
-                s = llclamp((b * f - c * d2_sq) / denom, 0.f, 1.f);
-            }
-            else
-            {
-                s = 0.f;
-            }
-            t = (b * s + f) / d2_sq;
-            if (t < 0.f)
-            {
-                t = 0.f;
-                s = llclamp(-c / d1_sq, 0.f, 1.f);
-            }
-            else if (t > 1.f)
-            {
-                t = 1.f;
-                s = llclamp((b - c) / d1_sq, 0.f, 1.f);
-            }
-        }
-
-        ray_t_out = s;
-        LLVector3 closest1 = A1 + d1 * s;
-        LLVector3 closest2 = A2 + d2 * t;
-        return (closest1 - closest2).lengthSquared();
-    }
-
-    // Per-volume aggregation. Three metrics are computed in a single triangle pass:
-    //   (1) hits_front: did the ray pierce any front-facing triangle (camera
-    //       side)? If yes, record the smallest such pierce t.
-    //   (2) hits_back: did the ray pierce any back-facing triangle (the inside
-    //       face of the mesh, looking away from camera)? Smallest t recorded.
-    //   (3) near_miss: did any triangle edge come within tolerance of the ray?
-    //       If yes, record the smallest ray foot t at that edge.
-    // The caller prefers (1) > (2) > (3): a volume whose camera-facing surface
-    // the ray pierces beats one that the ray only sees the back side of (which
-    // happens when CPU-skin numerical noise reorders mm-scale-overlapping mesh
-    // surfaces), which in turn beats a volume that the ray only grazes.
-    struct VolumeHit
-    {
-        bool hits_front = false;
-        F32 front_pierce_t = 1.f + 1e-3f; // smallest t among pierced front-facing triangles
-        bool hits_back = false;
-        F32 back_pierce_t = 1.f + 1e-3f; // smallest t among pierced back-facing triangles
-        bool near_miss = false;
-        F32 grazes_t = 1.f + 1e-3f; // smallest ray foot t among in-tolerance edges
-    };
-
-    bool scanVolume(LLVOVolume* volp,
-                    const LLVector3& ray_a,
-                    const LLVector3& ray_dir,
-                    F32 ray_len_sq,
-                    F32 tol_sq,
-                    VolumeHit& out_hit)
-    {
-        if (!volp || volp->isDead() || volp->isHUDAttachment())
-        {
-            return false;
-        }
-        if (!volp->isRiggedMesh())
-        {
-            return false;
-        }
-
-        // Ensure mRiggedVolume is allocated and CPU-skinned for all faces.
-        volp->updateRiggedVolume(true, LLRiggedVolume::UPDATE_ALL_FACES, false);
-        LLRiggedVolume* rigged = volp->getRiggedVolume();
-        if (!rigged)
-        {
-            return false;
-        }
-
-        VolumeHit hit;
-        const S32 nfaces = rigged->getNumVolumeFaces();
-        for (S32 f = 0; f < nfaces; ++f)
-        {
-            const LLVolumeFace& face = rigged->getVolumeFace(f);
-            if (!face.mPositions || !face.mIndices || face.mNumVertices <= 0 || face.mNumIndices < 3)
-            {
-                continue;
-            }
-            const LLVector4a* positions = face.mPositions;
-            const U16* indices = face.mIndices;
-            const S32 ntris = face.mNumIndices / 3;
-            for (S32 tri = 0; tri < ntris; ++tri)
-            {
-                const U16 i0 = indices[tri * 3 + 0];
-                const U16 i1 = indices[tri * 3 + 1];
-                const U16 i2 = indices[tri * 3 + 2];
-                if (i0 >= face.mNumVertices || i1 >= face.mNumVertices || i2 >= face.mNumVertices)
-                {
-                    continue;
-                }
-                const F32* p0 = positions[i0].getF32ptr();
-                const F32* p1 = positions[i1].getF32ptr();
-                const F32* p2 = positions[i2].getF32ptr();
-                LLVector3 v0(p0[0], p0[1], p0[2]);
-                LLVector3 v1(p1[0], p1[1], p1[2]);
-                LLVector3 v2(p2[0], p2[1], p2[2]);
-
-                // (1) Pierce test.
-                F32 pierce_t;
-                bool front_facing;
-                if (rayTriangleIntersect(ray_a, ray_dir, v0, v1, v2, pierce_t, front_facing))
-                {
-                    if (front_facing)
-                    {
-                        if (pierce_t < hit.front_pierce_t)
-                        {
-                            hit.front_pierce_t = pierce_t;
-                            hit.hits_front = true;
-                        }
-                    }
-                    else
-                    {
-                        if (pierce_t < hit.back_pierce_t)
-                        {
-                            hit.back_pierce_t = pierce_t;
-                            hit.hits_back = true;
-                        }
-                    }
-                }
-
-                // (2) Edge near-miss test (only meaningful if no pierce was found
-                // yet for this volume, but cheap enough to always run).
-                LLVector3 e[3] = { v1 - v0, v2 - v1, v0 - v2 };
-                LLVector3 a[3] = { v0, v1, v2 };
-                F32 e_sq[3] = { e[0].lengthSquared(), e[1].lengthSquared(), e[2].lengthSquared() };
-                for (int k = 0; k < 3; ++k)
-                {
-                    F32 ray_t;
-                    F32 d2 = distSqSegToSeg(ray_a, ray_dir, ray_len_sq, a[k], e[k], e_sq[k], ray_t);
-                    if (d2 <= tol_sq && ray_t < hit.grazes_t)
-                    {
-                        hit.grazes_t = ray_t;
-                        hit.near_miss = true;
-                    }
-                }
-            }
-        }
-
-        if (hit.hits_front || hit.hits_back || hit.near_miss)
-        {
-            out_hit = hit;
-            return true;
-        }
-        return false;
-    }
-
-    // Ranking categories — higher beats lower regardless of score_t.
-    enum PickCategory
-    {
-        PICK_NONE       = 0,
-        PICK_NEAR_MISS  = 1, // ray grazed an edge only
-        PICK_BACK_FACE  = 2, // ray pierced a back-facing triangle
-        PICK_FRONT_FACE = 3  // ray pierced a camera-facing triangle (preferred)
-    };
-
-    struct BestPick
-    {
-        LLViewerObject* obj = nullptr;
-        F32 score_t = 1.f + 1e-3f; // smaller is better, only compared within the same category
-        PickCategory category = PICK_NONE;
-    };
-
-    void considerVolume(LLVOVolume* volp, const VolumeHit& hit, BestPick& best, bool allow_near_miss)
-    {
-        // Front-face pierce: highest tier. A shirt's outer surface in front of
-        // a body's outer surface wins here automatically (smaller t).
-        if (hit.hits_front)
-        {
-            if (best.category < PICK_FRONT_FACE || hit.front_pierce_t < best.score_t)
-            {
-                best.obj = volp;
-                best.score_t = hit.front_pierce_t;
-                best.category = PICK_FRONT_FACE;
-            }
-            return;
-        }
-        // Back-face pierce: only competes if nothing has a front pierce yet.
-        // This protects against CPU-skin noise where a body-side back-face
-        // would otherwise sneak under the shirt's front-face by a sub-mm
-        // pierce_t margin.
-        if (hit.hits_back && best.category <= PICK_BACK_FACE)
-        {
-            if (best.category < PICK_BACK_FACE || hit.back_pierce_t < best.score_t)
-            {
-                best.obj = volp;
-                best.score_t = hit.back_pierce_t;
-                best.category = PICK_BACK_FACE;
-            }
-            return;
-        }
-        // Near-miss: lowest tier; only competes against other near-misses.
-        // Suppressed entirely when allow_near_miss=false (r21.1 needle-aim
-        // mode — the GPU ID buffer is the precise path, legacy stages only
-        // exist to recover pierces the GPU couldn't sample). Near-miss
-        // recoveries widen the hit zone by tolerance metres, which feels
-        // like ragdoll aiming on closeup avatars.
-        if (allow_near_miss && hit.near_miss && best.category <= PICK_NEAR_MISS)
-        {
-            if (best.category < PICK_NEAR_MISS || hit.grazes_t < best.score_t)
-            {
-                best.obj = volp;
-                best.score_t = hit.grazes_t;
-                best.category = PICK_NEAR_MISS;
-            }
-        }
-    }
-
-    void scanObjectAndChildren(LLViewerObject* obj,
-                               const LLVector3& ray_a,
-                               const LLVector3& ray_dir,
-                               F32 ray_len_sq,
-                               F32 tol_sq,
-                               BestPick& best,
-                               bool allow_near_miss)
-    {
-        if (!obj || obj->isDead())
-        {
-            return;
-        }
-        if (obj->getPCode() == LL_PCODE_VOLUME)
-        {
-            LLVOVolume* volp = dynamic_cast<LLVOVolume*>(obj);
-            VolumeHit hit;
-            if (volp && scanVolume(volp, ray_a, ray_dir, ray_len_sq, tol_sq, hit))
-            {
-                considerVolume(volp, hit, best, allow_near_miss);
-            }
-        }
-        for (LLViewerObject* child : obj->getChildren())
-        {
-            scanObjectAndChildren(child, ray_a, ray_dir, ray_len_sq, tol_sq, best, allow_near_miss);
-        }
-    }
-
-    // ----- Stage -1 (GPU ID buffer) helper -------------------------------
-
     // Recursive walk through gAgentAvatarp's attachment tree, looking for the
     // child whose LocalID matches what the GPU object-ID buffer reported at
-    // the mouse pixel. We deliberately scope the search to self attachments
-    // only — Stage -1 is a self-picker; the upstream picker handles the rest
-    // of the scene. This also means we never look up by ip/port and never
-    // risk grabbing a non-self object whose LocalID happens to collide.
+    // the mouse pixel. Scoped to self attachments only — the upstream picker
+    // handles the rest of the scene, and this also avoids LocalID collisions
+    // with non-self objects.
     LLViewerObject* findSelfAttachmentByLocalID(LLViewerObject* obj, U32 target_id)
     {
         if (!obj)
@@ -386,80 +51,9 @@ namespace
         }
         return nullptr;
     }
-
-    // ----- Stage 0 (depth-assist) helper ---------------------------------
-
-    // Read the depth buffer at (mouse_x, mouse_y) and unproject back to an
-    // agent-space world point. Returns false if depth-assist is unavailable
-    // (no deferred RT bound, or the sampled depth is at the far plane = sky).
-    bool screenDepthToAgentPoint(S32 mouse_x, S32 mouse_y, LLVector3& out_point)
-    {
-        if (!gPipeline.mRT)
-        {
-            return false;
-        }
-        LLRenderTarget& screen_rt = gPipeline.mRT->screen;
-        if (!screen_rt.isComplete())
-        {
-            return false;
-        }
-
-        // The world view rectangle (excluding UI chrome) is the viewport that
-        // the deferred geometry pass and the camera matrices were set up with.
-        LLRect wvr = gViewerWindow->getWorldViewRectRaw();
-        glm::ivec4 viewport(wvr.mLeft, wvr.mBottom, wvr.getWidth(), wvr.getHeight());
-
-        // mouse_x / mouse_y arrive here as LLCoordGL — bottom-origin window
-        // pixels in *scaled* (logical) coords. The screen RT is allocated at
-        // WorldViewRectRaw dimensions (pipeline.cpp resizeScreenTexture()), so
-        // its (0,0) is the world view rect's bottom-left in raw pixels.
-        //   1) scaled → raw via DisplayScale
-        //   2) subtract WorldViewRectRaw.mLeft/mBottom → buffer-local coord
-        // unProject(viewport = WorldViewRectRaw) likewise expects buffer-local
-        // pixels (its viewport rectangle has been translated to (mLeft,mBottom)
-        // already, so pass the buffer-local coord and unProject re-applies the
-        // offset internally).
-        const F32 sx = (F32)gViewerWindow->getWindowWidthRaw()  / (F32)gViewerWindow->getWindowWidthScaled();
-        const F32 sy = (F32)gViewerWindow->getWindowHeightRaw() / (F32)gViewerWindow->getWindowHeightScaled();
-        const S32 mx_win_raw = (S32)llround((F32)mouse_x * sx);
-        const S32 my_win_raw = (S32)llround((F32)mouse_y * sy);
-        const S32 mx_buf = mx_win_raw - wvr.mLeft;
-        const S32 my_buf = my_win_raw - wvr.mBottom;
-
-        if (mx_buf < 0 || my_buf < 0 ||
-            mx_buf >= wvr.getWidth() || my_buf >= wvr.getHeight())
-        {
-            return false;
-        }
-
-        F32 depth_sample = 1.f;
-        screen_rt.bindTarget();
-        glReadPixels(mx_buf, my_buf, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth_sample);
-        screen_rt.flush();
-
-        // depth ~= 1.0 means "no geometry written here" (sky / discarded /
-        // alpha-blend with depth-write off). Fall back to the ray stages.
-        if (depth_sample >= 0.9999f)
-        {
-            return false;
-        }
-
-        // glm::unProject expects window coords matching `viewport`. Since
-        // viewport is (wvr.mLeft, wvr.mBottom, wvr.W, wvr.H), pass the
-        // window-raw pixel here (not buffer-local) so it lies inside the
-        // viewport rect.
-        glm::vec3 win_coord((F32)mx_win_raw, (F32)my_win_raw, depth_sample);
-        glm::vec3 agent_coord = glm::unProject(win_coord,
-                                               get_current_modelview(),
-                                               get_current_projection(),
-                                               viewport);
-        out_point.setVec((F32)agent_coord.x, (F32)agent_coord.y, (F32)agent_coord.z);
-        return true;
-    }
-
 }
 
-LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance,
+LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse_y,
                                                           bool& out_gpu_authoritative)
 {
     out_gpu_authoritative = false;
@@ -467,248 +61,70 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
     {
         return nullptr;
     }
-    if (tolerance <= 0.f)
-    {
-        return nullptr;
-    }
 
-    // Stage -1: GPU object-ID buffer. The dedicated pass in renderDeferredLighting
-    // re-draws gAgentAvatarp's rigged attachments using the same GPU skinning the
-    // visible scene uses, packing each attachment's LocalID into RGBA8. Reading
-    // back the byte quad at the mouse pixel gives a pixel-perfect agreement with
-    // what is actually on screen — no CPU-skin vs GPU-skin drift, no ray vs
-    // skin-frame mismatch, no near-miss heuristics.
-    //
-    // r21.1 M4.7: fully authoritative. CPU bind-pose mesh ray (the legacy
-    // path below) cannot be made accurate for rigged attachments — that is
-    // exactly the upstream Linden picker problem r21.1 exists to solve.
-    // Falling back to it on GPU id=0 just reintroduces the old ragdoll aim.
-    // Outcomes:
-    //   - id != 0 + match → return it.
-    //   - id != 0 + no match (race: attachment removed mid-frame, stale
-    //     value) → out_gpu_authoritative=true, null. Caller may force-to-body.
-    //   - id == 0 → "no self rigged attachment at this pixel" is the truth.
-    //     out_gpu_authoritative=true, null. Caller may force-to-body when
-    //     upstream's worldray picked one of our attachments.
-    //
-    // Closeup-zoom shirt pixels currently return id=0 even when shirt is
-    // visually present — that is a GPU pass deficiency (cull/alpha/skin
-    // matrix/LOD state mismatch with deferred opaque) and must be fixed in
-    // the pass, NOT papered over with a CPU fallback.
     static LLCachedControl<bool> gpu_enable(gSavedSettings, "FSSelfRiggedPickerGPU", false);
-    if (gpu_enable && gPipeline.mObjectIDBuffer.isComplete())
-    {
-        // Coordinate conversion. mObjectIDBuffer is allocated by
-        // resizeScreenTexture() at *WorldViewRectRaw* dimensions — not the
-        // full window — so the buffer's (0,0) corresponds to the world
-        // view rect's bottom-left in *raw* pixels. LLCoordGL mouse coords
-        // are window-relative *scaled* (logical) pixels.
-        //   1) scaled → raw via DisplayScale (mWindowRectRaw / mWindowRectScaled)
-        //   2) subtract WorldViewRectRaw's mLeft/mBottom origin so the
-        //      result is buffer-local.
-        // Missing either step (raw mismatch on HiDPI / UI-chrome offset)
-        // reads the wrong pixel — typically id=0.
-        const LLRect wv_raw = gViewerWindow->getWorldViewRectRaw();
-        const F32 sx = (F32)gViewerWindow->getWindowWidthRaw()  / (F32)gViewerWindow->getWindowWidthScaled();
-        const F32 sy = (F32)gViewerWindow->getWindowHeightRaw() / (F32)gViewerWindow->getWindowHeightScaled();
-        const S32 mx_win_raw = (S32)llround((F32)mouse_x * sx);
-        const S32 my_win_raw = (S32)llround((F32)mouse_y * sy);
-        const S32 mx_buf = mx_win_raw - wv_raw.mLeft;
-        const S32 my_buf = my_win_raw - wv_raw.mBottom;
-
-        // Bounds guard: a click in UI chrome (outside the world view rect)
-        // would otherwise pass a negative coord to glReadPixels (undefined).
-        if (mx_buf < 0 || my_buf < 0 ||
-            mx_buf >= gPipeline.mObjectIDBuffer.getWidth() ||
-            my_buf >= gPipeline.mObjectIDBuffer.getHeight())
-        {
-            out_gpu_authoritative = false;
-            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
-                                 << ") buf=(" << mx_buf << "," << my_buf << ") OUT OF BOUNDS"
-                                 << " wv_raw=(" << wv_raw.mLeft << "," << wv_raw.mBottom
-                                 << "," << wv_raw.getWidth() << "x" << wv_raw.getHeight() << ")"
-                                 << " bufRes=" << gPipeline.mObjectIDBuffer.getWidth()
-                                 << "x" << gPipeline.mObjectIDBuffer.getHeight()
-                                 << " -> falling through" << LL_ENDL;
-        }
-        else
-        {
-
-        GLubyte rgba[4] = {0, 0, 0, 0};
-        gPipeline.mObjectIDBuffer.bindTarget();
-        glReadPixels(mx_buf, my_buf, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
-        gPipeline.mObjectIDBuffer.flush();
-        U32 local_id = ((U32)rgba[0])
-                     | ((U32)rgba[1] << 8)
-                     | ((U32)rgba[2] << 16)
-                     | ((U32)rgba[3] << 24);
-
-        // GPU is the source of truth.
-        out_gpu_authoritative = true;
-
-        if (local_id != 0)
-        {
-            for (const auto& it : gAgentAvatarp->mAttachmentPoints)
-            {
-                LLViewerJointAttachment* att = it.second;
-                if (!att || att->getIsHUDAttachment())
-                {
-                    continue;
-                }
-                for (LLViewerObject* root : att->mAttachedObjects)
-                {
-                    if (LLViewerObject* hit = findSelfAttachmentByLocalID(root, local_id))
-                    {
-                        // <AYAstorm:r21.1-diag> M4.7 / M4.13
-                        LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
-                                             << ") buf=(" << mx_buf << "," << my_buf << ")"
-                                             << " rgba=(" << (S32)rgba[0] << "," << (S32)rgba[1]
-                                             << "," << (S32)rgba[2] << "," << (S32)rgba[3]
-                                             << ") id=" << local_id
-                                             << " -> resolved id=" << hit->getID() << LL_ENDL;
-                        // </AYAstorm:r21.1-diag>
-                        return hit;
-                    }
-                }
-            }
-            // id != 0 but no matching attachment: race condition. GPU clearly
-            // sees something here, but our attachment table no longer has the
-            // owning object. authoritative empty so caller can force the body.
-            // <AYAstorm:r21.1-diag> M4.7 / M4.13
-            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
-                                 << ") buf=(" << mx_buf << "," << my_buf << ")"
-                                 << " rgba=(" << (S32)rgba[0] << "," << (S32)rgba[1]
-                                 << "," << (S32)rgba[2] << "," << (S32)rgba[3]
-                                 << ") id=" << local_id
-                                 << " -> NOT FOUND in attachment table (authoritative empty)" << LL_ENDL;
-            // </AYAstorm:r21.1-diag>
-        }
-        else
-        {
-            // id == 0: GPU says no self rigged attachment at this pixel. The
-            // truth of the visible scene. Authoritative empty.
-            // <AYAstorm:r21.1-diag> M4.7 / M4.13
-            LL_INFOS("FSPicker") << "GPU stage -1: mouse=(" << mouse_x << "," << mouse_y
-                                 << ") buf=(" << mx_buf << "," << my_buf << ")"
-                                 << " rgba=(0,0,0,0) id=0 -> authoritative empty (no rigged self at pixel)" << LL_ENDL;
-            // </AYAstorm:r21.1-diag>
-        }
-        // GPU has spoken — legacy stages would only re-introduce CPU bind-pose
-        // inaccuracy that r21.1 was built to eliminate. The legacy code below
-        // remains for diagnostic comparison if FSSelfRiggedPickerGPU is off.
-        return nullptr;
-        } // end else (in-bounds branch)
-    }
-
-    // Stage 0: depth-assist. Read the GPU depth buffer at the mouse pixel,
-    // unproject it to a world point, then run the existing ray-based pierce /
-    // near-miss machinery on a SHORT ray from the camera to that point. Why
-    // a short ray instead of "nearest triangle to the point":
-    //   - shirt-over-body: shirt triangles sit at smaller pierce_t than body
-    //     triangles along the same view ray, so the closest-to-camera pierce
-    //     naturally wins (point-to-triangle distance, by contrast, lets body
-    //     beat shirt in the mm-overlap zone via numerical noise).
-    //   - hair-over-face: the depth buffer records the face surface (the hair
-    //     mesh's alpha-discarded pixels never wrote depth there), so the ray
-    //     ends at the face and any hair triangles further along the ray are
-    //     t > 1 and excluded.
-    //   - idle-skin drift: a 10cm-class tolerance on this short ray absorbs
-    //     the CPU-vs-GPU skin frame drift that broke the long ray stages.
-    static LLCachedControl<bool> depth_assist_enable(gSavedSettings, "FSSelfRiggedPickerDepthAssist", true);
-    static LLCachedControl<F32>  depth_tol_cv(gSavedSettings, "FSSelfRiggedPickerDepthTolerance", 0.10f);
-    if (depth_assist_enable)
-    {
-        LLVector3 hit_point;
-        if (screenDepthToAgentPoint(mouse_x, mouse_y, hit_point))
-        {
-            F32 depth_tol = (F32)depth_tol_cv;
-            if (depth_tol > 0.f)
-            {
-                LLVector3 cam = LLViewerCamera::getInstance()->getOrigin();
-                // 1.001f buffers the t≈1 surface pierces so they don't get
-                // rejected by the strict t<=1 check inside rayTriangleIntersect.
-                LLVector3 short_dir = (hit_point - cam) * 1.001f;
-                F32 short_len_sq = short_dir.lengthSquared();
-                if (short_len_sq > 0.f)
-                {
-                    F32 short_tol_sq = depth_tol * depth_tol;
-                    BestPick short_best;
-                    for (const auto& it : gAgentAvatarp->mAttachmentPoints)
-                    {
-                        LLViewerJointAttachment* att = it.second;
-                        if (!att || att->getIsHUDAttachment())
-                        {
-                            continue;
-                        }
-                        for (LLViewerObject* root : att->mAttachedObjects)
-                        {
-                            // r21.1 M4.7: this code path only runs when the
-                            // GPU stage is unavailable (cvar off, or RT
-                            // allocation failed on a weak GPU / software
-                            // renderer). In that case we cannot do better
-                            // than CPU bind-pose mesh anyway, so restore the
-                            // near-miss tolerance recovery that upstream
-                            // Linden picker has historically relied on.
-                            // Users without a working GPU stage stay at
-                            // upstream-compatible "ragdoll Rigged aim" but
-                            // never lose the click outright.
-                            scanObjectAndChildren(root, cam, short_dir, short_len_sq, short_tol_sq, short_best, /*allow_near_miss*/ true);
-                        }
-                    }
-                    if (short_best.obj)
-                    {
-                        // <AYAstorm:r21.1-diag> M4.1
-                        LL_INFOS("FSPicker") << "Legacy stage 0 (depth-assist): resolved="
-                                             << short_best.obj->getID() << LL_ENDL;
-                        // </AYAstorm:r21.1-diag>
-                        return short_best.obj;
-                    }
-                }
-            }
-        }
-    }
-
-    // Build the world ray in the same agent-space coordinates that LLRiggedVolume
-    // stores its CPU-skinned mPositions in (matches LLViewerWindow::cursorIntersect /
-    // LLVOVolume::lineSegmentIntersect rigged path, which skips the volume-local
-    // transform).
-    LLVector3 cam_origin = LLViewerCamera::getInstance()->getOrigin();
-    LLVector3 mouse_dir = gViewerWindow->mouseDirectionGlobal(mouse_x, mouse_y);
-    const F32 depth = 512.f; // matches upstream cursorIntersect default
-    LLVector3 ray_a = cam_origin;
-    LLVector3 ray_dir = mouse_dir * depth; // segment vector
-    F32 ray_len_sq = ray_dir.lengthSquared();
-    if (ray_len_sq <= 0.f)
+    if (!gpu_enable || !gPipeline.mObjectIDBuffer.isComplete())
     {
         return nullptr;
     }
-    F32 tol_sq = tolerance * tolerance;
 
-    // Winner selection (see VolumeHit / considerVolume in this file):
-    //   - Front-face pierce wins, then back-face pierce. Within a category,
-    //     smallest t (closest surface) wins.
-    //   - Near-miss recovery is allowed here (M4.7 — this stage only runs
-    //     for users without a working GPU stage, where staying upstream-
-    //     compatible matters more than needle-aim precision).
-    BestPick best;
+    // Coordinate conversion. mObjectIDBuffer is allocated at WorldViewRectRaw
+    // dimensions (pipeline.cpp resizeScreenTexture), so its (0,0) corresponds
+    // to the world view rect's bottom-left in raw pixels. LLCoordGL mouse
+    // coords are window-relative scaled (logical) pixels.
+    //   1) scaled → raw via DisplayScale (mWindowRectRaw / mWindowRectScaled)
+    //   2) subtract WorldViewRectRaw's mLeft/mBottom origin → buffer-local
+    // Missing either step (raw mismatch on HiDPI / UI-chrome offset) reads
+    // the wrong pixel — typically id=0.
+    const LLRect wv_raw = gViewerWindow->getWorldViewRectRaw();
+    const F32 sx = (F32)gViewerWindow->getWindowWidthRaw()  / (F32)gViewerWindow->getWindowWidthScaled();
+    const F32 sy = (F32)gViewerWindow->getWindowHeightRaw() / (F32)gViewerWindow->getWindowHeightScaled();
+    const S32 mx_win_raw = (S32)llround((F32)mouse_x * sx);
+    const S32 my_win_raw = (S32)llround((F32)mouse_y * sy);
+    const S32 mx_buf = mx_win_raw - wv_raw.mLeft;
+    const S32 my_buf = my_win_raw - wv_raw.mBottom;
 
-    for (const auto& it : gAgentAvatarp->mAttachmentPoints)
+    if (mx_buf < 0 || my_buf < 0 ||
+        mx_buf >= gPipeline.mObjectIDBuffer.getWidth() ||
+        my_buf >= gPipeline.mObjectIDBuffer.getHeight())
     {
-        LLViewerJointAttachment* att = it.second;
-        if (!att || att->getIsHUDAttachment())
-        {
-            continue;
-        }
-        for (LLViewerObject* root : att->mAttachedObjects)
-        {
-            scanObjectAndChildren(root, ray_a, ray_dir, ray_len_sq, tol_sq, best, /*allow_near_miss*/ true);
-        }
+        return nullptr;
     }
 
-    // <AYAstorm:r21.1-diag> M4.4
-    LL_INFOS("FSPicker") << "Legacy stage 1 (ray pierce-only): resolved="
-                         << (best.obj ? best.obj->getID().asString() : std::string("null"))
-                         << LL_ENDL;
-    // </AYAstorm:r21.1-diag>
-    return best.obj;
+    GLubyte rgba[4] = {0, 0, 0, 0};
+    gPipeline.mObjectIDBuffer.bindTarget();
+    glReadPixels(mx_buf, my_buf, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, rgba);
+    gPipeline.mObjectIDBuffer.flush();
+    U32 local_id = ((U32)rgba[0])
+                 | ((U32)rgba[1] << 8)
+                 | ((U32)rgba[2] << 16)
+                 | ((U32)rgba[3] << 24);
+
+    // GPU is the source of truth.
+    out_gpu_authoritative = true;
+
+    if (local_id != 0)
+    {
+        for (const auto& it : gAgentAvatarp->mAttachmentPoints)
+        {
+            LLViewerJointAttachment* att = it.second;
+            if (!att || att->getIsHUDAttachment())
+            {
+                continue;
+            }
+            for (LLViewerObject* root : att->mAttachedObjects)
+            {
+                if (LLViewerObject* hit = findSelfAttachmentByLocalID(root, local_id))
+                {
+                    return hit;
+                }
+            }
+        }
+        // id != 0 but no matching attachment: race (attachment removed
+        // mid-frame, or stale value). Authoritative empty so caller can
+        // force-to-body.
+    }
+    // id == 0: GPU says no self rigged attachment at this pixel — the truth
+    // of the visible scene. Authoritative empty.
+    return nullptr;
 }

--- a/indra/newview/fsselfriggedpicker.cpp
+++ b/indra/newview/fsselfriggedpicker.cpp
@@ -1,0 +1,348 @@
+/**
+ * @file fsselfriggedpicker.cpp
+ * @brief Two-stage picker for the agent's own rigged attachments.
+ *        Stage 1: ray-triangle pierce test (closest-to-camera pierce wins).
+ *        Stage 2 (fallback): edge near-miss within tolerance (closest-to-camera
+ *        edge wins). Pierce always beats near-miss.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * AYAstorm Viewer Source Code
+ * $/LicenseInfo$
+ */
+
+#include "llviewerprecompiledheaders.h"
+
+#include "fsselfriggedpicker.h"
+
+#include "llvoavatarself.h"
+#include "llvovolume.h"
+#include "llviewerjointattachment.h"
+#include "llviewercamera.h"
+#include "llviewerwindow.h"
+#include "llvolume.h"
+#include "v3math.h"
+#include "v4math.h"
+
+namespace
+{
+    // Two-sided ray-triangle intersect (Möller-Trumbore). Treats the ray as a
+    // segment A + t*d with t in [0, 1]. Returns true if the ray pierces the
+    // triangle (with a small barycentric tolerance so that fitted-mesh clothing
+    // — whose triangles sit only millimeters off the body surface — still
+    // qualifies even when the ray clips just outside a strict u/v border).
+    // BARY_EPS = 0.02 ≈ 1mm on a 5cm triangle; far below the cm-scale
+    // separation that distinguishes e.g. hair triangles from face triangles, so
+    // it does not reintroduce the hair-steals-face problem fixed previously.
+    bool rayTriangleIntersect(const LLVector3& orig, const LLVector3& dir,
+                              const LLVector3& v0, const LLVector3& v1, const LLVector3& v2,
+                              F32& t_out)
+    {
+        const F32 EPS = 1e-8f;
+        const F32 BARY_EPS = 0.02f;
+        LLVector3 e1 = v1 - v0;
+        LLVector3 e2 = v2 - v0;
+        LLVector3 pvec = dir % e2;
+        F32 det = e1 * pvec;
+        if (fabsf(det) < EPS)
+        {
+            return false; // parallel to triangle plane
+        }
+        F32 inv_det = 1.f / det;
+        LLVector3 tvec = orig - v0;
+        F32 u = (tvec * pvec) * inv_det;
+        if (u < -BARY_EPS || u > 1.f + BARY_EPS)
+        {
+            return false;
+        }
+        LLVector3 qvec = tvec % e1;
+        F32 v = (dir * qvec) * inv_det;
+        if (v < -BARY_EPS || (u + v) > 1.f + BARY_EPS)
+        {
+            return false;
+        }
+        F32 t = (e2 * qvec) * inv_det;
+        if (t < 0.f || t > 1.f)
+        {
+            return false;
+        }
+        t_out = t;
+        return true;
+    }
+
+    // Squared distance between two finite line segments S1=[A1, A1+d1] and S2=[A2, A2+d2].
+    // d1_sq/d2_sq are precomputed |d|^2. Closed-form clamp-to-[0,1] solution.
+    // Returns the foot parameter on S1 in `ray_t_out` (the [0,1] position along
+    // the ray where it is closest to the edge — smaller = nearer the camera).
+    F32 distSqSegToSeg(const LLVector3& A1, const LLVector3& d1, F32 d1_sq,
+                       const LLVector3& A2, const LLVector3& d2, F32 d2_sq,
+                       F32& ray_t_out)
+    {
+        const F32 EPS = 1e-8f;
+        LLVector3 r = A1 - A2;
+        F32 c = d1 * r;
+        F32 f = d2 * r;
+        F32 s, t;
+
+        if (d1_sq <= EPS && d2_sq <= EPS)
+        {
+            ray_t_out = 0.f;
+            return r.lengthSquared();
+        }
+        if (d1_sq <= EPS)
+        {
+            s = 0.f;
+            t = llclamp(f / d2_sq, 0.f, 1.f);
+        }
+        else if (d2_sq <= EPS)
+        {
+            t = 0.f;
+            s = llclamp(-c / d1_sq, 0.f, 1.f);
+        }
+        else
+        {
+            F32 b = d1 * d2;
+            F32 denom = d1_sq * d2_sq - b * b;
+            if (denom > EPS)
+            {
+                s = llclamp((b * f - c * d2_sq) / denom, 0.f, 1.f);
+            }
+            else
+            {
+                s = 0.f;
+            }
+            t = (b * s + f) / d2_sq;
+            if (t < 0.f)
+            {
+                t = 0.f;
+                s = llclamp(-c / d1_sq, 0.f, 1.f);
+            }
+            else if (t > 1.f)
+            {
+                t = 1.f;
+                s = llclamp((b - c) / d1_sq, 0.f, 1.f);
+            }
+        }
+
+        ray_t_out = s;
+        LLVector3 closest1 = A1 + d1 * s;
+        LLVector3 closest2 = A2 + d2 * t;
+        return (closest1 - closest2).lengthSquared();
+    }
+
+    // Per-volume aggregation. Two metrics are computed in a single triangle pass:
+    //   (1) hits_through: did the ray actually pierce any triangle interior?
+    //       If yes, record the smallest pierce t (= closest-to-camera hit).
+    //   (2) near_miss: did any triangle edge come within `tolerance` of the ray?
+    //       If yes, record the smallest ray foot t at that edge.
+    // The caller prefers (1) over (2): a volume that the ray physically passes
+    // through always beats one that the ray merely grazes nearby. This stops
+    // a hair mesh that hangs in front of the face (its triangle edges within
+    // tolerance, but no triangle actually pierced by the ray under the nose)
+    // from stealing the click from the face mesh the ray really enters.
+    struct VolumeHit
+    {
+        bool hits_through = false;
+        F32 pierce_t = 1.f + 1e-3f; // smallest t among pierced triangles
+        bool near_miss = false;
+        F32 grazes_t = 1.f + 1e-3f; // smallest ray foot t among in-tolerance edges
+    };
+
+    bool scanVolume(LLVOVolume* volp,
+                    const LLVector3& ray_a,
+                    const LLVector3& ray_dir,
+                    F32 ray_len_sq,
+                    F32 tol_sq,
+                    VolumeHit& out_hit)
+    {
+        if (!volp || volp->isDead() || volp->isHUDAttachment())
+        {
+            return false;
+        }
+        if (!volp->isRiggedMesh())
+        {
+            return false;
+        }
+
+        // Ensure mRiggedVolume is allocated and CPU-skinned for all faces.
+        volp->updateRiggedVolume(true, LLRiggedVolume::UPDATE_ALL_FACES, false);
+        LLRiggedVolume* rigged = volp->getRiggedVolume();
+        if (!rigged)
+        {
+            return false;
+        }
+
+        VolumeHit hit;
+        const S32 nfaces = rigged->getNumVolumeFaces();
+        for (S32 f = 0; f < nfaces; ++f)
+        {
+            const LLVolumeFace& face = rigged->getVolumeFace(f);
+            if (!face.mPositions || !face.mIndices || face.mNumVertices <= 0 || face.mNumIndices < 3)
+            {
+                continue;
+            }
+            const LLVector4a* positions = face.mPositions;
+            const U16* indices = face.mIndices;
+            const S32 ntris = face.mNumIndices / 3;
+            for (S32 tri = 0; tri < ntris; ++tri)
+            {
+                const U16 i0 = indices[tri * 3 + 0];
+                const U16 i1 = indices[tri * 3 + 1];
+                const U16 i2 = indices[tri * 3 + 2];
+                if (i0 >= face.mNumVertices || i1 >= face.mNumVertices || i2 >= face.mNumVertices)
+                {
+                    continue;
+                }
+                const F32* p0 = positions[i0].getF32ptr();
+                const F32* p1 = positions[i1].getF32ptr();
+                const F32* p2 = positions[i2].getF32ptr();
+                LLVector3 v0(p0[0], p0[1], p0[2]);
+                LLVector3 v1(p1[0], p1[1], p1[2]);
+                LLVector3 v2(p2[0], p2[1], p2[2]);
+
+                // (1) Pierce test.
+                F32 pierce_t;
+                if (rayTriangleIntersect(ray_a, ray_dir, v0, v1, v2, pierce_t))
+                {
+                    if (pierce_t < hit.pierce_t)
+                    {
+                        hit.pierce_t = pierce_t;
+                        hit.hits_through = true;
+                    }
+                }
+
+                // (2) Edge near-miss test (only meaningful if no pierce was found
+                // yet for this volume, but cheap enough to always run).
+                LLVector3 e[3] = { v1 - v0, v2 - v1, v0 - v2 };
+                LLVector3 a[3] = { v0, v1, v2 };
+                F32 e_sq[3] = { e[0].lengthSquared(), e[1].lengthSquared(), e[2].lengthSquared() };
+                for (int k = 0; k < 3; ++k)
+                {
+                    F32 ray_t;
+                    F32 d2 = distSqSegToSeg(ray_a, ray_dir, ray_len_sq, a[k], e[k], e_sq[k], ray_t);
+                    if (d2 <= tol_sq && ray_t < hit.grazes_t)
+                    {
+                        hit.grazes_t = ray_t;
+                        hit.near_miss = true;
+                    }
+                }
+            }
+        }
+
+        if (hit.hits_through || hit.near_miss)
+        {
+            out_hit = hit;
+            return true;
+        }
+        return false;
+    }
+
+    struct BestPick
+    {
+        LLViewerObject* obj = nullptr;
+        F32 score_t = 1.f + 1e-3f; // smaller is better
+        bool from_pierce = false;  // true means score_t came from a real ray-through hit
+    };
+
+    void considerVolume(LLVOVolume* volp, const VolumeHit& hit, BestPick& best)
+    {
+        if (hit.hits_through)
+        {
+            // Pierce always beats near-miss. Among pierces, smallest t wins.
+            if (!best.from_pierce || hit.pierce_t < best.score_t)
+            {
+                best.obj = volp;
+                best.score_t = hit.pierce_t;
+                best.from_pierce = true;
+            }
+        }
+        else if (hit.near_miss && !best.from_pierce)
+        {
+            // Only a near-miss; only competes against other near-misses.
+            if (hit.grazes_t < best.score_t)
+            {
+                best.obj = volp;
+                best.score_t = hit.grazes_t;
+                best.from_pierce = false;
+            }
+        }
+    }
+
+    void scanObjectAndChildren(LLViewerObject* obj,
+                               const LLVector3& ray_a,
+                               const LLVector3& ray_dir,
+                               F32 ray_len_sq,
+                               F32 tol_sq,
+                               BestPick& best)
+    {
+        if (!obj || obj->isDead())
+        {
+            return;
+        }
+        if (obj->getPCode() == LL_PCODE_VOLUME)
+        {
+            LLVOVolume* volp = dynamic_cast<LLVOVolume*>(obj);
+            VolumeHit hit;
+            if (volp && scanVolume(volp, ray_a, ray_dir, ray_len_sq, tol_sq, hit))
+            {
+                considerVolume(volp, hit, best);
+            }
+        }
+        for (LLViewerObject* child : obj->getChildren())
+        {
+            scanObjectAndChildren(child, ray_a, ray_dir, ray_len_sq, tol_sq, best);
+        }
+    }
+}
+
+LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance)
+{
+    if (!isAgentAvatarValid())
+    {
+        return nullptr;
+    }
+    if (tolerance <= 0.f)
+    {
+        return nullptr;
+    }
+
+    // Build the world ray in the same agent-space coordinates that LLRiggedVolume
+    // stores its CPU-skinned mPositions in (matches LLViewerWindow::cursorIntersect /
+    // LLVOVolume::lineSegmentIntersect rigged path, which skips the volume-local
+    // transform).
+    LLVector3 cam_origin = LLViewerCamera::getInstance()->getOrigin();
+    LLVector3 mouse_dir = gViewerWindow->mouseDirectionGlobal(mouse_x, mouse_y);
+    const F32 depth = 512.f; // matches upstream cursorIntersect default
+    LLVector3 ray_a = cam_origin;
+    LLVector3 ray_dir = mouse_dir * depth; // segment vector
+    F32 ray_len_sq = ray_dir.lengthSquared();
+    if (ray_len_sq <= 0.f)
+    {
+        return nullptr;
+    }
+    F32 tol_sq = tolerance * tolerance;
+
+    // Winner selection (see VolumeHit / considerVolume in this file):
+    //   1. If any attachment is actually pierced by the ray (triangle interior),
+    //      pierces beat all near-misses, and among pierces the smallest t (the
+    //      surface nearest the camera) wins. This makes a shirt in front of the
+    //      body win over the body underneath, and makes the face mesh win over
+    //      hair that drapes nearby but doesn't actually intersect the ray.
+    //   2. If no pierce, fall back to "closest edge wins" by ray foot t (this
+    //      covers the original ~4.7cm offset rescue case).
+    BestPick best;
+
+    for (const auto& it : gAgentAvatarp->mAttachmentPoints)
+    {
+        LLViewerJointAttachment* att = it.second;
+        if (!att || att->getIsHUDAttachment())
+        {
+            continue;
+        }
+        for (LLViewerObject* root : att->mAttachedObjects)
+        {
+            scanObjectAndChildren(root, ray_a, ray_dir, ray_len_sq, tol_sq, best);
+        }
+    }
+
+    return best.obj;
+}

--- a/indra/newview/fsselfriggedpicker.h
+++ b/indra/newview/fsselfriggedpicker.h
@@ -1,26 +1,14 @@
 /**
  * @file fsselfriggedpicker.h
- * @brief Hybrid picker for the agent's own rigged attachments.
+ * @brief GPU picker for the agent's own rigged attachments.
  *
  * AYAstorm r21.1 — replacement for the upstream LLPipeline::lineSegmentIntersectInWorld
- * path when picking self rigged attachments. The upstream path mis-aligns the world
- * ray vs the GPU-skinned mesh in some configurations, so we have a GPU object-ID
- * buffer path (Stage -1) plus pierce-only CPU fallbacks:
- *   - stage -1 (GPU): read the byte quad at the mouse pixel from
- *     LLPipeline::mObjectIDBuffer. Authoritative when id != 0 (exact match
- *     with the visible scene). See findClosestAttachment() docstring for
- *     the hybrid model.
- *   - stage 0 (depth-assist): pierce-only test on the SHORT ray from the
- *     camera to the unprojected depth-buffer sample. Near-miss recovery is
- *     suppressed — only triangles physically pierced by the ray win, so the
- *     aim is needle-precise (no body-region drift). Used when the GPU
- *     stage produced id=0 (sky, alpha-discarded hair, closeup LOD edge case).
- *   - stage 1 (ray pierce-only): full-length camera ray, same pierce-only
- *     rule. Two-sided Möller-Trumbore with a 2% barycentric epsilon. Catches
- *     attachments whose depth wasn't sampled in stage 0 either.
- *   - (no stage 2): the historical edge near-miss recovery is removed in
- *     r21.1 — the GPU ID buffer is the precise path, and widening the legacy
- *     hit zone by tolerance metres made the aim feel sloppy.
+ * path when picking self rigged attachments. The upstream worldray mis-aligns
+ * vs the GPU-skinned mesh in some configurations (closeup zoom, alpha-discard
+ * hair, idle-skin drift), so we re-draw self rigged attachments into a
+ * dedicated GPU object-ID buffer each frame and resolve clicks by reading back
+ * the byte quad at the mouse pixel. The buffer matches what is actually on
+ * screen, so picks are pixel-perfect.
  *
  * $LicenseInfo:firstyear=2026&license=viewerlgpl$
  * AYAstorm Viewer Source Code
@@ -35,30 +23,22 @@ class LLViewerObject;
 namespace FSSelfRiggedPicker
 {
     // Find the self rigged attachment that the user is clicking on at
-    // (mouse_x, mouse_y). Stage order:
-    //   -1. GPU object-ID buffer (gated on FSSelfRiggedPickerGPU): read the
-    //       byte quad at the mouse pixel from LLPipeline::mObjectIDBuffer
-    //       (re-drawn each frame with each self rigged attachment's LocalID
-    //       packed into RGBA8). Hybrid authority (see fsselfriggedpicker.cpp
-    //       Stage -1 comment for the closeup-zoom rationale):
-    //         - id != 0 + match  → return it (legacy skipped).
-    //         - id != 0 + no match (race) → out_gpu_authoritative=true,
-    //           return nullptr. Caller may force-to-body.
-    //         - id == 0          → fall through to legacy stages.
-    //   0. Depth-assist (gated on FSSelfRiggedPickerDepthAssist): pierce-only
-    //      test on the short ray from the camera to the unprojected depth-
-    //      buffer sample. Closest-to-camera pierce wins. Near-miss recovery
-    //      is suppressed in r21.1 (needle-aim).
-    //   1. If stage 0 yields no hit (sky / discarded pixel / depth-assist
-    //      off), fall back to pierce-only on the full-length camera ray.
-    //      Closest-to-camera pierce wins.
-    // Returns nullptr if no stage finds a candidate.
+    // (mouse_x, mouse_y). Reads LLPipeline::mObjectIDBuffer (re-drawn each
+    // frame with each self rigged attachment's LocalID packed into RGBA8)
+    // and resolves the sampled LocalID back to the owning LLViewerObject.
     //
-    // out_gpu_authoritative: set to true only in the GPU-saw-something-but-
-    // table-doesn't-know-what race case. When true + return null, the caller
-    // may force the selection to the self avatar (body). For id==0 the flag
-    // stays false so legacy result is trusted.
-    LLViewerObject* findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance,
+    // Gated on FSSelfRiggedPickerGPU; returns null if the cvar is off or the
+    // buffer isn't allocated (e.g. cube snapshot path).
+    //
+    // out_gpu_authoritative is set to true whenever the GPU stage ran, even
+    // when it returns null:
+    //   - id != 0 + match           → returns the attachment, authoritative=true.
+    //   - id != 0 + no match (race) → returns null, authoritative=true.
+    //                                 Caller may force-to-body for rigged picks.
+    //   - id == 0                    → returns null, authoritative=true.
+    //                                 Caller may force-to-body for rigged picks.
+    //   - cvar off / RT not ready    → returns null, authoritative=false.
+    LLViewerObject* findClosestAttachment(S32 mouse_x, S32 mouse_y,
                                           bool& out_gpu_authoritative);
 }
 

--- a/indra/newview/fsselfriggedpicker.h
+++ b/indra/newview/fsselfriggedpicker.h
@@ -1,15 +1,26 @@
 /**
  * @file fsselfriggedpicker.h
- * @brief Vertex-distance picker for the agent's own rigged attachments.
+ * @brief Hybrid picker for the agent's own rigged attachments.
  *
  * AYAstorm r21.1 — replacement for the upstream LLPipeline::lineSegmentIntersectInWorld
  * path when picking self rigged attachments. The upstream path mis-aligns the world
- * ray vs the GPU-skinned mesh in some configurations, so we fall back to a brute
- * two-stage scan over gAgentAvatarp's rigged attachment volumes:
- *   - stage 1: ray-triangle pierce test (Möller-Trumbore, two-sided);
- *   - stage 2: per-edge segment-to-segment distance within tolerance.
- * Pierce always wins over near-miss. Among pierces (or among near-misses when no
- * pierce is found anywhere), the surface nearest the camera along the ray wins.
+ * ray vs the GPU-skinned mesh in some configurations, so we have a GPU object-ID
+ * buffer path (Stage -1) plus pierce-only CPU fallbacks:
+ *   - stage -1 (GPU): read the byte quad at the mouse pixel from
+ *     LLPipeline::mObjectIDBuffer. Authoritative when id != 0 (exact match
+ *     with the visible scene). See findClosestAttachment() docstring for
+ *     the hybrid model.
+ *   - stage 0 (depth-assist): pierce-only test on the SHORT ray from the
+ *     camera to the unprojected depth-buffer sample. Near-miss recovery is
+ *     suppressed — only triangles physically pierced by the ray win, so the
+ *     aim is needle-precise (no body-region drift). Used when the GPU
+ *     stage produced id=0 (sky, alpha-discarded hair, closeup LOD edge case).
+ *   - stage 1 (ray pierce-only): full-length camera ray, same pierce-only
+ *     rule. Two-sided Möller-Trumbore with a 2% barycentric epsilon. Catches
+ *     attachments whose depth wasn't sampled in stage 0 either.
+ *   - (no stage 2): the historical edge near-miss recovery is removed in
+ *     r21.1 — the GPU ID buffer is the precise path, and widening the legacy
+ *     hit zone by tolerance metres made the aim feel sloppy.
  *
  * $LicenseInfo:firstyear=2026&license=viewerlgpl$
  * AYAstorm Viewer Source Code
@@ -23,15 +34,32 @@ class LLViewerObject;
 
 namespace FSSelfRiggedPicker
 {
-    // Find the self rigged attachment that the screen-space ray from
-    // (mouse_x, mouse_y) hits. Preference order:
-    //   1. Attachments whose triangle the ray actually pierces (Möller-Trumbore,
-    //      two-sided). Among those, the closest-to-camera pierce wins.
-    //   2. Otherwise, attachments with at least one CPU-skinned triangle edge
-    //      within `tolerance` meters of the ray; among those, the closest-to-
-    //      camera edge wins.
-    // Returns nullptr if neither stage finds a candidate.
-    LLViewerObject* findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance);
+    // Find the self rigged attachment that the user is clicking on at
+    // (mouse_x, mouse_y). Stage order:
+    //   -1. GPU object-ID buffer (gated on FSSelfRiggedPickerGPU): read the
+    //       byte quad at the mouse pixel from LLPipeline::mObjectIDBuffer
+    //       (re-drawn each frame with each self rigged attachment's LocalID
+    //       packed into RGBA8). Hybrid authority (see fsselfriggedpicker.cpp
+    //       Stage -1 comment for the closeup-zoom rationale):
+    //         - id != 0 + match  → return it (legacy skipped).
+    //         - id != 0 + no match (race) → out_gpu_authoritative=true,
+    //           return nullptr. Caller may force-to-body.
+    //         - id == 0          → fall through to legacy stages.
+    //   0. Depth-assist (gated on FSSelfRiggedPickerDepthAssist): pierce-only
+    //      test on the short ray from the camera to the unprojected depth-
+    //      buffer sample. Closest-to-camera pierce wins. Near-miss recovery
+    //      is suppressed in r21.1 (needle-aim).
+    //   1. If stage 0 yields no hit (sky / discarded pixel / depth-assist
+    //      off), fall back to pierce-only on the full-length camera ray.
+    //      Closest-to-camera pierce wins.
+    // Returns nullptr if no stage finds a candidate.
+    //
+    // out_gpu_authoritative: set to true only in the GPU-saw-something-but-
+    // table-doesn't-know-what race case. When true + return null, the caller
+    // may force the selection to the self avatar (body). For id==0 the flag
+    // stays false so legacy result is trusted.
+    LLViewerObject* findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance,
+                                          bool& out_gpu_authoritative);
 }
 
 #endif // FS_SELFRIGGEDPICKER_H

--- a/indra/newview/fsselfriggedpicker.h
+++ b/indra/newview/fsselfriggedpicker.h
@@ -1,0 +1,37 @@
+/**
+ * @file fsselfriggedpicker.h
+ * @brief Vertex-distance picker for the agent's own rigged attachments.
+ *
+ * AYAstorm r21.1 — replacement for the upstream LLPipeline::lineSegmentIntersectInWorld
+ * path when picking self rigged attachments. The upstream path mis-aligns the world
+ * ray vs the GPU-skinned mesh in some configurations, so we fall back to a brute
+ * two-stage scan over gAgentAvatarp's rigged attachment volumes:
+ *   - stage 1: ray-triangle pierce test (Möller-Trumbore, two-sided);
+ *   - stage 2: per-edge segment-to-segment distance within tolerance.
+ * Pierce always wins over near-miss. Among pierces (or among near-misses when no
+ * pierce is found anywhere), the surface nearest the camera along the ray wins.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * AYAstorm Viewer Source Code
+ * $/LicenseInfo$
+ */
+
+#ifndef FS_SELFRIGGEDPICKER_H
+#define FS_SELFRIGGEDPICKER_H
+
+class LLViewerObject;
+
+namespace FSSelfRiggedPicker
+{
+    // Find the self rigged attachment that the screen-space ray from
+    // (mouse_x, mouse_y) hits. Preference order:
+    //   1. Attachments whose triangle the ray actually pierces (Möller-Trumbore,
+    //      two-sided). Among those, the closest-to-camera pierce wins.
+    //   2. Otherwise, attachments with at least one CPU-skinned triangle edge
+    //      within `tolerance` meters of the ray; among those, the closest-to-
+    //      camera edge wins.
+    // Returns nullptr if neither stage finds a candidate.
+    LLViewerObject* findClosestAttachment(S32 mouse_x, S32 mouse_y, F32 tolerance);
+}
+
+#endif // FS_SELFRIGGEDPICKER_H

--- a/indra/newview/llspatialpartition.h
+++ b/indra/newview/llspatialpartition.h
@@ -143,6 +143,17 @@ public:
     bool mHasGlow = false;
     bool mIsSSSTarget = false; // <FS:AYA r20 Phase C> propagated from parent LLViewerObject::isSSSTarget()
 
+    // <AYAstorm:r21.1 M4.17> Source LLViewerObject's LocalID, stashed at
+    // DrawInfo construction time so the GPU self-rigged picker can write a
+    // per-prim identity into mObjectIDBuffer without relying on skin-hash
+    // keyed lookup. Multiple linked rigged child prims commonly share one
+    // skin hash (same rig binding, different vertex meshes); the old hash-
+    // keyed approach collapsed them to a single LocalID and made every body
+    // pixel resolve to whichever child was iterated last. Zero means "no
+    // LocalID known" (non-prim DrawInfos, e.g. particles) and the picker
+    // skips such batches.
+    U32 mFSPickerLocalID = 0;
+
     struct CompareTexture
     {
         bool operator()(const LLDrawInfo& lhs, const LLDrawInfo& rhs)

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -2347,80 +2347,60 @@ bool LLToolPie::handleRightClickPick()
     // Can't ignore children here.
     LLToolSelect::handleObjectSelection(mPick, false, true);
 
-    // <FS:AYA r21.1> Self rigged-attachment fallback picker.
-    // The upstream pick path occasionally mis-aligns the world ray against GPU-skinned
-    // rigged meshes attached to the agent (observed ~4.7cm offset on a fitted body),
-    // causing the right-click menu to resolve to the bare self avatar instead of the
-    // attachment. When the pick fell through to the self avatar (or hit nothing),
-    // run a brute vertex-distance pass against gAgentAvatarp's rigged attachments
-    // and, if any vertex of an attachment is within tolerance of the ray, redirect
-    // selection to that attachment so gPieMenuAttachmentSelf opens correctly.
+    // <FS:AYA r21.1> Self rigged-attachment GPU picker.
+    // The upstream worldray pick occasionally mis-aligns against GPU-skinned
+    // rigged meshes attached to the agent (closeup zoom / alpha-discard hair /
+    // idle-skin drift), resolving to the bare self avatar or the wrong prim.
+    // When the pick fell through to the self avatar — or upstream picked a
+    // self rigged attachment, which might still be wrong — read the GPU
+    // LocalID written into mObjectIDBuffer at the mouse pixel and redirect
+    // selection to the correct attachment so the pie menu opens on the right
+    // target.
     if (mPick.mPickType != LLPickInfo::PICK_LAND)
     {
         static LLCachedControl<bool> fs_self_picker_enable(gSavedSettings, "FSSelfRiggedPickerEnable", true);
-        static LLCachedControl<F32>  fs_self_picker_tol(gSavedSettings, "FSSelfRiggedPickerTolerance", 0.05f);
         if (fs_self_picker_enable && isAgentAvatarValid())
         {
             const bool fell_through_to_self_avatar = (mPick.mObjectID == gAgent.getID());
-            // The picker should also second-guess upstream when upstream picked
-            // a self rigged attachment — the worldray test can pierce an alpha-
-            // discarded triangle (e.g. a hidden sleeve) that the user does not
-            // actually see, and the GPU ID buffer reflects the visible scene.
+            // Second-guess upstream when it picked a self rigged attachment —
+            // the worldray test can pierce an alpha-discarded triangle (hidden
+            // sleeve etc.) the user does not actually see, and the GPU ID
+            // buffer reflects the visible scene.
             const bool upstream_picked_self_attachment =
                 object && (object->getAvatar() == gAgentAvatarp.get()) && !object->isAvatar();
-            // r21.1 M4.9: HUD attachments render through a separate camera-
-            // locked screen-space path and are NOT included in the world
-            // mObjectIDBuffer. If upstream picked a HUD attachment correctly
-            // (left-click drag confirms it works), running the GPU stage just
-            // reads id=0 from a buffer that never had HUD pixels, then
-            // authoritative-empty force-to-body kicks in and the right-click
-            // menu collapses to the self-avatar / nametag pie menu. Skip the
-            // picker entirely for HUD picks — upstream is correct.
+            // HUD attachments render through a separate camera-locked
+            // screen-space path and are NOT included in the world
+            // mObjectIDBuffer. Skip the picker entirely — upstream is correct.
             const bool upstream_picked_hud_attachment =
                 object && object->isHUDAttachment();
-            // r21.1 M4.14 diag: always log upstream pick state at right-click
-            // so we can tell whether picker is even being invoked for bare-skin
-            // (arm / head) clicks that currently feel like "0% hit rate".
-            LL_INFOS("FSPicker") << "rclick upstream:"
-                                 << " obj=" << (object ? object->getID().asString() : std::string("null"))
-                                 << " is_self_avatar=" << (object == gAgentAvatarp.get())
-                                 << " is_attachment=" << (object ? object->isAttachment() : false)
-                                 << " is_self_att=" << upstream_picked_self_attachment
-                                 << " is_hud=" << upstream_picked_hud_attachment
-                                 << " fell_through_self=" << fell_through_to_self_avatar
-                                 << " pickType=" << (S32)mPick.mPickType
-                                 << LL_ENDL;
 
             if (!upstream_picked_hud_attachment &&
                 (fell_through_to_self_avatar || upstream_picked_self_attachment || !object))
             {
                 bool gpu_authoritative = false;
                 LLViewerObject* picked = FSSelfRiggedPicker::findClosestAttachment(
-                    x, y, (F32)fs_self_picker_tol, gpu_authoritative);
+                    x, y, gpu_authoritative);
                 if (picked)
                 {
                     object = picked;
                     mPick.mObjectID = picked->getID();
                     LLToolSelect::handleObjectSelection(mPick, false, true);
                 }
-                else if (gpu_authoritative && upstream_picked_self_attachment)
+                else if (gpu_authoritative && upstream_picked_self_attachment
+                         && object->isRiggedMesh())
                 {
-                    // GPU sampled a non-zero LocalID that no longer matches any
-                    // tracked attachment (race: attachment removed mid-frame, or
-                    // stale GPU value). We know upstream's worldray pick is
-                    // wrong because the GPU clearly sees something else on
-                    // screen; default to the self avatar (body) as the safe
-                    // fallback so the user doesn't get a phantom attachment
-                    // pie menu.
+                    // Only force-to-body when upstream picked a RIGGED self
+                    // attachment that the GPU explicitly contradicts. Non-
+                    // rigged self attachments (piercings, separate jewelry
+                    // prims) aren't dispatched through any PASS_*_RIGGED type,
+                    // so the buffer reads id=0 at their pixels regardless of
+                    // visibility — treating that as "GPU disagrees" would
+                    // make jewelry/piercings unselectable. Trust upstream's
+                    // worldray hit for the non-rigged case.
                     object = gAgentAvatarp.get();
                     mPick.mObjectID = gAgent.getID();
                     LLToolSelect::handleObjectSelection(mPick, false, true);
                 }
-            }
-            else
-            {
-                // r21.1 M4.14 diag: record why picker was bypassed entirely.
-                LL_INFOS("FSPicker") << "rclick: picker BYPASSED (upstream picked non-self something else, or HUD)" << LL_ENDL;
             }
         }
     }

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -83,6 +83,8 @@
 
 #include "llviewernetwork.h"    // <FS:CR> For prim equivilance hiding
 
+#include "fsselfriggedpicker.h" // <FS:AYA r21.1> self rigged attachment fallback picker
+
 extern bool gDebugClicks;
 
 static void handle_click_action_play();
@@ -2344,6 +2346,35 @@ bool LLToolPie::handleRightClickPick()
 
     // Can't ignore children here.
     LLToolSelect::handleObjectSelection(mPick, false, true);
+
+    // <FS:AYA r21.1> Self rigged-attachment fallback picker.
+    // The upstream pick path occasionally mis-aligns the world ray against GPU-skinned
+    // rigged meshes attached to the agent (observed ~4.7cm offset on a fitted body),
+    // causing the right-click menu to resolve to the bare self avatar instead of the
+    // attachment. When the pick fell through to the self avatar (or hit nothing),
+    // run a brute vertex-distance pass against gAgentAvatarp's rigged attachments
+    // and, if any vertex of an attachment is within tolerance of the ray, redirect
+    // selection to that attachment so gPieMenuAttachmentSelf opens correctly.
+    if (mPick.mPickType != LLPickInfo::PICK_LAND)
+    {
+        static LLCachedControl<bool> fs_self_picker_enable(gSavedSettings, "FSSelfRiggedPickerEnable", true);
+        static LLCachedControl<F32>  fs_self_picker_tol(gSavedSettings, "FSSelfRiggedPickerTolerance", 0.05f);
+        if (fs_self_picker_enable)
+        {
+            const bool fell_through_to_self_avatar = (mPick.mObjectID == gAgent.getID());
+            if (fell_through_to_self_avatar || !object)
+            {
+                LLViewerObject* picked = FSSelfRiggedPicker::findClosestAttachment(x, y, (F32)fs_self_picker_tol);
+                if (picked)
+                {
+                    object = picked;
+                    mPick.mObjectID = picked->getID();
+                    LLToolSelect::handleObjectSelection(mPick, false, true);
+                }
+            }
+        }
+    }
+    // </FS:AYA>
 
     // Spawn pie menu
     if (mPick.mPickType == LLPickInfo::PICK_LAND)

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -2359,18 +2359,68 @@ bool LLToolPie::handleRightClickPick()
     {
         static LLCachedControl<bool> fs_self_picker_enable(gSavedSettings, "FSSelfRiggedPickerEnable", true);
         static LLCachedControl<F32>  fs_self_picker_tol(gSavedSettings, "FSSelfRiggedPickerTolerance", 0.05f);
-        if (fs_self_picker_enable)
+        if (fs_self_picker_enable && isAgentAvatarValid())
         {
             const bool fell_through_to_self_avatar = (mPick.mObjectID == gAgent.getID());
-            if (fell_through_to_self_avatar || !object)
+            // The picker should also second-guess upstream when upstream picked
+            // a self rigged attachment — the worldray test can pierce an alpha-
+            // discarded triangle (e.g. a hidden sleeve) that the user does not
+            // actually see, and the GPU ID buffer reflects the visible scene.
+            const bool upstream_picked_self_attachment =
+                object && (object->getAvatar() == gAgentAvatarp.get()) && !object->isAvatar();
+            // r21.1 M4.9: HUD attachments render through a separate camera-
+            // locked screen-space path and are NOT included in the world
+            // mObjectIDBuffer. If upstream picked a HUD attachment correctly
+            // (left-click drag confirms it works), running the GPU stage just
+            // reads id=0 from a buffer that never had HUD pixels, then
+            // authoritative-empty force-to-body kicks in and the right-click
+            // menu collapses to the self-avatar / nametag pie menu. Skip the
+            // picker entirely for HUD picks — upstream is correct.
+            const bool upstream_picked_hud_attachment =
+                object && object->isHUDAttachment();
+            // r21.1 M4.14 diag: always log upstream pick state at right-click
+            // so we can tell whether picker is even being invoked for bare-skin
+            // (arm / head) clicks that currently feel like "0% hit rate".
+            LL_INFOS("FSPicker") << "rclick upstream:"
+                                 << " obj=" << (object ? object->getID().asString() : std::string("null"))
+                                 << " is_self_avatar=" << (object == gAgentAvatarp.get())
+                                 << " is_attachment=" << (object ? object->isAttachment() : false)
+                                 << " is_self_att=" << upstream_picked_self_attachment
+                                 << " is_hud=" << upstream_picked_hud_attachment
+                                 << " fell_through_self=" << fell_through_to_self_avatar
+                                 << " pickType=" << (S32)mPick.mPickType
+                                 << LL_ENDL;
+
+            if (!upstream_picked_hud_attachment &&
+                (fell_through_to_self_avatar || upstream_picked_self_attachment || !object))
             {
-                LLViewerObject* picked = FSSelfRiggedPicker::findClosestAttachment(x, y, (F32)fs_self_picker_tol);
+                bool gpu_authoritative = false;
+                LLViewerObject* picked = FSSelfRiggedPicker::findClosestAttachment(
+                    x, y, (F32)fs_self_picker_tol, gpu_authoritative);
                 if (picked)
                 {
                     object = picked;
                     mPick.mObjectID = picked->getID();
                     LLToolSelect::handleObjectSelection(mPick, false, true);
                 }
+                else if (gpu_authoritative && upstream_picked_self_attachment)
+                {
+                    // GPU sampled a non-zero LocalID that no longer matches any
+                    // tracked attachment (race: attachment removed mid-frame, or
+                    // stale GPU value). We know upstream's worldray pick is
+                    // wrong because the GPU clearly sees something else on
+                    // screen; default to the self avatar (body) as the safe
+                    // fallback so the user doesn't get a phantom attachment
+                    // pie menu.
+                    object = gAgentAvatarp.get();
+                    mPick.mObjectID = gAgent.getID();
+                    LLToolSelect::handleObjectSelection(mPick, false, true);
+                }
+            }
+            else
+            {
+                // r21.1 M4.14 diag: record why picker was bypassed entirely.
+                LL_INFOS("FSPicker") << "rclick: picker BYPASSED (upstream picked non-self something else, or HUD)" << LL_ENDL;
             }
         }
     }

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -166,6 +166,8 @@ LLGLSLShader            gHazeWaterProgram;
 LLGLSLShader            gDeferredGodraysProgram;
 // <FS:AYA r20 P0a> skin SSS prototype (screen-space separable blur, no whitelist)
 LLGLSLShader            gDeferredSkinSSSProgram;
+// <FS:AYA r21.1> GPU self-rigged picker: write attachment LocalID into mObjectIDBuffer
+LLGLSLShader            gFSObjectIDShader;
 LLGLSLShader            gDeferredBlurLightProgram;
 LLGLSLShader            gDeferredSoftenProgram;
 LLGLSLShader            gDeferredShadowProgram;
@@ -2253,6 +2255,32 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gDeferredSkinSSSProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
 
         success = gDeferredSkinSSSProgram.createShader();
+        llassert(success);
+    }
+    // </FS:AYA>
+
+    // <FS:AYA r21.1> GPU self-rigged picker (Stage -1):
+    // Re-skins the agent's rigged attachments using the same matrixPalette
+    // path as the visible draw, and writes the attachment's LocalID packed
+    // across the four 8-bit channels of mObjectIDBuffer. Picker reads the
+    // pixel at the mouse and recombines four bytes into a U32 LocalID.
+    // hasObjectSkinning=true attaches avatar/objectSkinV.glsl so the
+    // vertex stage's getObjectSkinnedTransform() resolves at link time.
+    if (success)
+    {
+        gFSObjectIDShader.mName = "FS Object ID Shader";
+        gFSObjectIDShader.mShaderFiles.clear();
+        gFSObjectIDShader.mFeatures.hasObjectSkinning = true;
+
+        gFSObjectIDShader.clearPermutations();
+        gFSObjectIDShader.mShaderFiles.push_back(make_pair("deferred/fsObjectIDV.glsl", GL_VERTEX_SHADER));
+        gFSObjectIDShader.mShaderFiles.push_back(make_pair("deferred/fsObjectIDF.glsl", GL_FRAGMENT_SHADER));
+
+        add_common_permutations(&gFSObjectIDShader);
+
+        gFSObjectIDShader.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+
+        success = gFSObjectIDShader.createShader();
         llassert(success);
     }
     // </FS:AYA>

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -2259,7 +2259,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
     }
     // </FS:AYA>
 
-    // <FS:AYA r21.1> GPU self-rigged picker (Stage -1):
+    // <FS:AYA r21.1> GPU self-rigged picker:
     // Re-skins the agent's rigged attachments using the same matrixPalette
     // path as the visible draw, and writes the attachment's LocalID packed
     // across the four 8-bit channels of mObjectIDBuffer. Picker reads the

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -239,6 +239,8 @@ extern LLGLSLShader         gHazeWaterProgram;
 extern LLGLSLShader         gDeferredGodraysProgram;
 // <FS:AYA r20 P0a> skin SSS prototype (screen-space separable blur, no whitelist)
 extern LLGLSLShader         gDeferredSkinSSSProgram;
+// <FS:AYA r21.1> GPU self-rigged picker: write attachment LocalID into mObjectIDBuffer
+extern LLGLSLShader         gFSObjectIDShader;
 extern LLGLSLShader         gDeferredBlurLightProgram;
 extern LLGLSLShader         gDeferredAvatarProgram;
 extern LLGLSLShader         gDeferredSoftenProgram;

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -5758,7 +5758,13 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
         info->mModelMatrix == model_mat &&
         info->mShaderMask == shader_mask &&
         info->mAvatar == facep->mAvatar &&
-        info->getSkinHash() == facep->getSkinHash())
+        info->getSkinHash() == facep->getSkinHash() &&
+        // <AYAstorm:r21.1 M4.17> Refuse to batch faces from different
+        // LLVOVolumes even when every other criterion matches. Two linked
+        // rigged child prims commonly share skin/avatar/material/VB-pool and
+        // would otherwise merge into one DrawInfo, erasing the per-prim
+        // identity the GPU self-rigged picker needs.
+        info->mFSPickerLocalID == (facep->getViewerObject() ? facep->getViewerObject()->getLocalID() : 0))
     {
         info->mCount += facep->getIndicesCount();
         info->mEnd += facep->getGeomCount();
@@ -5808,9 +5814,13 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
 
         // <FS:AYA r20 Phase C> propagate per-object SSS skin flag into LLDrawInfo
         // so the pool render can emit a per-draw uniform without per-frame lookup.
+        // <AYAstorm:r21.1 M4.17> also stash the source prim's LocalID so the
+        // GPU self-rigged picker can write per-prim identity into the
+        // ObjectIDBuffer without skin-hash collapse.
         if (LLViewerObject* vobj = facep->getViewerObject())
         {
             draw_info->mIsSSSTarget = vobj->isSSSTarget();
+            draw_info->mFSPickerLocalID = vobj->getLocalID();
         }
         // </FS:AYA>
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -9877,21 +9877,9 @@ LLVector4 pow4fsrgb(LLVector4 v, F32 f)
     return v;
 }
 
-// <AYAstorm:r21.1> GPU self-rigged picker (Stage -1) helpers ----------------
+// <AYAstorm:r21.1> GPU self-rigged picker helpers ----------------------------
 namespace
 {
-    // r21.1 M4.17: per-DrawInfo LocalID is stamped at DrawInfo construction
-    // time (llvovolume.cpp registerFace path) into mFSPickerLocalID. Earlier
-    // M4.11-M4.16 attempts maintained a `skin->mHash → LocalID` map built
-    // here by walking attachment children, but that collapsed on the very
-    // common case of linked rigged child prims sharing one rig (same skin
-    // hash, different vertex meshes — typical BoM body parts). Whichever
-    // child happened to be iterated last won the map slot, and every body
-    // pixel resolved to that single LocalID (observed: two clicks at
-    // disjoint arm positions both returning the foot prim's LocalID,
-    // 2026-05-14). Per-DrawInfo identity sidesteps the collision entirely.
-    // No helper is needed here anymore.
-
     // All PASS_*_RIGGED types in the LL render map. The visible deferred opaque
     // pass dispatches rigged geometry through these via renderRiggedGroup /
     // pushRiggedBatches (see lldrawpool.cpp:410, 466). Iterating the same set
@@ -9942,9 +9930,6 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
     if (!isAgentAvatarValid()) return;
     if (!mObjectIDBuffer.isComplete()) return;
 
-    // r21.1 M4.17: per-DrawInfo LocalID lives on info->mFSPickerLocalID; no
-    // pre-build map is needed.
-
     mObjectIDBuffer.bindTarget();
     // gbuffer3 has no alpha in default LL config (project memory
     // reference_gbuffer3_storage); make sure all four channels are writable so
@@ -9953,31 +9938,7 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
     glClearColor(0.f, 0.f, 0.f, 0.f);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    // <AYAstorm:r21.1-diag> M4.12 Diag-D: red canary in GL top-left corner
-    // (100x100). After verticalFlip in the dump path:
-    //   red in PNG top-left   → no flip (X & Y both correct)
-    //   red in PNG top-right  → X-mirror
-    //   red in PNG bottom-left → Y-flip
-    //   red in PNG bottom-right → both
-    // Only when dump cvar is on, so production runs are unaffected.
-    {
-        static LLCachedControl<bool> dump_buffer(gSavedSettings, "FSSelfRiggedPickerDumpBuffer", false);
-        if (dump_buffer)
-        {
-            const S32 h = mObjectIDBuffer.getHeight();
-            glEnable(GL_SCISSOR_TEST);
-            glScissor(0, h - 100, 100, 100);
-            glClearColor(1.f, 0.f, 0.f, 1.f);
-            glClear(GL_COLOR_BUFFER_BIT);
-            glDisable(GL_SCISSOR_TEST);
-            glClearColor(0.f, 0.f, 0.f, 0.f);
-        }
-    }
-    // </AYAstorm:r21.1-diag>
-
-    // Depth shared with deferredScreen — test only, no write. Diag-A (M4.10)
-    // confirmed depth is innocent of the M4.5/M4.6 regression; the real issue
-    // was iterating LLDrawable static faces instead of the rigged render map.
+    // Depth shared with deferredScreen — test only, no write.
     LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
     LLGLDisable   blend(GL_BLEND);
     // Cull pinned to BACK to match deferred opaque (back-facing collar
@@ -10040,47 +10001,6 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
 
     gFSObjectIDShader.unbind();
 
-    // <AYAstorm:r21.1-diag> M4.12 Diag-C: one-shot PNG dump of mObjectIDBuffer
-    // contents — read while still bound, before flush(). Auto-resets cvar.
-    static LLCachedControl<bool> dump_buffer(gSavedSettings, "FSSelfRiggedPickerDumpBuffer", false);
-    if (dump_buffer)
-    {
-        const S32 w = mObjectIDBuffer.getWidth();
-        const S32 h = mObjectIDBuffer.getHeight();
-        LLPointer<LLImageRaw> raw = new LLImageRaw(w, h, 4);
-        glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, raw->getData());
-        // No verticalFlip: LLImagePNG::encode handles the GL bottom-up →
-        // PNG top-down inversion internally. Diag-D canary confirmed an
-        // extra verticalFlip() call inverts the image (observed: red square
-        // appeared in PNG bottom-left when drawn at GL top-left).
-        // The alpha channel packs the high byte of the LocalID, which is
-        // usually small (~12). Image viewers would render the PNG as nearly
-        // fully transparent. Force alpha to 255 for the dump only so the RGB
-        // is visible — picker readback is unaffected.
-        {
-            U8* data = raw->getData();
-            const S64 pixel_count = (S64)w * (S64)h;
-            for (S64 p = 0; p < pixel_count; ++p)
-            {
-                data[p * 4 + 3] = 255;
-            }
-        }
-        LLPointer<LLImagePNG> png = new LLImagePNG;
-        if (png->encode(raw, 0.f))
-        {
-            std::string path = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "AYAstorm_picker_dump.png");
-            png->save(path);
-            LL_INFOS("FSPickerDump") << "Diag-C: dumped picker buffer to " << path
-                                     << " (" << w << "x" << h << ")" << LL_ENDL;
-        }
-        else
-        {
-            LL_WARNS("FSPickerDump") << "Diag-C: PNG encode failed" << LL_ENDL;
-        }
-        gSavedSettings.setBOOL("FSSelfRiggedPickerDumpBuffer", false);
-    }
-    // </AYAstorm:r21.1-diag>
-
     mObjectIDBuffer.flush();
 
 }
@@ -10097,7 +10017,7 @@ void LLPipeline::renderDeferredLighting()
 
     llassert(!sRenderingHUDs);
 
-    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // <AYAstorm:r21.1> GPU self-rigged picker:
     // Write the self attachment LocalIDs into mObjectIDBuffer now — the
     // deferred gbuffer pass has just completed, so depth is final and
     // the rigged attachments are at their on-screen positions. Skip in

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -28,6 +28,8 @@
 
 #include "pipeline.h"
 
+#include <unordered_map>
+
 // library includes
 #include "llimagepng.h"
 #include "llaudioengine.h" // For debugging.
@@ -88,6 +90,7 @@
 #include "llviewerregion.h" // for audio debugging.
 #include "llviewerwindow.h" // For getSpinAxis
 #include "llvoavatarself.h"
+#include "llviewerjointattachment.h"
 #include "llvocache.h"
 #include "llvosky.h"
 #include "llvowlsky.h"
@@ -1009,15 +1012,29 @@ bool LLPipeline::allocateScreenBufferInternal(U32 resX, U32 resY)
 
     if (!gCubeSnapshot) // hack to not re-allocate various targets for cube snapshots
     {
-        LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("non-cube allocations"); // <FS:Beq/> improve Tracy scoping 
+        LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("non-cube allocations"); // <FS:Beq/> improve Tracy scoping
         if (RenderUIBuffer)
         {
-            LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("UIBuffer"); // <FS:Beq/> improve Tracy scoping 
+            LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("UIBuffer"); // <FS:Beq/> improve Tracy scoping
             if (!mUIScreen.allocate(resX, resY, GL_RGBA))
             {
                 return false;
             }
         }
+
+        // <AYAstorm:r21.1> GPU self-rigged picker ID buffer.
+        // Allocated only on the main RT (not aux / hero probe). Borrows the
+        // deferred depth buffer so the ID pass agrees pixel-for-pixel with
+        // the real scene without re-writing depth. Note the call order:
+        // `A.shareDepthBuffer(B)` lends A's depth to B, so the lender (the
+        // one that already owns depth) goes on the left.
+        if (mRT == &mMainRT)
+        {
+            LL_PROFILE_ZONE_NAMED_CATEGORY_DISPLAY("ObjectIDBuffer");
+            if (!mObjectIDBuffer.allocate(resX, resY, GL_RGBA, false)) return false;
+            mRT->deferredScreen.shareDepthBuffer(mObjectIDBuffer);
+        }
+        // </AYAstorm:r21.1>
 
         if (RenderFSAAType > 0)
         {
@@ -1420,6 +1437,10 @@ void LLPipeline::releaseScreenBuffers()
     mHeroProbeRT.deferredLight.release();
 
     mPreviewScreen.release(); // <FS:Beq/> dedicated preview target
+
+    // <AYAstorm:r21.1> GPU self-rigged picker ID buffer
+    mObjectIDBuffer.release();
+    // </AYAstorm:r21.1>
 }
 
 void LLPipeline::releaseSunShadowTarget(U32 index)
@@ -9856,6 +9877,215 @@ LLVector4 pow4fsrgb(LLVector4 v, F32 f)
     return v;
 }
 
+// <AYAstorm:r21.1> GPU self-rigged picker (Stage -1) helpers ----------------
+namespace
+{
+    // r21.1 M4.17: per-DrawInfo LocalID is stamped at DrawInfo construction
+    // time (llvovolume.cpp registerFace path) into mFSPickerLocalID. Earlier
+    // M4.11-M4.16 attempts maintained a `skin->mHash → LocalID` map built
+    // here by walking attachment children, but that collapsed on the very
+    // common case of linked rigged child prims sharing one rig (same skin
+    // hash, different vertex meshes — typical BoM body parts). Whichever
+    // child happened to be iterated last won the map slot, and every body
+    // pixel resolved to that single LocalID (observed: two clicks at
+    // disjoint arm positions both returning the foot prim's LocalID,
+    // 2026-05-14). Per-DrawInfo identity sidesteps the collision entirely.
+    // No helper is needed here anymore.
+
+    // All PASS_*_RIGGED types in the LL render map. The visible deferred opaque
+    // pass dispatches rigged geometry through these via renderRiggedGroup /
+    // pushRiggedBatches (see lldrawpool.cpp:410, 466). Iterating the same set
+    // gives pixel-perfect agreement with what the user actually sees.
+    const U32 kFSRiggedPasses[] = {
+        LLRenderPass::PASS_SIMPLE_RIGGED,
+        LLRenderPass::PASS_FULLBRIGHT_RIGGED,
+        LLRenderPass::PASS_INVISIBLE_RIGGED,
+        LLRenderPass::PASS_INVISI_SHINY_RIGGED,
+        LLRenderPass::PASS_FULLBRIGHT_SHINY_RIGGED,
+        LLRenderPass::PASS_SHINY_RIGGED,
+        LLRenderPass::PASS_BUMP_RIGGED,
+        LLRenderPass::PASS_POST_BUMP_RIGGED,
+        LLRenderPass::PASS_MATERIAL_RIGGED,
+        LLRenderPass::PASS_MATERIAL_ALPHA_RIGGED,
+        LLRenderPass::PASS_MATERIAL_ALPHA_MASK_RIGGED,
+        LLRenderPass::PASS_MATERIAL_ALPHA_EMISSIVE_RIGGED,
+        LLRenderPass::PASS_SPECMAP_RIGGED,
+        LLRenderPass::PASS_SPECMAP_BLEND_RIGGED,
+        LLRenderPass::PASS_SPECMAP_MASK_RIGGED,
+        LLRenderPass::PASS_SPECMAP_EMISSIVE_RIGGED,
+        LLRenderPass::PASS_NORMMAP_RIGGED,
+        LLRenderPass::PASS_NORMMAP_BLEND_RIGGED,
+        LLRenderPass::PASS_NORMMAP_MASK_RIGGED,
+        LLRenderPass::PASS_NORMMAP_EMISSIVE_RIGGED,
+        LLRenderPass::PASS_NORMSPEC_RIGGED,
+        LLRenderPass::PASS_NORMSPEC_BLEND_RIGGED,
+        LLRenderPass::PASS_NORMSPEC_MASK_RIGGED,
+        LLRenderPass::PASS_NORMSPEC_EMISSIVE_RIGGED,
+        LLRenderPass::PASS_GLOW_RIGGED,
+        LLRenderPass::PASS_GLTF_GLOW_RIGGED,
+        LLRenderPass::PASS_ALPHA_RIGGED,
+        LLRenderPass::PASS_ALPHA_MASK_RIGGED,
+        LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK_RIGGED,
+        LLRenderPass::PASS_ALPHA_INVISIBLE_RIGGED,
+        LLRenderPass::PASS_GLTF_PBR_RIGGED,
+        LLRenderPass::PASS_GLTF_PBR_ALPHA_MASK_RIGGED,
+    };
+}
+
+void LLPipeline::renderSelfRiggedObjectIDBuffer()
+{
+    LL_PROFILE_ZONE_SCOPED_CATEGORY_PIPELINE;
+    LL_PROFILE_GPU_ZONE("renderSelfRiggedObjectIDBuffer");
+
+    static LLCachedControl<bool> gpu_enable(gSavedSettings, "FSSelfRiggedPickerGPU", false);
+    if (!gpu_enable) return;
+    if (!isAgentAvatarValid()) return;
+    if (!mObjectIDBuffer.isComplete()) return;
+
+    // r21.1 M4.17: per-DrawInfo LocalID lives on info->mFSPickerLocalID; no
+    // pre-build map is needed.
+
+    mObjectIDBuffer.bindTarget();
+    // gbuffer3 has no alpha in default LL config (project memory
+    // reference_gbuffer3_storage); make sure all four channels are writable so
+    // the top 8 bits of each packed ID survive the write.
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    glClearColor(0.f, 0.f, 0.f, 0.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    // <AYAstorm:r21.1-diag> M4.12 Diag-D: red canary in GL top-left corner
+    // (100x100). After verticalFlip in the dump path:
+    //   red in PNG top-left   → no flip (X & Y both correct)
+    //   red in PNG top-right  → X-mirror
+    //   red in PNG bottom-left → Y-flip
+    //   red in PNG bottom-right → both
+    // Only when dump cvar is on, so production runs are unaffected.
+    {
+        static LLCachedControl<bool> dump_buffer(gSavedSettings, "FSSelfRiggedPickerDumpBuffer", false);
+        if (dump_buffer)
+        {
+            const S32 h = mObjectIDBuffer.getHeight();
+            glEnable(GL_SCISSOR_TEST);
+            glScissor(0, h - 100, 100, 100);
+            glClearColor(1.f, 0.f, 0.f, 1.f);
+            glClear(GL_COLOR_BUFFER_BIT);
+            glDisable(GL_SCISSOR_TEST);
+            glClearColor(0.f, 0.f, 0.f, 0.f);
+        }
+    }
+    // </AYAstorm:r21.1-diag>
+
+    // Depth shared with deferredScreen — test only, no write. Diag-A (M4.10)
+    // confirmed depth is innocent of the M4.5/M4.6 regression; the real issue
+    // was iterating LLDrawable static faces instead of the rigged render map.
+    LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_LEQUAL);
+    LLGLDisable   blend(GL_BLEND);
+    // Cull pinned to BACK to match deferred opaque (back-facing collar
+    // interiors must not write IDs at chin pixels).
+    LLGLEnable    cull (GL_CULL_FACE);
+    glCullFace(GL_BACK);
+
+    gFSObjectIDShader.bind();
+
+    static LLStaticHashedString sObjectIDPacked("object_id_packed");
+
+    // uploadMatrixPalette caches the last (avatar, mesh) pair to skip redundant
+    // GPU uploads for back-to-back DrawInfos with the same skin.
+    const LLVOAvatar* lastAvatar = nullptr;
+    U64  lastMeshId   = 0;
+    bool skipLastSkin = false;
+
+    LLVOAvatar* agent_avatar = gAgentAvatarp.get();
+
+    for (U32 pass_type : kFSRiggedPasses)
+    {
+        LLCullResult::drawinfo_iterator begin = beginRenderMap(pass_type);
+        LLCullResult::drawinfo_iterator end   = endRenderMap(pass_type);
+        for (LLCullResult::drawinfo_iterator i = begin; i != end; )
+        {
+            LLDrawInfo* info = *i;
+            LLCullResult::increment_iterator(i, end);
+            if (!info || !info->mVertexBuffer || info->mCount == 0) continue;
+            if (info->mAvatar.get() != agent_avatar) continue;
+            const LLMeshSkinInfo* skin = info->mSkinInfo.get();
+            if (!skin || skin->mHash == 0) continue;
+            U32 id = info->mFSPickerLocalID;
+            if (id == 0)
+            {
+                // DrawInfo wasn't stamped with a LocalID at construction
+                // time (non-prim source, or stale batch from a removed
+                // attachment). Skip — its pixels stay 0 in the buffer and
+                // resolve as "no self rigged attachment here".
+                continue;
+            }
+
+            F32 r = ((id >>  0) & 0xff) / 255.f;
+            F32 g = ((id >>  8) & 0xff) / 255.f;
+            F32 b = ((id >> 16) & 0xff) / 255.f;
+            F32 a = ((id >> 24) & 0xff) / 255.f;
+            gFSObjectIDShader.uniform4f(sObjectIDPacked, r, g, b, a);
+
+            if (!LLRenderPass::uploadMatrixPalette(agent_avatar, skin,
+                                                  lastAvatar, lastMeshId, skipLastSkin))
+            {
+                continue;
+            }
+
+            info->mVertexBuffer->setBuffer();
+            info->mVertexBuffer->drawRange(LLRender::TRIANGLES,
+                                           info->mStart, info->mEnd,
+                                           info->mCount, info->mOffset);
+        }
+    }
+
+    gFSObjectIDShader.unbind();
+
+    // <AYAstorm:r21.1-diag> M4.12 Diag-C: one-shot PNG dump of mObjectIDBuffer
+    // contents — read while still bound, before flush(). Auto-resets cvar.
+    static LLCachedControl<bool> dump_buffer(gSavedSettings, "FSSelfRiggedPickerDumpBuffer", false);
+    if (dump_buffer)
+    {
+        const S32 w = mObjectIDBuffer.getWidth();
+        const S32 h = mObjectIDBuffer.getHeight();
+        LLPointer<LLImageRaw> raw = new LLImageRaw(w, h, 4);
+        glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, raw->getData());
+        // No verticalFlip: LLImagePNG::encode handles the GL bottom-up →
+        // PNG top-down inversion internally. Diag-D canary confirmed an
+        // extra verticalFlip() call inverts the image (observed: red square
+        // appeared in PNG bottom-left when drawn at GL top-left).
+        // The alpha channel packs the high byte of the LocalID, which is
+        // usually small (~12). Image viewers would render the PNG as nearly
+        // fully transparent. Force alpha to 255 for the dump only so the RGB
+        // is visible — picker readback is unaffected.
+        {
+            U8* data = raw->getData();
+            const S64 pixel_count = (S64)w * (S64)h;
+            for (S64 p = 0; p < pixel_count; ++p)
+            {
+                data[p * 4 + 3] = 255;
+            }
+        }
+        LLPointer<LLImagePNG> png = new LLImagePNG;
+        if (png->encode(raw, 0.f))
+        {
+            std::string path = gDirUtilp->getExpandedFilename(LL_PATH_LOGS, "AYAstorm_picker_dump.png");
+            png->save(path);
+            LL_INFOS("FSPickerDump") << "Diag-C: dumped picker buffer to " << path
+                                     << " (" << w << "x" << h << ")" << LL_ENDL;
+        }
+        else
+        {
+            LL_WARNS("FSPickerDump") << "Diag-C: PNG encode failed" << LL_ENDL;
+        }
+        gSavedSettings.setBOOL("FSSelfRiggedPickerDumpBuffer", false);
+    }
+    // </AYAstorm:r21.1-diag>
+
+    mObjectIDBuffer.flush();
+
+}
+// </AYAstorm:r21.1>
+
 void LLPipeline::renderDeferredLighting()
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_PIPELINE;
@@ -9866,6 +10096,19 @@ void LLPipeline::renderDeferredLighting()
     }
 
     llassert(!sRenderingHUDs);
+
+    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // Write the self attachment LocalIDs into mObjectIDBuffer now — the
+    // deferred gbuffer pass has just completed, so depth is final and
+    // the rigged attachments are at their on-screen positions. Skip in
+    // cube snapshot / reflection probe path (mObjectIDBuffer only exists
+    // for the main RT pack, and the picker only ever reads it for the
+    // main viewport).
+    if (!gCubeSnapshot)
+    {
+        renderSelfRiggedObjectIDBuffer();
+    }
+    // </AYAstorm:r21.1>
 
     F32 light_scale = 1.f;
 

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -332,6 +332,17 @@ public:
 
     void renderDeferredLighting();
 
+    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // After the deferred gbuffer pass is complete (depth finalised), re-draw
+    // every rigged attachment hanging off gAgentAvatarp into mObjectIDBuffer
+    // with the attachment's LocalID packed across four 8-bit channels. The
+    // shared depth buffer + LEQUAL test means only pixels that actually got
+    // drawn for that attachment receive the ID — alpha-discarded triangles
+    // never reach the ID image, so the picker's mouse pixel agrees with
+    // what is visible on screen. Gated by FSSelfRiggedPickerGPU.
+    void renderSelfRiggedObjectIDBuffer();
+    // </AYAstorm:r21.1>
+
     // apply atmospheric haze based on contents of color and depth buffer
     // should be called just before rendering water when camera is under water
     // and just before rendering alpha when camera is above water
@@ -798,6 +809,17 @@ public:
 
     LLRenderTarget          mPbrBrdfLut;
     LLRenderTarget          mWaterExclusionMask;
+
+    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // RGBA8 buffer where rigged attachments of gAgentAvatarp are re-rendered
+    // with their LocalID packed into 4 bytes (R=byte0 .. A=byte3). Shares the
+    // depth buffer with mRT->deferredScreen so it agrees pixel-for-pixel with
+    // the real scene. Right-click picker reads the byte quad at the mouse
+    // pixel and recombines it into a U32 LocalID, which it then looks up via
+    // gObjectList. ID 0 means "no self rigged attachment here" (clear value).
+    // Allocated only for mMainRT (top-level, not in RenderTargetPack).
+    LLRenderTarget          mObjectIDBuffer;
+    // </AYAstorm:r21.1>
 
     // copy of the color/depth buffer just before gamma correction
     // for use by SSR

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -332,7 +332,7 @@ public:
 
     void renderDeferredLighting();
 
-    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // <AYAstorm:r21.1> GPU self-rigged picker:
     // After the deferred gbuffer pass is complete (depth finalised), re-draw
     // every rigged attachment hanging off gAgentAvatarp into mObjectIDBuffer
     // with the attachment's LocalID packed across four 8-bit channels. The
@@ -810,14 +810,15 @@ public:
     LLRenderTarget          mPbrBrdfLut;
     LLRenderTarget          mWaterExclusionMask;
 
-    // <AYAstorm:r21.1> GPU self-rigged picker (Stage -1):
+    // <AYAstorm:r21.1> GPU self-rigged picker:
     // RGBA8 buffer where rigged attachments of gAgentAvatarp are re-rendered
     // with their LocalID packed into 4 bytes (R=byte0 .. A=byte3). Shares the
     // depth buffer with mRT->deferredScreen so it agrees pixel-for-pixel with
     // the real scene. Right-click picker reads the byte quad at the mouse
-    // pixel and recombines it into a U32 LocalID, which it then looks up via
-    // gObjectList. ID 0 means "no self rigged attachment here" (clear value).
-    // Allocated only for mMainRT (top-level, not in RenderTargetPack).
+    // pixel, recombines it into a U32 LocalID, and resolves it by walking
+    // gAgentAvatarp's attachment tree (see fsselfriggedpicker.cpp). ID 0
+    // means "no self rigged attachment here" (clear value). Allocated only
+    // for mMainRT (top-level, not in RenderTargetPack).
     LLRenderTarget          mObjectIDBuffer;
     // </AYAstorm:r21.1>
 


### PR DESCRIPTION
## 概要

自分の rigged attachment 右クリック picker を上流 CPU bind-pose mesh-ray から **GPU 専用 object-ID buffer** (`mObjectIDBuffer`) に差し替え。視覚パスと同じ skinning matrix で `gAgentAvatarp` を再描画し、各 prim の LocalID を 4-byte channel に pack。`glReadPixels` で mouse pixel を読み戻して attachment tree から resolve。

## 主要 commit

- `r21.1 self rigged picker REPLACE` — 上流 ray-mesh fallback を独立 GPU pass に差し替え
- `M4.17 LLDrawInfo per-batch LocalID` — BoM body rig hash collision 解決
- `godraysF link guard` — `HAS_SUN_SHADOW` 未定義時の link 防御
- `r21.1 cleanup` — CPU stage 廃止 (legacy fallback drop)、spec/release-note 起票

## 設定

- `FSSelfRiggedPickerEnable` (default `1`): picker の master switch
- `FSSelfRiggedPickerGPU` (default `0`): GPU buffer pass の kill-switch。**M5 で `1` に flip 予定** (本 PR では `0` のまま)

## 検証

- Linux PASS (closeup zoom / idle skin drift / alpha-cutout hair / BoM body / 非 rigged ピアス) — 構造的に当たる pixel が一致
- macOS / Windows は M5 release 検証 (release-feedback で確認、Mac software OpenGL は kill-switch で逃げる)

## ドキュメント

- spec: `docs/ayastorm-r21-self-rigged-picker.md`
- release note: `docs/ayastorm-r21-release-note.{en,ja,zh}.md`

## 残タスク

- #72 M4.8 closeup zoom GPU id=0 究明 (M4.17 で事実上解消、再現したら deep trace)
- #64 M5 検証 + `FSSelfRiggedPickerGPU` default `1` flip