### PR TITLE
r20: AYAR20AvatarSkinSSSGlowGain default を 3.0→1.0 に控えめ化

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10044,13 +10044,13 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>AYAR20AvatarSkinSSSGlowGain</key>
     <map>
       <key>Comment</key>
-      <string>r20 Phase D: SSS blur 後の lit^3 に additive を足す gain。SSS で眠くなった hi-light を peak だけ非対称に持ち上げる。default 3.0 (AYA 確定値、warm-salmon color と組み合わせて血色感を補強)</string>
+      <string>r20 Phase D: SSS blur 後の lit^3 に additive を足す gain。SSS で眠くなった hi-light を peak だけ非対称に持ち上げる。default 1.0 (warm-salmon color と組み合わせて血色感を控えめに補強)</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>F32</string>
       <key>Value</key>
-      <real>3.0</real>
+      <real>1.0</real>
     </map>
     <key>AYAR20AvatarSkinSSSGlowColor</key>
     <map>


### PR DESCRIPTION
SSS blur 後の lit^3 additive gain。3.0 だと warm-salmon color と 組み合わせた時の血色感が強めすぎる、控えめに 1.0 で評価する方向。
Persist=1 なので既存ユーザーの override は維持される、新規/未調整
ユーザーが見る初期画は控えめになる。

Comment 文も「default 1.0、控えめに補強」に追従更新。

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
