### PR TITLE
Fix self-rigged picker selection handoff

### DIFF
--- a/docs/ayastorm-r21-selection-handoff-investigation.md
+++ b/docs/ayastorm-r21-selection-handoff-investigation.md
@@ -1,0 +1,152 @@
+# AYAstorm r21 selection handoff investigation
+
+**作成日**: 2026-05-15
+**対象ブランチ**: `fix/ayastorm-r21-self-rigged-picker-selection`
+**対象機能**: r21 self rigged attachment GPU picker
+
+---
+
+## 概要
+
+r21 self rigged attachment GPU picker の検証中、右クリック後に次の警告が大量に出るケースを確認した。
+
+```text
+Couldn't find object ... selected.
+```
+
+この警告は `LLSelectMgr::processObjectProperties()` で出ている。意味は、sim から `ObjectProperties` 応答が返ってきたが、その UUID の object が現在の selection node に存在しない、というもの。
+
+調査の結果、GPU picker の readback 自体ではなく、右クリック時に temporary selection を渡す順序が原因である可能性が高い。
+
+---
+
+## 障害内容
+
+修正前の `LLToolPie::handleRightClickPick()` では、`LLToolSelect::handleObjectSelection(mPick, false, true)` が AYA GPU picker 補正前に一度実行されていた。
+
+さらに、GPU picker が self rigged attachment を拾った場合、補正後の `mPick` に対しても `handleObjectSelection()` が再度呼ばれる構造だった。
+
+このため、右クリック 1 回につき次の 2 種類の temporary selection が連続して送られる可能性があった。
+
+1. 上流 worldray の stale な selection
+2. AYA GPU picker 補正後の selection
+
+その結果、先に送られた selection に対する `ObjectProperties` 応答が返った時点では、すでに現在の selection が別 object に置き換わっており、`processObjectProperties()` が対象 object を見つけられず警告を出していたと考えられる。
+
+---
+
+## 修正案
+
+`LLToolSelect::handleObjectSelection(mPick, false, true)` の呼び出しを、AYA GPU picker の補正後に 1 回だけ行う。
+
+AYA GPU picker block 内では、次の補正だけを行う。
+
+- `object` の差し替え
+- `mPick.mObjectID` の差し替え
+
+selection は block の後で一度だけ渡す。
+
+```cpp
+// Can't ignore children here. Select only after the optional AYA GPU
+// redirect has finalized mPick, otherwise right-click can send a stale
+// temporary selection before the corrected attachment selection. Keep the
+// call unconditional so land/no-object picks still follow upstream
+// deselection behavior.
+LLToolSelect::handleObjectSelection(mPick, false, true);
+```
+
+この呼び出しは unconditional のまま維持する。land / no-object pick における upstream の deselection 挙動を変えないため。
+
+---
+
+## 調査用 trace
+
+実機確認のため、一時的に `FSSelfRiggedPickerTrace` を追加した。
+
+ON の場合、次を `FSSelfRiggedPicker` channel に出す。
+
+- `renderSelfRiggedObjectIDBuffer()` が実際に走ったか
+- `mObjectIDBuffer` のサイズ
+- self rigged DrawInfo の candidate / draw call / triangle 数
+- 右クリック時の `glReadPixels` 結果 RGBA と復元 LocalID
+- GPU readback を skip した場合の理由
+
+これは release 用機能ではなく調査用。最終化時は default OFF、または設定ごと削除する。
+
+---
+
+## 比較検証
+
+2026-05-15 に、同じ trace を入れた状態で以下の 2 パターンを比較した。
+
+### 修正後 app
+
+- `LLToolSelect::handleObjectSelection()` を AYA GPU picker 補正後の 1 回に集約した状態
+- `FSSelfRiggedPicker` の GPU pass / readback は継続して動作
+- `Couldn't find object ... selected.` はログ検索で再発なし
+
+### 修正前 trace-only app
+
+- `LLToolSelect::handleObjectSelection()` を AYA GPU picker 補正前にも呼ぶ旧構造
+- 比較用 app:
+
+```text
+build-darwin-universal/newview/Release/AYAstorm-trace-only-before-selection-fix.app
+```
+
+- GPU pass / readback は動作
+- `Couldn't find object ... selected.` が大量に再発
+
+観測例:
+
+```text
+2026-05-14T19:22:07Z INFO #FSSelfRiggedPicker# ... readback ... local_id=49768396
+2026-05-14T19:22:07Z WARNING # newview/llselectmgr.cpp(6275) processObjectProperties : Couldn't find object ... selected.
+
+2026-05-14T19:22:10Z INFO #FSSelfRiggedPicker# ... readback ... local_id=49768397
+2026-05-14T19:22:10Z WARNING # newview/llselectmgr.cpp(6275) processObjectProperties : Couldn't find object ... selected.
+```
+
+同ログ内で `Couldn't find object ... selected.` は 887 件確認された。
+
+---
+
+## 他人アバター右クリック時の確認
+
+2026-05-15 に、他人アバターの装着物を右クリックして、self rigged picker が介入していないか確認した。
+
+確認時のログ開始位置:
+
+```text
+AYAstorm.log 3297 行
+2026-05-14T19:33:25Z
+```
+
+3297 行以降では、次の定期 GPU ID pass は確認された。
+
+```text
+2026-05-14T19:33:28Z INFO #FSSelfRiggedPicker# ... GPU ID pass ran buffer=2560x1368 candidates=87 draw_calls=87 triangles=456559
+2026-05-14T19:33:30Z INFO #FSSelfRiggedPicker# ... GPU ID pass ran buffer=2560x1368 candidates=36 draw_calls=36 triangles=301016
+```
+
+ただし、右クリック時に実際の picker readback を示す次のログは出ていない。
+
+```text
+findClosestAttachment : readback
+```
+
+したがって、他人アバターの装着物右クリックでは、`FSSelfRiggedPicker::findClosestAttachment()` の readback 経路には入っていない。
+
+`GPU ID pass ran` は描画パイプライン側で self rigged picker 用の ID buffer を定期更新しているログであり、右クリック判定そのものではない。この pass は自分の `gAgentAvatarp` にぶら下がる rigged attachment だけを描く。`renderSelfRiggedObjectIDBuffer()` 側でも `info->mAvatar.get() != agent_avatar` を skip するため、他人アバターの装着物を ID buffer に描くものではない。
+
+今回の selection handoff 修正で変更したのは `LLToolSelect::handleObjectSelection()` を呼ぶタイミングであり、`renderSelfRiggedObjectIDBuffer()` が定期実行される構造は変更していない。したがって、この定期 GPU ID pass が出る挙動は修正前後で同じ。
+
+---
+
+## 判断
+
+比較結果から、警告は GPU picker の readback そのものではなく、selection を渡すタイミングによって誘発されている可能性が高い。
+
+修正前 trace-only app では、GPU readback が動作しているにもかかわらず警告が大量に出る。修正後 app では、同じ GPU pass / readback が動作していても警告は再発していない。
+
+したがって、`LLToolSelect::handleObjectSelection()` を AYA GPU picker 補正後の 1 回に集約する修正は妥当と判断する。

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -23264,6 +23264,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>1</integer>
     </map>
