### PR TITLE
fsselfriggedpicker: C4018 修正 (signed/unsigned 比較)

### DIFF
--- a/indra/newview/fsselfriggedpicker.cpp
+++ b/indra/newview/fsselfriggedpicker.cpp
@@ -85,8 +85,8 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
     const S32 my_buf = my_win_raw - wv_raw.mBottom;
 
     if (mx_buf < 0 || my_buf < 0 ||
-        mx_buf >= gPipeline.mObjectIDBuffer.getWidth() ||
-        my_buf >= gPipeline.mObjectIDBuffer.getHeight())
+        mx_buf >= (S32)gPipeline.mObjectIDBuffer.getWidth() ||
+        my_buf >= (S32)gPipeline.mObjectIDBuffer.getHeight())
     {
         return nullptr;
     }


### PR DESCRIPTION
mx_buf/my_buf (S32) と mObjectIDBuffer.getWidth()/getHeight() (U32) の比較で C4018 警告 → /WX でエラー昇格していたのを S32 キャストで解消。
直前の < 0 チェックで非負が保証されているのでキャストは安全。

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
