### PR TITLE
Sync README.ja/zh with English Contributors section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -168,6 +168,47 @@ AYAstorm 独自のビルド手順 (Linux / Windows):
 
 ---
 
-## ベース
+## 貢献者
 
-AYAstorm は [Phoenix Firestorm](https://www.firestormviewer.org) のフォークです。Firestorm は [Second Life](https://github.com/secondlife/viewer) の公式クライアントから派生した LGPL ライセンスのオープンソース Viewer です。
+### AYAstorm チーム
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/mayatonton">
+        <img src="https://github.com/mayatonton.png?size=100" width="80" height="80" alt="mayatonton"/>
+        <br/>
+        <sub><b>mayatonton</b></sub>
+      </a>
+      <br/>
+      <sub>作者 / メンテナ</sub>
+    </td>
+    <td align="center">
+      <a href="https://github.com/t-noami">
+        <img src="https://github.com/t-noami.png?size=100" width="80" height="80" alt="t-noami"/>
+        <br/>
+        <sub><b>t-noami</b></sub>
+      </a>
+      <br/>
+      <sub>共同メンテナ</sub>
+    </td>
+    <!--
+    To add another contributor, copy a <td> block above and update:
+      - the GitHub username in the URL and image src
+      - the display name in <sub><b>...</b></sub>
+      - the role text in the trailing <sub>...</sub>
+    -->
+  </tr>
+</table>
+
+AYAstorm の開発に参加しませんか? バグ報告、Pull Request、翻訳すべて歓迎です — [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+### Firestorm をベースに
+
+AYAstorm は [Phoenix Firestorm](https://www.firestormviewer.org) のフォークで、Firestorm は [Second Life](https://github.com/secondlife/viewer) の公式クライアントから派生した LGPL ライセンスのオープンソース Viewer です。
+
+AYAstorm の土台となっている Firestorm チームと上流の全コントリビューターに心からの感謝を:
+
+<a href="https://github.com/FirestormViewer/phoenix-firestorm/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=FirestormViewer/phoenix-firestorm" alt="Firestorm contributors" />
+</a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -168,6 +168,47 @@ AYAstorm 专用编译步骤 (Linux / Windows):
 
 ---
 
-## 基于
+## 贡献者
+
+### AYAstorm 团队
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://github.com/mayatonton">
+        <img src="https://github.com/mayatonton.png?size=100" width="80" height="80" alt="mayatonton"/>
+        <br/>
+        <sub><b>mayatonton</b></sub>
+      </a>
+      <br/>
+      <sub>创建者 / 维护者</sub>
+    </td>
+    <td align="center">
+      <a href="https://github.com/t-noami">
+        <img src="https://github.com/t-noami.png?size=100" width="80" height="80" alt="t-noami"/>
+        <br/>
+        <sub><b>t-noami</b></sub>
+      </a>
+      <br/>
+      <sub>共同维护者</sub>
+    </td>
+    <!--
+    To add another contributor, copy a <td> block above and update:
+      - the GitHub username in the URL and image src
+      - the display name in <sub><b>...</b></sub>
+      - the role text in the trailing <sub>...</sub>
+    -->
+  </tr>
+</table>
+
+想要参与 AYAstorm 的开发吗？欢迎提交 Bug 报告、Pull Request 和翻译 — 详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+### 基于 Firestorm
 
 AYAstorm 是 [Phoenix Firestorm](https://www.firestormviewer.org) 的分支项目，而 Firestorm 本身是基于 [Second Life](https://github.com/secondlife/viewer) 官方客户端的开源项目，采用 LGPL 许可证。
+
+衷心感谢 Firestorm 团队以及所有上游贡献者，他们的工作正是 AYAstorm 得以构建的基础：
+
+<a href="https://github.com/FirestormViewer/phoenix-firestorm/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=FirestormViewer/phoenix-firestorm" alt="Firestorm contributors" />
+</a>


### PR DESCRIPTION
## Summary
- Mirror the English README update (commit 511eb6cb09) into README.ja.md and README.zh.md
- Replace the single-paragraph "Based On / 基于" block with the expanded **Contributors** section: AYAstorm Team table (mayatonton, t-noami) + CONTRIBUTING link + Firestorm upstream thanks block (contrib.rocks image)

Role labels follow each language's convention:
- ja: `作者 / メンテナ`, `共同メンテナ`
- zh: `创建者 / 维护者`, `共同维护者`

## Test plan
- [ ] GitHub render check: README.ja.md Contributors section displays the same layout as README.md
- [ ] GitHub render check: README.zh.md Contributors section displays the same layout as README.md
- [ ] Language switcher links at the top of each file still point to the correct counterparts