+    <key>FSSelfRiggedPickerTrace</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAstorm r21.1: runtime trace for the GPU self rigged-attachment picker. When enabled, logs whether renderSelfRiggedObjectIDBuffer actually ran, how many self-rigged DrawInfos were drawn into mObjectIDBuffer, and what LocalID glReadPixels returned on right-click.</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
     <key>FSShowMutedChatHistory</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/fsselfriggedpicker.cpp
+++ b/indra/newview/fsselfriggedpicker.cpp
@@ -63,8 +63,16 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
     }
 
     static LLCachedControl<bool> gpu_enable(gSavedSettings, "FSSelfRiggedPickerGPU", false);
+    static LLCachedControl<bool> trace(gSavedSettings, "FSSelfRiggedPickerTrace", false);
     if (!gpu_enable || !gPipeline.mObjectIDBuffer.isComplete())
     {
+        if (trace)
+        {
+            LL_INFOS("FSSelfRiggedPicker")
+                << "readback skipped gpu_enable=" << (bool)gpu_enable
+                << " buffer_complete=" << gPipeline.mObjectIDBuffer.isComplete()
+                << LL_ENDL;
+        }
         return nullptr;
     }
 
@@ -88,6 +96,16 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
         mx_buf >= (S32)gPipeline.mObjectIDBuffer.getWidth() ||
         my_buf >= (S32)gPipeline.mObjectIDBuffer.getHeight())
     {
+        if (trace)
+        {
+            LL_INFOS("FSSelfRiggedPicker")
+                << "readback skipped out_of_bounds"
+                << " mouse=" << mouse_x << "," << mouse_y
+                << " buffer_xy=" << mx_buf << "," << my_buf
+                << " buffer=" << gPipeline.mObjectIDBuffer.getWidth()
+                << "x" << gPipeline.mObjectIDBuffer.getHeight()
+                << LL_ENDL;
+        }
         return nullptr;
     }
 
