### PR TITLE
r21 M5: FSSelfRiggedPickerGPU default 1 flip

### DIFF
--- a/docs/ayastorm-r21-release-note.en.md
+++ b/docs/ayastorm-r21-release-note.en.md
@@ -25,7 +25,7 @@ Details → spec `docs/ayastorm-r21-self-rigged-picker.md`
 | Key | Default | Purpose |
 |---|---|---|
 | `FSSelfRiggedPickerEnable` | `1` | Master switch for the picker. `0` reverts to pre-r21 upstream behaviour entirely |
-| `FSSelfRiggedPickerGPU` | `0` (M5 flip → `1`) | Kill-switch for the GPU buffer pass. `0` = picker no-op, upstream worldray is used unchanged. Provided as escape hatch for environments where the GPU pass misbehaves (Mac software OpenGL etc.) |
+| `FSSelfRiggedPickerGPU` | `1` | Kill-switch for the GPU buffer pass. `0` = picker no-op, upstream worldray is used unchanged. Provided as escape hatch for environments where the GPU pass misbehaves (Mac software OpenGL etc.) |
 
 > **CPU fallback is intentionally not provided.** Either the GPU pass is active (`GPU=1`) or the picker is disabled (`GPU=0`, equivalent to pre-r21 behaviour). This is a deliberate design choice — see memory `feedback_root_cause_not_dump.md` (no half-working workarounds) and `feedback_feature_value_in_main_usecase.md` (judge features by the main use case).
 

--- a/docs/ayastorm-r21-release-note.ja.md
+++ b/docs/ayastorm-r21-release-note.ja.md
@@ -25,7 +25,7 @@ r21 では self attachment の picker を **専用 GPU object-ID buffer** (`mObj
 | キー | 既定 | 用途 |
 |---|---|---|
 | `FSSelfRiggedPickerEnable` | `1` | picker の master switch。`0` で r20 以前の上流挙動に完全に戻る |
-| `FSSelfRiggedPickerGPU` | `0` (M5 で `1` に flip 予定) | GPU buffer pass の kill-switch。`0` = picker 無効化 (上流 worldray を素通し)。Mac software OpenGL 等で GPU pass が破綻した場合の逃げ道として用意 |
+| `FSSelfRiggedPickerGPU` | `1` | GPU buffer pass の kill-switch。`0` = picker 無効化 (上流 worldray を素通し)。Mac software OpenGL 等で GPU pass が破綻した場合の逃げ道として用意 |
 
 > **CPU fallback は意図的に提供しません。** GPU pass が動く (`GPU=1`) か、picker そのものが無効化される (`GPU=0`、= r20 以前と同じ) か、のいずれかです。これは memory `feedback_root_cause_not_dump.md` (半分動く workaround を残さない) と `feedback_feature_value_in_main_usecase.md` (主流ユースケースで機能の存在価値を判定する) に基づく設計判断です。
 

--- a/docs/ayastorm-r21-release-note.zh.md
+++ b/docs/ayastorm-r21-release-note.zh.md
@@ -25,7 +25,7 @@ r21 把自身 attachment 的 picker 切出到 **专用 GPU object-ID buffer** (`
 | 键 | 默认 | 用途 |
 |---|---|---|
 | `FSSelfRiggedPickerEnable` | `1` | picker 的主开关。`0` 时完全回到 r20 之前的上游行为 |
-| `FSSelfRiggedPickerGPU` | `0` (M5 翻转为 `1`) | GPU buffer pass 的 kill-switch。`0` = picker 无效 (上游 worldray 不加修改直接使用)。为 Mac software OpenGL 等 GPU pass 不稳定环境提供逃生通道 |
+| `FSSelfRiggedPickerGPU` | `1` | GPU buffer pass 的 kill-switch。`0` = picker 无效 (上游 worldray 不加修改直接使用)。为 Mac software OpenGL 等 GPU pass 不稳定环境提供逃生通道 |
 
 > **不提供 CPU fallback。** 要么 GPU pass 启用 (`GPU=1`)、要么 picker 整体禁用 (`GPU=0`，即 r20 之前的行为)。这是有意的设计选择 — 见 memory `feedback_root_cause_not_dump.md` (不留半工作的 workaround) 与 `feedback_feature_value_in_main_usecase.md` (按主流用例判定功能价值)。
 

--- a/docs/ayastorm-r21-self-rigged-picker.md
+++ b/docs/ayastorm-r21-self-rigged-picker.md
@@ -136,7 +136,7 @@ GPU buffer は `PASS_*_RIGGED` のみ dispatch されるので、**rigged では
 
 GPU picker 全体の **master switch**。OFF にすると lltoolpie の picker 呼び出し自体がスキップされ、上流 worldray の結果が無加工で使われる (= 完全に r20 以前の挙動)。
 
-### 3.2 `FSSelfRiggedPickerGPU` (Boolean, default 0 → M5 で 1 予定)
+### 3.2 `FSSelfRiggedPickerGPU` (Boolean, default 1)
 
 GPU buffer pass (`renderSelfRiggedObjectIDBuffer`) と GPU readback の **kill-switch**。OFF の場合:
 
@@ -151,7 +151,7 @@ GPU buffer pass (`renderSelfRiggedObjectIDBuffer`) と GPU readback の **kill-s
 | キー | 一時値 | 戻すべき default | 備考 |
 |---|---|---|---|
 | `FSSelfRiggedPickerEnable` | 0 (kill) / 1 (normal) | **1** | master、検証時に切るシナリオあり |
-| `FSSelfRiggedPickerGPU` | 1 (検証 ON) | **0** (M5 までは default OFF / M5 で 1) | M5 リリース以降は default 1 |
+| `FSSelfRiggedPickerGPU` | 0 (GPU pass を一時 OFF にする検証 / Mac software OpenGL 等の trouble shoot) | **1** | M5 で flip 済、kill-switch として残存 |
 
 ---
 

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -23262,7 +23262,7 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Type</key>
       <string>Boolean</string>
       <key>Value</key>
-      <integer>0</integer>
+      <integer>1</integer>
     </map>
     <key>FSShowMutedChatHistory</key>
     <map>


### PR DESCRIPTION
## 概要

self rigged picker の GPU pass を default ON 化 (M5 計画の cvar flip)。

## 経緯

- Linux: r21.1 picker PR #59 で merge 済、`FSSelfRiggedPickerGPU=1` で完璧動作確認 (closeup zoom / idle skin drift / alpha-cutout hair / BoM body / 非 rigged ピアス)
- Windows: AYA 検証で `FSSelfRiggedPickerGPU=1` 設定により Linux と同等の動作を確認、default=0 のままだと上流の CPU bind-pose picker が動いて r20 以前の挙動に見えていた
- → default を `1` に flip して「ビルドして起動したらすぐ Linux 品質」にする

## 変更

- `settings.xml`: `FSSelfRiggedPickerGPU` Value `0`→`1`
- release note (ja/en/zh) / spec doc: cvar 表と §3.2 / §3.3 戻し方表を「default 1、kill-switch として残存」に揃える

## kill-switch は維持

cvar 自体は残存。Mac software OpenGL 等で GPU pass が破綻した場合は debug settings から `=0` に落として上流 worldray に戻せる (memory `feedback_release_with_user_feedback.md` 方針)。