@@ -99,6 +117,18 @@ LLViewerObject* FSSelfRiggedPicker::findClosestAttachment(S32 mouse_x, S32 mouse
                  | ((U32)rgba[1] << 8)
                  | ((U32)rgba[2] << 16)
                  | ((U32)rgba[3] << 24);
+
+    if (trace)
+    {
+        LL_INFOS("FSSelfRiggedPicker")
+            << "readback"
+            << " mouse=" << mouse_x << "," << mouse_y
+            << " buffer_xy=" << mx_buf << "," << my_buf
+            << " rgba=(" << (U32)rgba[0] << "," << (U32)rgba[1] << ","
+            << (U32)rgba[2] << "," << (U32)rgba[3] << ")"
+            << " local_id=" << local_id
+            << LL_ENDL;
+    }
 
     // GPU is the source of truth.
     out_gpu_authoritative = true;

--- a/indra/newview/lltoolpie.cpp
+++ b/indra/newview/lltoolpie.cpp
@@ -2344,9 +2344,6 @@ bool LLToolPie::handleRightClickPick()
     // didn't click in any UI object, so must have clicked in the world
     LLViewerObject *object = mPick.getObject();
 
-    // Can't ignore children here.
-    LLToolSelect::handleObjectSelection(mPick, false, true);
-
     // <FS:AYA r21.1> Self rigged-attachment GPU picker.
     // The upstream worldray pick occasionally mis-aligns against GPU-skinned
     // rigged meshes attached to the agent (closeup zoom / alpha-discard hair /
@@ -2384,7 +2381,6 @@ bool LLToolPie::handleRightClickPick()
                 {
                     object = picked;
                     mPick.mObjectID = picked->getID();
-                    LLToolSelect::handleObjectSelection(mPick, false, true);
                 }
                 else if (gpu_authoritative && upstream_picked_self_attachment
                          && object->isRiggedMesh())
@@ -2399,12 +2395,18 @@ bool LLToolPie::handleRightClickPick()
                     // worldray hit for the non-rigged case.
                     object = gAgentAvatarp.get();
                     mPick.mObjectID = gAgent.getID();
-                    LLToolSelect::handleObjectSelection(mPick, false, true);
                 }
             }
         }
     }
     // </FS:AYA>
+
+    // Can't ignore children here. Select only after the optional AYA GPU
+    // redirect has finalized mPick, otherwise right-click can send a stale
+    // temporary selection before the corrected attachment selection. Keep the
+    // call unconditional so land/no-object picks still follow upstream
+    // deselection behavior.
+    LLToolSelect::handleObjectSelection(mPick, false, true);
 
     // Spawn pie menu
     if (mPick.mPickType == LLPickInfo::PICK_LAND)

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -9926,6 +9926,7 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
     LL_PROFILE_GPU_ZONE("renderSelfRiggedObjectIDBuffer");
 
     static LLCachedControl<bool> gpu_enable(gSavedSettings, "FSSelfRiggedPickerGPU", false);
+    static LLCachedControl<bool> trace(gSavedSettings, "FSSelfRiggedPickerTrace", false);
     if (!gpu_enable) return;
     if (!isAgentAvatarValid()) return;
     if (!mObjectIDBuffer.isComplete()) return;
@@ -9957,6 +9958,9 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
     bool skipLastSkin = false;
 
     LLVOAvatar* agent_avatar = gAgentAvatarp.get();
+    U32 candidates = 0;
+    U32 draw_calls = 0;
+    U32 triangles = 0;
 
     for (U32 pass_type : kFSRiggedPasses)
     {
@@ -9968,6 +9972,7 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
             LLCullResult::increment_iterator(i, end);
             if (!info || !info->mVertexBuffer || info->mCount == 0) continue;
             if (info->mAvatar.get() != agent_avatar) continue;
+            ++candidates;
             const LLMeshSkinInfo* skin = info->mSkinInfo.get();
             if (!skin || skin->mHash == 0) continue;
             U32 id = info->mFSPickerLocalID;
@@ -9996,6 +10001,8 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
             info->mVertexBuffer->drawRange(LLRender::TRIANGLES,
                                            info->mStart, info->mEnd,
                                            info->mCount, info->mOffset);
+            ++draw_calls;
+            triangles += info->mCount / 3;
         }
     }
 
@@ -10003,6 +10010,21 @@ void LLPipeline::renderSelfRiggedObjectIDBuffer()
 
     mObjectIDBuffer.flush();
 
+    if (trace)
+    {
+        static U32 frame_count = 0;
+        ++frame_count;
+        if ((frame_count % 120) == 1)
+        {
+            LL_INFOS("FSSelfRiggedPicker")
+                << "GPU ID pass ran"
+                << " buffer=" << mObjectIDBuffer.getWidth() << "x" << mObjectIDBuffer.getHeight()
+                << " candidates=" << candidates
+                << " draw_calls=" << draw_calls
+                << " triangles=" << triangles
+                << LL_ENDL;
+        }
+    }
 }
 // </AYAstorm:r21.1>
 


### PR DESCRIPTION
## 概要

r21 self rigged attachment GPU picker で、右クリック時に temporary selection が二重に渡されることで `Couldn't find object ... selected.` が大量に出る可能性があった問題を修正します。

原因は、AYA GPU picker による pick 補正前に `LLToolSelect::handleObjectSelection()` が一度呼ばれ、その後 GPU picker 補正後の object に対して再度 selection handoff が行われる構造でした。

この PR では、AYA GPU picker の補正が完了した後にだけ `LLToolSelect::handleObjectSelection()` を呼ぶようにし、stale な temporary selection を先に送らないようにします。

## 変更内容

- `LLToolSelect::handleObjectSelection(mPick, false, true)` の呼び出しを、AYA GPU picker 補正後の 1 回に集約
- GPU picker block 内では、`mPick` の object / object id 補正だけを行う
- land / no-object pick の deselection 挙動を維持するため、最終的な selection handoff 呼び出しは unconditional のまま維持
- picker 調査用 trace を追加
  - GPU ID pass の実行有無
  - ID buffer サイズ
  - candidate / draw call / triangle 数
  - readback された RGBA と復元 LocalID
  - readback skip 理由
- 調査報告を `docs/ayastorm-r21-selection-handoff-investigation.md` に追加

## 検証

検証環境:

```text
macOS
Release build
build-darwin-universal
```

macOS での build:

```text
xcodebuild -project build-darwin-universal/Firestorm.xcodeproj -scheme ayastorm-bin -configuration Release -derivedDataPath build-darwin-universal/DerivedData build
```

結果:

```text
BUILD SUCCEEDED
```

macOS 上での実機ログ確認:

- 修正後 app
  - GPU pass / readback は継続して動作
  - `Couldn't find object ... selected.` は再発なし

- 修正前 trace-only app
  - GPU pass / readback は動作
  - `Couldn't find object ... selected.` が大量に再発
  - 同ログ内で 887 件確認

- 他人アバターの装着物右クリック確認
  - `FSSelfRiggedPicker::findClosestAttachment()` の readback 経路には入っていない
  - self rigged picker は自分の `gAgentAvatarp` にぶら下がる rigged attachment のみを対象にしている

## 補足

この PR は selection handoff の障害修正に絞っています。

picker trace は今回の障害調査とレビュー確認のために入れています。機能本体ではないため、merge 後またはリリース前に削除するか、少なくとも default off に変更する cleanup が必要です。

GPU ID pass の負荷低減を目的とした armed mode は別ブランチで試験中です。この PR には含めていません。
