### PR TITLE
r23: parcel-bound 3D stream + r13–r23 bundle release docs

### DIFF
--- a/docs/ayastorm-r14-release-note.en.md
+++ b/docs/ayastorm-r14-release-note.en.md
@@ -1,0 +1,59 @@
+# AYAstorm r14 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r14 is the opening release of the visual-realism chapter** (r14–r20) — adding altitude-dependent atmospheric density and scene-referred (linear-space) integration on top of SL's existing Beer-Lambert + in-scatter atmospherics, so that air gains a real sense of volume without breaking WindLight preset compatibility.
+
+> **Distribution**: r14 ships **bundled with the r23 release** (no standalone r14 tag). The r23 release page links back to this note and to the r14 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r14-volumetric-atmosphere.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r14 — Volumetric atmosphere (air with volume)
+
+### Headline: air starts to feel like a medium, not a flat tint
+
+Through r13, SL atmospherics already used Beer-Lambert extinction and an in-scatter haze_glow term — but two physical ingredients were missing, making the sky read as a flat gradient rather than as an actual body of air:
+
+- **No altitude density gradient**: ground and sky use the same density, so an overcast day never feels "thick at ground level, thinning above"
+- **No scene-referred integration**: `additive` was composited in sRGB and converted to linear afterwards, breaking HDR scene-buffer physicality
+
+r14 adds both, **without rewriting the existing pipeline**:
+
+- New `calcAtmosphericVars` branch with an exponential altitude-density profile (controlled by `scale_height`, derived from preset `max_y * 0.1`)
+- Linear-space mixing of `additive` and `blue_horizon` directly inside `atmosphericsFuncs.glsl` and `skyV.glsl` so depth-aware air composition lands physically correctly on the HDR scene buffer
+- WindLight preset values are reinterpreted as inputs; preset compatibility is preserved
+
+The implementation is **analytic and inexpensive** — no raymarching. Heavy volumetric work (godrays, cloud volume, aerial perspective) is deferred to r15–r18.
+
+Details → spec `docs/ayastorm-r14-volumetric-atmosphere.md`
+
+### Master switch (introduces the chapter-wide toggle)
+
+r14 introduces the **chapter master switch** used through r14–r20:
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | Master switch for the entire visual-realism chapter. `0` reverts atmospherics, sky compositing and (later) godrays / aerial perspective / cloud volume / translucency / avatar SSS to the pre-r14 behaviour |
+
+> **Per-feature debug cvars are intentionally not provided.** One sensible default beats a constellation of tuning knobs (per memory `feedback_prefer_defaults_over_config.md`).
+
+### Known tradeoffs
+
+- **Linear-space mixing flattens midtones slightly** — the sky reads as marginally more "overcast" overall. The horizon (sunrise / sunset / haze quality) gains physical accuracy; this is the price. Tunable preset values still let you push back, and later chapter releases (r15+) restore richness through dispersion / godrays / aerial perspective.
+- **Sun disc protection split (P2.a refined)**: the in-shader split keeps `haze_horizon` (the sun-direction glow) in legacy sRGB to avoid linearised haze peaks washing out the sun disc. Only `blue_horizon` (the all-direction blue) is moved to linear.
+- **Preetham off-axis path length (P2.b) and per-wavelength Rayleigh/Mie split (P2.c) were deferred** — both caused sun-disc artifacts in early experiments; reattempted in later chapter releases with sun-disc protection as a hard constraint.
+
+### Implementation summary
+
+- `atmosphericsFuncs.glsl` — altitude density profile + linear `additive` mixing under the master switch
+- `skyV.glsl` — linear `blue_horizon` mixing under the master switch (with inline `aya_srgb_to_linear` / `aya_linear_to_srgb` since `srgbF.glsl` isn't attached to vertex shaders)
+- `LLSettingsVOSky::applyToShader` — uniform plumbing for `aya_visual_realism_enabled` (template followed: `classic_mode`)
+- `LLShaderMgr` enum + `mReservedUniforms` extended
+- `settings.xml` — `AYAVisualRealismEnabled` Boolean default 1
+
+### Documentation
+
+- r14 spec / pipeline rationale / known tradeoffs / risk register: `docs/ayastorm-r14-volumetric-atmosphere.md`
+- P0 atmospheric-pipeline survey: `doc/r14/volumetric_atmosphere_survey.md`
+- Visual-realism chapter roadmap (covers r14–r20): `docs/ayastorm-visual-realism-roadmap.md`
+- Deprecated r14 sun-dazzle plan (pivot history): `docs/ayastorm-r14-sun-dazzle.md`

--- a/docs/ayastorm-r14-release-note.ja.md
+++ b/docs/ayastorm-r14-release-note.ja.md
@@ -1,0 +1,59 @@
+# AYAstorm r14 — リリース告知
+
+GitHub release ページ用の文案。**r14 は視覚的リアリティ章 (r14〜r20) の開幕リリース** で、SL の既存 Beer-Lambert + in-scatter atmospherics の上に高度依存の密度勾配と scene-referred (linear 空間) 積分を追加し、WindLight preset 互換を保ったまま空気が体積として感じられるようにします。
+
+> **配信形態**: r14 は **r23 リリースに同梱配信** されます (r14 単独タグは発行しません)。r23 リリースページから本ノートと r14 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r14-volumetric-atmosphere.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r14 — Volumetric atmosphere (空気の体積感)
+
+### r14 の柱: 空気が「平らな色つき」ではなく「媒質」として感じられる
+
+r13 までの SL atmospherics は Beer-Lambert の減衰と in-scatter (haze_glow) を既に持っていましたが、物理的に欠けていた要素が 2 つあり、空が「平らなグラデーション」にしか見えない状態でした:
+
+- **高度依存の密度勾配が無い**: 地表と上空で同じ density のため、曇天の「地表は霞んで上空は抜ける」物理感が出ない
+- **scene-referred 積分が無い**: `additive` を sRGB で合成して後で linear 化する経路、HDR scene buffer 上で物理整合性が低い
+
+r14 はこの 2 点を **既存パイプラインを書き換えずに追加** します:
+
+- 新しい `calcAtmosphericVars` 分岐で高度の exponential 密度プロファイル (preset `max_y * 0.1` から導出する `scale_height` で制御)
+- `additive` と `blue_horizon` の合成を `atmosphericsFuncs.glsl` / `skyV.glsl` 内で linear 空間に移し、depth-aware な空気合成が HDR scene buffer 上で物理的に正しく着地する
+- WindLight preset の値は入力として再解釈するのみで、preset 互換は維持
+
+実装は **analytic で軽量** (raymarch 無し)。重い volumetric 処理 (godrays / cloud volume / aerial perspective) は r15〜r18 に分割します。
+
+詳細 → spec `docs/ayastorm-r14-volumetric-atmosphere.md`
+
+### Master switch (本章共通スイッチを r14 で導入)
+
+r14 で **章全体の master switch** (r14〜r20 共通) を導入します:
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 視覚的リアリティ章全体の master switch。`0` で atmospherics / 空合成 / (後段) godrays / aerial perspective / cloud volume / translucency / avatar SSS が r14 以前の挙動に戻る |
+
+> **機能別の debug cvar は意図的に提供しません。** 多数の tuning キーより 1 つの妥当なデフォルト (memory `feedback_prefer_defaults_over_config.md`)。
+
+### 既知のトレードオフ
+
+- **Linear 空間合成で midtone がやや平坦化** — 全体として「曇りっぽさ」が増します。地平線 (朝・夕 / haze の質感) は物理整合性で改善、ここはトレードオフ。preset 値で push back する余地は残し、章の後段 (r15+) で dispersion / godrays / aerial perspective によりリッチネスを取り戻します。
+- **太陽 disc 保護のための分割 (P2.a refined)**: shader 内 split で `haze_horizon` (太陽方向の glow) は旧 sRGB のままに残し、linear 化された haze peak が sun disc を白飛びさせるのを回避。`blue_horizon` (全方向の青) のみ linear に移行。
+- **Preetham 太陽方向経路長 (P2.b) と Rayleigh/Mie 波長分離 (P2.c) は deferred** — 早期実験で sun disc 劣化が出たため drop、後段の章リリースで「sun disc 保護」を制約として両立する形で再挑戦予定。
+
+### 実装概要
+
+- `atmosphericsFuncs.glsl` — master switch 下で高度密度プロファイル + linear `additive` 合成
+- `skyV.glsl` — master switch 下で linear `blue_horizon` 合成 (vertex shader には `srgbF.glsl` が attach されないため `aya_srgb_to_linear` / `aya_linear_to_srgb` をインライン定義)
+- `LLSettingsVOSky::applyToShader` — `aya_visual_realism_enabled` の uniform plumbing (template = `classic_mode`)
+- `LLShaderMgr` enum + `mReservedUniforms` を拡張
+- `settings.xml` — `AYAVisualRealismEnabled` Boolean default 1
+
+### ドキュメント
+
+- r14 spec / パイプライン根拠 / 既知トレードオフ / リスク登録: `docs/ayastorm-r14-volumetric-atmosphere.md`
+- P0 atmospheric pipeline 調査: `doc/r14/volumetric_atmosphere_survey.md`
+- 視覚的リアリティ章ロードマップ (r14〜r20 全体): `docs/ayastorm-visual-realism-roadmap.md`
+- 廃案となった r14 sun-dazzle 案 (pivot 経緯): `docs/ayastorm-r14-sun-dazzle.md`

--- a/docs/ayastorm-r14-release-note.zh.md
+++ b/docs/ayastorm-r14-release-note.zh.md
@@ -1,0 +1,59 @@
+# AYAstorm r14 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r14 是视觉真实感章 (r14–r20) 的开篇 release**,在 SL 既有的 Beer-Lambert + in-scatter atmospherics 之上加入高度依存的密度梯度和 scene-referred (linear 空间) 积分,在保持 WindLight preset 兼容的前提下让空气开始具备"体积感"。
+
+> **发布形态**: r14 与 **r23 发布版本一同捆绑发布** (不单独发行 r14 tag)。r23 发布页面会回链至本说明及 r14 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r14-volumetric-atmosphere.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r14 — Volumetric atmosphere (空气的体积感)
+
+### r14 主轴: 空气从「平面色调」变为「介质」
+
+r13 之前的 SL atmospherics 已经具备 Beer-Lambert 衰减和 in-scatter (haze_glow),但物理上缺少两个要素,导致天空看起来仅是「平面渐变」:
+
+- **缺少高度依存的密度梯度**: 地表和上空 density 相同,无法呈现「地表朦胧、上空通透」这种阴天物理质感
+- **缺少 scene-referred 积分**: `additive` 在 sRGB 中合成后再线性化的路径,在 HDR scene buffer 上物理一致性不足
+
+r14 在 **不重写既有 pipeline 的前提下** 补上这两点:
+
+- 新的 `calcAtmosphericVars` 分支引入高度向 exponential 密度 profile (由 preset `max_y * 0.1` 导出的 `scale_height` 控制)
+- 将 `additive` 和 `blue_horizon` 的合成在 `atmosphericsFuncs.glsl` / `skyV.glsl` 内移至 linear 空间,使 depth-aware 的空气合成在 HDR scene buffer 上物理正确落地
+- WindLight preset 的取值仅作为输入重新解释,保持 preset 兼容
+
+实现 **解析式、轻量** (无 raymarch)。重型 volumetric 处理 (godrays / cloud volume / aerial perspective) 拆分至 r15–r18。
+
+详情 → spec `docs/ayastorm-r14-volumetric-atmosphere.md`
+
+### Master switch (本章共通开关在 r14 引入)
+
+r14 引入了 **章节级 master switch** (r14–r20 共享):
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 视觉真实感章节整体的 master switch。设为 `0` 后 atmospherics / 空合成 / (后续) godrays / aerial perspective / cloud volume / translucency / avatar SSS 全部回到 r14 之前的行为 |
+
+> **不另外提供每个功能的 debug cvar。** 比起众多 tuning 键,更优先 1 个妥当默认值 (memory `feedback_prefer_defaults_over_config.md`)。
+
+### 已知 trade-off
+
+- **Linear 空间合成让 midtone 略显平坦** — 整体上「阴天感」增强。地平线 (朝/夕 / haze 质感) 因物理一致性而改善,这里是 trade-off。可用 preset 值 push back,后续章节 (r15+) 通过 dispersion / godrays / aerial perspective 再补回丰富度。
+- **保护太阳 disc 的 split (P2.a refined)**: shader 内分流,`haze_horizon` (太阳方向的 glow) 保留旧 sRGB 路径,避免 linear 化后的 haze peak 把 sun disc 烧白。仅 `blue_horizon` (全方向的蓝) 切到 linear。
+- **Preetham 太阳方向光路 (P2.b) 与 Rayleigh/Mie 波长分离 (P2.c) 暂缓** — 早期实验出现 sun disc 劣化故 drop,后续章节中以「保护 sun disc」为约束条件重新挑战。
+
+### 实现概要
+
+- `atmosphericsFuncs.glsl` — master switch 下加入高度密度 profile + linear `additive` 合成
+- `skyV.glsl` — master switch 下加入 linear `blue_horizon` 合成 (vertex shader 不 attach `srgbF.glsl`,因此就地内联 `aya_srgb_to_linear` / `aya_linear_to_srgb`)
+- `LLSettingsVOSky::applyToShader` — `aya_visual_realism_enabled` uniform plumbing (template = `classic_mode`)
+- `LLShaderMgr` enum + `mReservedUniforms` 扩充
+- `settings.xml` — `AYAVisualRealismEnabled` Boolean default 1
+
+### 文档
+
+- r14 spec / pipeline 依据 / 已知 trade-off / 风险登记: `docs/ayastorm-r14-volumetric-atmosphere.md`
+- P0 atmospheric pipeline 调查: `doc/r14/volumetric_atmosphere_survey.md`
+- 视觉真实感章节路线图 (r14–r20 整体): `docs/ayastorm-visual-realism-roadmap.md`
+- 废案的 r14 sun-dazzle 草案 (pivot 经过): `docs/ayastorm-r14-sun-dazzle.md`

--- a/docs/ayastorm-r16-release-note.en.md
+++ b/docs/ayastorm-r16-release-note.en.md
@@ -1,0 +1,57 @@
+# AYAstorm r16 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r16 is the third release of the visual-realism chapter (r14–r20)** — adds wavelength-dependent (Rayleigh λ⁻⁴) in-scatter weighting to the scene aerial perspective path so distant terrain shifts toward blue while preserving WindLight preset compatibility and **without touching the sky dome** (sun disc is structurally protected).
+
+> **Distribution**: r16 ships **bundled with the r23 release** (no standalone r16 tag). The r23 release page links back to this note and to the r16 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r16-aerial-perspective.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r16 — Aerial perspective (distance shifts color)
+
+### Headline: distant terrain settles into the air physically
+
+r14 made the air feel like a medium; r15 made light beams traverse the volume; r16 makes **distant terrain settle into that air** the way mountains do in a photograph:
+
+- **Distant mountains haze toward blue** (Rayleigh scattering — short wavelengths scatter more, the longer the line-of-sight, the bluer the residual)
+- **Foreground unchanged** (atmosFragLighting scalarizes atten, so wavelength dependence only shows through the additive in-scatter term — by design)
+- **WindLight preset values are reinterpreted as input**, preset compatibility preserved
+
+Done **without rewriting any pipeline**:
+
+- New `rayleigh_w = (1.0, 2.33, 5.71)` weighting in `atmosphericsFuncs.glsl::calcAtmosphericVars` is applied to `combined_haze` and `blue_weight` (in-scatter), but **not** to `light_atten` (which would turn the near scene amber — `aerial perspective ≠ sunset`)
+- **`skyV.glsl` is not touched**; the sun disc / horizon / haze_glow remain at the r14 P2.a refined state — structurally protects the sun disc that r14 P2.b/c had degraded
+
+### What was tried and dropped (intentional)
+
+- **Preetham 1999 spherical sec(θ) approximation (P1.b)**: implemented and verified on Linux. Numerically the difference is real (sec=57.3 → Preetham=26.5 at θ=89°), but the AYAstorm reviewer judged "no perceptible difference" because SL's sun timeline crosses ±5° at the horizon in a single time step. Dropped per `feedback_feature_value_in_main_usecase.md` (working ≠ effective). Revisited later in the chapter when sun-path physics can be retried with sun-disc protection as a constraint.
+- **Distance Multiplier physical reinterpretation**: deferred, P1.a alone already produces the perceptual shift, no reason to take preset-compat risk.
+
+### Master switch + per-feature sentinel
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | Chapter master switch (r14–r20). `0` reverts everything to pre-r14 behaviour |
+| `AYAR16AerialPerspectiveEnabled` | `1` (ON) | r16 sentinel. `0` reverts to r15 behaviour (rayleigh_w = (1,1,1), arithmetically identity) |
+
+The per-feature sentinel exists because the chapter master toggles r14 / r15 effects simultaneously — without a per-r16 toggle, instant A/B evaluation of r16 alone is impossible. We accept this small departure from "prefer one sensible default" as a chapter-evaluation tool, with the intention to fold it into the master once the A-axis (r14–r18) is complete.
+
+### Known tradeoffs
+
+- **`atmosFragLighting` scalarizes atten** (`light *= atten.r`): surface direct-transmission wavelength dependence is effectively a no-op. The visible Rayleigh shift you see in r16 comes entirely through the **additive (in-scatter) path** (`blue_weight` and `(1 - combined_haze)`). This is documented in spec §3 and memory `project_atmos_atten_scalarized.md` to keep future contributors from assuming per-channel atten works on direct transmission.
+- **Foreground appears nearly unchanged** by design — `density_dist` is small at short ranges, so additive is thin and Rayleigh weight has little leverage there. This is the correct physical behaviour (aerial perspective is a long-path phenomenon).
+
+### Implementation summary
+
+- `atmosphericsFuncs.glsl` — `rayleigh_w` ternary, applied to `combined_haze` and `blue_weight`; `light_atten` deliberately untouched
+- `LLSettingsVOSky::applyToShader` — `aya_r16_aerial_perspective_enabled` uniform plumbing
+- `LLShaderMgr` enum + reserved uniform name
+- `settings.xml` — `AYAR16AerialPerspectiveEnabled` Boolean default 1
+
+### Documentation
+
+- r16 spec / pipeline rationale / dropped P1.b notes / risk register: `docs/ayastorm-r16-aerial-perspective.md`
+- P0 atmospheric pipeline survey: `doc/r16/aerial_perspective_survey.md`
+- Visual-realism chapter roadmap (r14–r20 overview): `docs/ayastorm-visual-realism-roadmap.md`
+- atmosFragLighting atten scalarize note: memory `project_atmos_atten_scalarized.md`

--- a/docs/ayastorm-r16-release-note.ja.md
+++ b/docs/ayastorm-r16-release-note.ja.md
@@ -1,0 +1,58 @@
+# AYAstorm r16 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r16 は視覚的リアリティ章 (r14〜r20) の第 3 弾**で、scene の aerial perspective 経路に波長依存 (Rayleigh λ⁻⁴) の in-scatter weighting を入れ、遠景が距離に応じて青味方向にシフトするようにします。WindLight preset 互換を保ったまま、**sky dome は一切触らず** (sun disc は構造的に保護)。
+
+> **配信形態**: r16 は **r23 リリースに同梱配信** されます (r16 単独タグは発行しません)。r23 リリースページから本ノートと r16 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r16-aerial-perspective.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r16 — Aerial perspective (距離による色変化)
+
+### r16 の柱: 遠景が空気の中に物理的に座る
+
+r14 で「空気が体積として見える」、r15 で「光線が空間を貫く」と積んだ上で、r16 では **遠景が空気の中に物理的に座る** ところを取りに行きます。写真で山が距離と共に青くかすむあの絵:
+
+- **遠くの山が青くかすむ** (Rayleigh 散乱 — 短波長が散乱で減衰、長距離経路で青味が強調される)
+- **近景はほぼ変化なし** (atmosFragLighting が atten をスカラー化するため、波長依存は additive (in-scatter) 経由でのみ効く設計)
+- **WindLight preset の値は input として再解釈**、preset 互換を維持
+
+実装は **既存パイプラインを書き換えずに追加**:
+
+- `atmosphericsFuncs.glsl::calcAtmosphericVars` に新たな `rayleigh_w = (1.0, 2.33, 5.71)` を `combined_haze` と `blue_weight` (in-scatter color) に乗算
+- `light_atten` (太陽光路) には **適用しない** — 適用すると近景まで黄ばんで「常時夕焼け」化する副作用が出る (aerial perspective ≠ 夕焼けの物理的分離)
+- **`skyV.glsl` は本リリースで一切触らない**。sun disc / 地平線 / haze_glow は r14 P2.a refined のまま温存 — r14 P2.b/c で出た sun disc 劣化を構造的に回避
+
+### 試して drop した分 (意図的)
+
+- **Preetham 1999 球面 sec(θ) 近似 (P1.b)**: 実装 + Linux 実機検証。数値的には差は出る (θ=89° で sec=57.3 → Preetham=26.5) が、AYA 体感で「穏やかになった感じは特にない」 — SL の sun timeline は地平線 ±5° を時間ステップで一気に跨ぐため perceptual threshold 以下。`feedback_feature_value_in_main_usecase.md` (動いた ≠ 効いた) に従い drop。後段の章で「sun disc 保護」を制約として太陽方向光路を再挑戦予定
+- **Distance Multiplier 物理係数化**: deferred。P1.a で既に遠景青味シフトが出ており、preset 互換破壊リスクを取らない判断
+
+### Master switch + 個別 sentinel
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 章 master switch (r14〜r20)。`0` で r14 以前の挙動に完全復帰 |
+| `AYAR16AerialPerspectiveEnabled` | `1` (ON) | r16 単独 sentinel。`0` で r15 までの挙動 (rayleigh_w = (1,1,1) で旧式と数式等価) |
+
+個別 sentinel が要るのは、master を切ると r14/r15 効果も同時に消えて r16 単独の体感評価が不可能になるため。「個別 cvar を増やさない原則」(memory `feedback_prefer_defaults_over_config.md`) との折り合いとして、章評価期間の sentinel として r14/r15/r16 各 1 本に限定する運用、A 軸完走時 (r18) に master へ吸収を検討。
+
+### 既知のトレードオフ
+
+- **`atmosFragLighting` の atten スカラー化** (`light *= atten.r`): surface 直接透過の波長依存は effectively no-op。r16 で見える遠景青味シフトは **additive (in-scatter) 経由のみ** (`blue_weight` および `(1 - combined_haze)`)。将来の開発者が atten を per-channel と仮定しないよう spec §3 と memory `project_atmos_atten_scalarized.md` に明記
+- **近景はほぼ変化しない** のは設計通り — `density_dist` が小さい近距離では additive 自体が薄く、Rayleigh weight が効くだけのレバレッジが無い (aerial perspective は本質的に長距離現象)
+
+### 実装概要
+
+- `atmosphericsFuncs.glsl` — `rayleigh_w` ternary を追加、`combined_haze` と `blue_weight` に乗算 (`light_atten` は意図的に不変)
+- `LLSettingsVOSky::applyToShader` — `aya_r16_aerial_perspective_enabled` uniform plumbing
+- `LLShaderMgr` enum + reserved uniform 名追加
+- `settings.xml` — `AYAR16AerialPerspectiveEnabled` Boolean default 1
+
+### ドキュメント
+
+- r16 spec / パイプライン根拠 / drop した P1.b の経緯 / リスク登録: `docs/ayastorm-r16-aerial-perspective.md`
+- P0 atmospheric pipeline 調査: `doc/r16/aerial_perspective_survey.md`
+- 視覚的リアリティ章ロードマップ (r14〜r20 全体): `docs/ayastorm-visual-realism-roadmap.md`
+- atmosFragLighting atten scalarize メモ: memory `project_atmos_atten_scalarized.md`

--- a/docs/ayastorm-r16-release-note.zh.md
+++ b/docs/ayastorm-r16-release-note.zh.md
@@ -1,0 +1,58 @@
+# AYAstorm r16 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r16 是视觉真实感章 (r14–r20) 的第三弹**,在 scene aerial perspective 路径上加入波长依存 (Rayleigh λ⁻⁴) 的 in-scatter weighting,使远景随距离向蓝色方向偏移。保持 WindLight preset 兼容,**完全不动 sky dome** (sun disc 在结构上得到保护)。
+
+> **发布形态**: r16 与 **r23 发布版本一同捆绑发布** (不单独发行 r16 tag)。r23 发布页面会回链至本说明及 r16 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r16-aerial-perspective.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r16 — Aerial perspective (距离引发的色变)
+
+### r16 主轴: 远景物理地坐落于空气之中
+
+r14 让空气具备体积感、r15 让光束贯穿空间,r16 则让 **远景物理地坐落于那片空气之中** — 就像照片中远山被距离染蓝的那种感觉:
+
+- **远山染向蓝色** (Rayleigh 散射 — 短波长散射更强,视线越长蓝味越突出)
+- **近景几乎不变** (atmosFragLighting 把 atten 标量化,波长依存只能通过 additive (in-scatter) 路径生效 — 设计如此)
+- **WindLight preset 取值作为 input 重新解释**,preset 兼容性保持
+
+实现 **不重写既有 pipeline**:
+
+- 在 `atmosphericsFuncs.glsl::calcAtmosphericVars` 引入新的 `rayleigh_w = (1.0, 2.33, 5.71)`,乘到 `combined_haze` 和 `blue_weight` (in-scatter color)
+- **不** 应用到 `light_atten` (太阳光路) — 应用后近景也会变黄,演变为「常时夕烧」副作用 (aerial perspective ≠ 夕烧的物理分离)
+- **`skyV.glsl` 在本 release 中完全不动**。sun disc / 地平线 / haze_glow 维持 r14 P2.a refined 的状态 — 结构上回避 r14 P2.b/c 出现的 sun disc 劣化
+
+### 尝试过但 drop 的部分 (有意)
+
+- **Preetham 1999 球面 sec(θ) 近似 (P1.b)**: 实现 + Linux 实机验证。数值上差异确实存在 (θ=89° 处 sec=57.3 → Preetham=26.5),但 AYA 体感「没有变得更柔和的感觉」 — SL 的 sun timeline 在地平线 ±5° 一个时间步就跨过,低于知觉阈值。依据 `feedback_feature_value_in_main_usecase.md` (动了 ≠ 效了) drop。后续章节会以「保护 sun disc」为约束条件重新挑战太阳方向光路
+- **Distance Multiplier 物理系数化**: deferred。P1.a 已经能出远景青味偏移,不冒 preset 兼容破坏的风险
+
+### Master switch + 单独 sentinel
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 章节 master switch (r14–r20)。`0` 完全回到 r14 之前的行为 |
+| `AYAR16AerialPerspectiveEnabled` | `1` (ON) | r16 单独 sentinel。`0` 回到 r15 时的行为 (rayleigh_w = (1,1,1) 与旧式数学等价) |
+
+需要单独 sentinel 是因为 master 一切则 r14/r15 效果同时消失,无法对 r16 单独做 instant A/B 体感评估。与「个别 cvar 不滥增原则」(memory `feedback_prefer_defaults_over_config.md`) 的折中:章节评估期间 sentinel 限定为 r14/r15/r16 各 1 件,A 轴完走时 (r18) 检讨并入 master。
+
+### 已知 trade-off
+
+- **`atmosFragLighting` 的 atten 标量化** (`light *= atten.r`): surface 直接透过的波长依存 effectively no-op。r16 看到的远景青味偏移 **完全来自 additive (in-scatter) 路径** (`blue_weight` 与 `(1 - combined_haze)`)。为避免未来开发者假定 atten 是 per-channel,已在 spec §3 与 memory `project_atmos_atten_scalarized.md` 中明记
+- **近景几乎不变化** 是设计如此 — 在近距离 `density_dist` 很小、additive 本身很薄,Rayleigh weight 没有杠杆点 (aerial perspective 本质是长距离现象)
+
+### 实现概要
+
+- `atmosphericsFuncs.glsl` — 加入 `rayleigh_w` ternary、乘到 `combined_haze` 与 `blue_weight` (`light_atten` 故意不动)
+- `LLSettingsVOSky::applyToShader` — `aya_r16_aerial_perspective_enabled` uniform plumbing
+- `LLShaderMgr` enum + reserved uniform 名添加
+- `settings.xml` — `AYAR16AerialPerspectiveEnabled` Boolean default 1
+
+### 文档
+
+- r16 spec / pipeline 依据 / drop 的 P1.b 经过 / 风险登记: `docs/ayastorm-r16-aerial-perspective.md`
+- P0 atmospheric pipeline 调查: `doc/r16/aerial_perspective_survey.md`
+- 视觉真实感章节路线图 (r14–r20 整体): `docs/ayastorm-visual-realism-roadmap.md`
+- atmosFragLighting atten scalarize 备忘: memory `project_atmos_atten_scalarized.md`

--- a/docs/ayastorm-r17-release-note.en.md
+++ b/docs/ayastorm-r17-release-note.en.md
@@ -1,0 +1,75 @@
+# AYAstorm r17 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r17 is the fourth release of the visual-realism chapter (r14–r20)** — adds a sun-elevation-driven color temperature modulator that warms the sun / ambient / cloud color toward orange as the sun approaches the horizon, restoring the cinematic warmth of sunset that flat preset values alone don't deliver.
+
+> **Distribution**: r17 ships **bundled with the r23 release** (no standalone r17 tag). The r23 release page links back to this note and to the r17 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r17-color-temperature.md`). This note is link-only + diff highlights.
+
+> **Note on r17 history**: r17 was once dropped after an instant A/B test reported "no perceptible difference" — but sustained viewing afterward made it clear that **the cinematic orange sunset was gone**. The drop was reverted on the same day. The original implementation (`c3d6aee734`) was restored in full. This is the lesson recorded in memory `feedback_instant_ab_vs_sustained.md`: instant A/B and sustained viewing are different evaluation axes, and "didn't show in A/B" ≠ "doesn't matter cumulatively".
+
+---
+
+## AYAstorm r17 — Time-of-day color temperature
+
+### Headline: bring back the warmth of sunset
+
+WindLight presets carry color information, but the sun-elevation curve in SL has no physical color-temperature modulation — Sunset preset gives you warm-tinted values, but the **sun itself never grows visibly orange** during a day cycle, and ambient / cloud light don't follow the sun toward warm tones the way they do in a photograph.
+
+r17 adds a single helper, `LLSettingsVOSky::getR17SunModulator(lightnorm, psky)`, that:
+
+- Takes the sun direction's elevation (`lightnorm.z`)
+- Computes `t = smoothstep(0, 0.4, lightnorm.z)`
+- Maps `t` to Kelvin: `K = mix(2200, 6500, t)` (warm horizon → neutral midday)
+- Converts Kelvin → RGB via Tanner Helland 2012
+
+The resulting modulator is applied at **three injection points**:
+
+1. **Sky path** (`llsettingsvo.cpp::applySpecial`): multiplies `SUNLIGHT_COLOR`, `CLOUD_COLOR`, and ambient
+2. **Scene path** (`pipeline.cpp::setupHWLights`): multiplies `mSunDiffuse` and ambient before `gGL.setAmbientLightColor`
+3. **Cloud path B-axis** (shared with r18 — the modulated `CLOUD_COLOR` rides through the cloud shader so volumetric clouds (r18) catch the warm tone too)
+
+### Where r17 is effective vs not (preset-dependent)
+
+The modulator is **physical / elevation-driven**, which means it shines when the sun actually moves — and is intentionally subtle on fixed presets that pin the sun at zenith:
+
+| Preset | sun elevation | K | Modulator | Where it shows |
+|---|---|---|---|---|
+| Day cycle (estate time) | varies 0.0 → 1.0 | 2200 → 6500 | strong amber → identity | **Strongest effect** — cumulative warm-up as sun sets |
+| Sunset (fixed) | 0 | 2200 | strong warm | **Cinematic orange sunset restored** (the revert motivation) |
+| Sunrise (fixed) | 0.996 (zenith) | 6500 | identity | No-op (preset designer pinned the sun high) |
+| Midday (fixed) | 0.37 | ≈6500 | near-identity | No-op |
+| Midday (legacy preset, `KNOWN_SKY_LEGACY_MIDDAY`) | — | — | identity (pinpoint exclusion) | Deliberately untouched to preserve pre-PBR noon |
+
+This "effective on some presets, identity on others" behaviour is an acceptable tradeoff per `feedback_release_with_user_feedback.md`. We call it out here so users don't expect a uniform effect across every preset.
+
+### Settings
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | Chapter master switch (r14–r20). Now **U32** (Firestorm View=0 / AYAstorm View=1), tied to the new `AYAViewMode` combo_box in Preferences → Graphics → Shaders |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | r17 sentinel. `0` returns the modulator to identity (preset colors pass through unmodified) |
+
+### Master cvar promoted to U32
+
+`AYAVisualRealismEnabled` changes from **Boolean → U32** in this release (default still 1). Reason: the new `AYAViewMode` combo_box (`Firestorm View=0` / `AYAstorm View=1`) couples cleanly with U32 cvars but suffers from LLSD-coercion flakiness against Boolean cvars (memory `feedback_combo_box_u32_cvar.md`). The three C++ read sites (`llsettingsvo.cpp::applySpecial` ×2, `pipeline.cpp::doGodrays`) were updated to `LLCachedControl<U32>` with `() != 0` predicate.
+
+### Implementation summary
+
+- `llsettingsvo.{h,cpp}` — `getR17SunModulator()` helper + `kelvinToRGB()`, three injection-point integrations
+- `pipeline.cpp::setupHWLights` — scene-path modulator application
+- `settings.xml` — `AYAR17ColorTemperatureEnabled` Boolean default 1; `AYAVisualRealismEnabled` promoted to U32
+- `panel_preferences_graphics1.xml` (en/ja) — `AYAViewMode` combo_box exposed in Preferences
+
+### Known limitations
+
+- **Subtle in instant A/B**, cumulative in sustained viewing. The lesson from the drop / revert episode: evaluate this kind of effect by sustained viewing, not by quick toggle (memory `feedback_instant_ab_vs_sustained.md`).
+- **`KNOWN_SKY_LEGACY_MIDDAY` is pinpoint-excluded** — that preset is intentionally a flat pre-PBR noon reproduction; we don't modulate it.
+
+### Documentation
+
+- r17 spec / revert record / why the modulator works on Day cycle but not Sunrise preset: `docs/ayastorm-r17-color-temperature.md`
+- r18 cloud volumetric spec (where the B-axis CLOUD_COLOR mod lives): `docs/ayastorm-r18-cloud-volumetric.md`
+- Visual-realism chapter roadmap: `docs/ayastorm-visual-realism-roadmap.md`
+- combo_box ↔ U32 cvar pattern: memory `feedback_combo_box_u32_cvar.md`
+- instant A/B vs sustained viewing lesson: memory `feedback_instant_ab_vs_sustained.md`

--- a/docs/ayastorm-r17-release-note.ja.md
+++ b/docs/ayastorm-r17-release-note.ja.md
@@ -1,0 +1,75 @@
+# AYAstorm r17 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r17 は視覚的リアリティ章 (r14〜r20) の第 4 弾**で、太陽 elevation 駆動の色温度 modulator を導入し、太陽が地平線に近づくに従って sun / ambient / cloud color が orange 方向に温まる cinematic な夕焼け感を取り戻します。preset の値だけでは出ない「夕焼けの世界」を物理駆動で乗せる。
+
+> **配信形態**: r17 は **r23 リリースに同梱配信** されます (r17 単独タグは発行しません)。r23 リリースページから本ノートと r17 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r17-color-temperature.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+> **r17 の経緯メモ**: r17 は一度「instant A/B で効きが分からない」と判定されて drop されたが、drop 後の sustained viewing で **「オレンジの夕焼けの世界が失われた」** ことが明確になり、同日中に revert (実装は `c3d6aee734` の内容を完全復活)。**instant A/B と sustained viewing は別軸で評価する** (memory `feedback_instant_ab_vs_sustained.md`) — 即時切替で「変化が分からない」機能でも sustained 視聴で cumulative に効いていることがある、この教訓を反映した release です。
+
+---
+
+## AYAstorm r17 — 時間帯色温度
+
+### r17 の柱: 夕焼けの暖かさを取り戻す
+
+WindLight preset は色情報を持っていますが、SL の sun elevation カーブに物理的な色温度変調が無いため、Sunset preset で warm な値が来ても **太陽自体が dynamic に orange 方向へ深まらない**、ambient / cloud light が太陽方向の warm tone に追従しない、という写真感の欠落が起きていました。
+
+r17 は単一のヘルパー `LLSettingsVOSky::getR17SunModulator(lightnorm, psky)` を追加:
+
+- 太陽方向 elevation (`lightnorm.z`) を取り
+- `t = smoothstep(0, 0.4, lightnorm.z)` で正規化
+- `K = mix(2200, 6500, t)` で Kelvin (warm horizon → neutral midday)
+- Tanner Helland 2012 公開式で Kelvin → RGB modulator を生成
+
+この modulator を **3 注入点** で適用:
+
+1. **sky path** (`llsettingsvo.cpp::applySpecial`): `SUNLIGHT_COLOR` + `CLOUD_COLOR` + ambient に乗算
+2. **scene path** (`pipeline.cpp::setupHWLights`): `mSunDiffuse` + `gGL.setAmbientLightColor` 前の ambient に乗算
+3. **cloud path B 軸** (r18 と共有): 上記 sky path で modulated `CLOUD_COLOR` が cloud shader に流れる経路、体積化された雲面 (r18) にも warm tone が乗る
+
+### 効く preset / 効かない preset (preset 依存)
+
+modulator は **物理駆動 (elevation driven)** であるため、太陽が実際に動くシーンで真価を発揮し、preset で太陽を zenith に固定したシーンでは意図的に subtle になります:
+
+| Preset | sun elevation | K | Modulator | 効く場面 |
+|---|---|---|---|---|
+| Day cycle (estate time) | 0.0 → 1.0 動的 | 2200 → 6500 | strong amber → identity | **最大効果** — 日没に向けた cumulative warm-up |
+| Sunset (固定) | 0 | 2200 | strong warm | **cinematic な orange 夕焼けが復活** (revert の動機) |
+| Sunrise (固定) | 0.996 (zenith) | 6500 | identity | no-op (preset designer が太陽を真上に固定) |
+| Midday (固定) | 0.37 | ≈6500 | near-identity | no-op |
+| 昼間 (レガシー preset, `KNOWN_SKY_LEGACY_MIDDAY`) | — | — | identity (pinpoint 除外) | PBR 前 noon 再現 preset の意図を保護 |
+
+「効く preset / 効かない preset が混在する」状態は `feedback_release_with_user_feedback.md` 流儀で受け入れる方針です。本ノートで明示しているのはユーザー期待値の調整目的。
+
+### 設定
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 章 master switch (r14〜r20)。本リリースで **U32 化** (Firestorm View=0 / AYAstorm View=1)、Preferences → Graphics → Shaders の `AYAViewMode` combo_box と直結 |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | r17 sentinel。`0` で modulator が identity (preset 色そのまま素通し) |
+
+### Master cvar の U32 昇格
+
+本リリースで `AYAVisualRealismEnabled` を **Boolean → U32** に変更 (default は依然 1)。理由は新規追加した `AYAViewMode` combo_box (`Firestorm View=0` / `AYAstorm View=1`) が U32 cvar とはきれいに binding するのに対し、Boolean cvar との LLSD coercion が不安定なため (memory `feedback_combo_box_u32_cvar.md`)。C++ 側 3 サイト (`llsettingsvo.cpp::applySpecial` ×2、`pipeline.cpp::doGodrays`) を `LLCachedControl<U32>` + `() != 0` 判定に更新。
+
+### 実装概要
+
+- `llsettingsvo.{h,cpp}` — `getR17SunModulator()` + `kelvinToRGB()` ヘルパー、3 注入点組込み
+- `pipeline.cpp::setupHWLights` — scene-path modulator 適用
+- `settings.xml` — `AYAR17ColorTemperatureEnabled` Boolean default 1、`AYAVisualRealismEnabled` を U32 化
+- `panel_preferences_graphics1.xml` (en/ja) — Preferences に `AYAViewMode` combo_box 露出
+
+### 既知の制約
+
+- **instant A/B では subtle、sustained viewing で cumulative に効く**。drop/revert の経緯から得た教訓: この種の効果は即時切替ではなく sustained 視聴で評価する (memory `feedback_instant_ab_vs_sustained.md`)
+- **「昼間 (レガシー)」preset は pinpoint 除外** — PBR 前 noon 再現 preset の意図を歪めない
+
+### ドキュメント
+
+- r17 spec / revert 記録 / Day cycle で効くが Sunrise で効かない理由: `docs/ayastorm-r17-color-temperature.md`
+- r18 雲体積化 spec (B 軸 CLOUD_COLOR mod の同居先): `docs/ayastorm-r18-cloud-volumetric.md`
+- 視覚的リアリティ章ロードマップ: `docs/ayastorm-visual-realism-roadmap.md`
+- combo_box ↔ U32 cvar binding パターン: memory `feedback_combo_box_u32_cvar.md`
+- instant A/B と sustained viewing の評価軸: memory `feedback_instant_ab_vs_sustained.md`

--- a/docs/ayastorm-r17-release-note.zh.md
+++ b/docs/ayastorm-r17-release-note.zh.md
@@ -1,0 +1,75 @@
+# AYAstorm r17 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r17 是视觉真实感章 (r14–r20) 的第四弹**,引入太阳 elevation 驱动的色温 modulator,使太阳接近地平线时 sun / ambient / cloud color 向 orange 方向变暖,找回单凭 preset 取值出不来的「夕烧的暖意」cinematic 感。
+
+> **发布形态**: r17 与 **r23 发布版本一同捆绑发布** (不单独发行 r17 tag)。r23 发布页面会回链至本说明及 r17 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r17-color-temperature.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+> **r17 经过备忘**: r17 曾在「instant A/B 看不出效果」的判定下被 drop,但 drop 后的 sustained viewing 让 **「orange 夕烧的世界丢失了」** 变得清晰可见,同日内 revert (实现恢复至 `c3d6aee734` 的完整内容)。**instant A/B 与 sustained viewing 是不同的评估轴** (memory `feedback_instant_ab_vs_sustained.md`) — 即时切换「感觉不出变化」的功能,sustained 视听中可能是 cumulative 起作用的。本 release 反映这一教训。
+
+---
+
+## AYAstorm r17 — 时间带色温
+
+### r17 主轴: 找回夕烧的暖意
+
+WindLight preset 自身带有颜色信息,但 SL 的 sun elevation 曲线缺少物理性的色温调制,即使 Sunset preset 送来 warm 数值, **太阳本身在 day cycle 中不会动态向 orange 加深**、ambient / cloud light 也不会跟随太阳方向偏向 warm tone,导致照片感的缺失。
+
+r17 加入单一 helper `LLSettingsVOSky::getR17SunModulator(lightnorm, psky)`:
+
+- 取太阳方向 elevation (`lightnorm.z`)
+- `t = smoothstep(0, 0.4, lightnorm.z)` 做归一化
+- `K = mix(2200, 6500, t)` 得到 Kelvin (warm horizon → neutral midday)
+- 通过 Tanner Helland 2012 公开式将 Kelvin → RGB modulator
+
+modulator 在 **3 个注入点** 应用:
+
+1. **sky path** (`llsettingsvo.cpp::applySpecial`): 乘到 `SUNLIGHT_COLOR` + `CLOUD_COLOR` + ambient
+2. **scene path** (`pipeline.cpp::setupHWLights`): 乘到 `mSunDiffuse` + `gGL.setAmbientLightColor` 前的 ambient
+3. **cloud path B 轴** (与 r18 共享): 上述 sky path 中 modulated 的 `CLOUD_COLOR` 流入 cloud shader,体积化的云面 (r18) 也带上 warm tone
+
+### 哪些 preset 有效 / 哪些无效 (preset 依存)
+
+modulator 是 **物理驱动 (elevation driven)** 的,因此在太阳实际移动的场景中真正发挥作用,而在把太阳固定在 zenith 的 preset 中故意保持 subtle:
+
+| Preset | sun elevation | K | Modulator | 有效场面 |
+|---|---|---|---|---|
+| Day cycle (estate time) | 0.0 → 1.0 动态 | 2200 → 6500 | strong amber → identity | **效果最大** — 向日落进行的 cumulative warm-up |
+| Sunset (固定) | 0 | 2200 | strong warm | **cinematic orange 夕烧复活** (revert 的动机) |
+| Sunrise (固定) | 0.996 (zenith) | 6500 | identity | no-op (preset 设计者将太阳钉在正上方) |
+| Midday (固定) | 0.37 | ≈6500 | near-identity | no-op |
+| 昼间 (legacy preset, `KNOWN_SKY_LEGACY_MIDDAY`) | — | — | identity (pinpoint 除外) | 保护 PBR 前 noon 还原 preset 的意图 |
+
+「有效 preset / 无效 preset 混在」的状态按 `feedback_release_with_user_feedback.md` 流派接受,本说明仅为校准用户预期。
+
+### 设置
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON) | 章节 master switch (r14–r20)。本 release **U32 化** (Firestorm View=0 / AYAstorm View=1),与 Preferences → Graphics → Shaders 新增的 `AYAViewMode` combo_box 直接 binding |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | r17 sentinel。`0` 时 modulator 变 identity (preset 颜色原样素通) |
+
+### Master cvar 升级为 U32
+
+本 release 将 `AYAVisualRealismEnabled` 由 **Boolean → U32** (default 仍为 1)。原因:新增的 `AYAViewMode` combo_box (`Firestorm View=0` / `AYAstorm View=1`) 与 U32 cvar 干净 binding,与 Boolean cvar 之间的 LLSD coercion 不稳定 (memory `feedback_combo_box_u32_cvar.md`)。C++ 侧 3 个读取点 (`llsettingsvo.cpp::applySpecial` ×2、`pipeline.cpp::doGodrays`) 已更新为 `LLCachedControl<U32>` + `() != 0` 判定。
+
+### 实现概要
+
+- `llsettingsvo.{h,cpp}` — `getR17SunModulator()` + `kelvinToRGB()` helper、3 注入点集成
+- `pipeline.cpp::setupHWLights` — scene-path modulator 应用
+- `settings.xml` — `AYAR17ColorTemperatureEnabled` Boolean default 1、`AYAVisualRealismEnabled` 升级为 U32
+- `panel_preferences_graphics1.xml` (en/ja) — Preferences 暴露 `AYAViewMode` combo_box
+
+### 已知限制
+
+- **instant A/B 中 subtle,sustained viewing 中 cumulative 生效**。从 drop/revert 中获得的教训:此类效果应通过 sustained 视听评估,而非即时切换 (memory `feedback_instant_ab_vs_sustained.md`)
+- **「昼间 (legacy)」preset 被 pinpoint 除外** — 不调制 PBR 前 noon 还原 preset 的意图
+
+### 文档
+
+- r17 spec / revert 记录 / Day cycle 有效但 Sunrise 无效的原因: `docs/ayastorm-r17-color-temperature.md`
+- r18 云体积化 spec (B 轴 CLOUD_COLOR mod 的同居处): `docs/ayastorm-r18-cloud-volumetric.md`
+- 视觉真实感章节路线图: `docs/ayastorm-visual-realism-roadmap.md`
+- combo_box ↔ U32 cvar binding 模式: memory `feedback_combo_box_u32_cvar.md`
+- instant A/B 与 sustained viewing 评估轴: memory `feedback_instant_ab_vs_sustained.md`

--- a/docs/ayastorm-r18-release-note.en.md
+++ b/docs/ayastorm-r18-release-note.en.md
@@ -1,0 +1,72 @@
+# AYAstorm r18 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r18 is the fifth release of the visual-realism chapter (r14–r20) — and completes the A-axis (atmosphere)**. Clouds are no longer flat textured planes: a lightweight slab raymarch over the existing 2D `cloud_noise_texture` gives them depth, sculpted edges, and (when combined with r17's color temperature) **cinematic orange sunset clouds**.
+
+> **Distribution**: r18 ships **bundled with the r23 release** (no standalone r18 tag). The r23 release page links back to this note and to the r18 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r18-cloud-volumetric.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r18 — Cloud volumetric + color-temperature coupling
+
+### Headline: clouds get depth, sunset clouds get cinematic
+
+r14 → r17 built up the air, the light beams, the long-range haze, and the warm sun. r18 lands the core of "a sky worth photographing":
+
+- **Clouds stop being flat planes** — a 4-step slab raymarch along the view direction over the existing `cloud_noise_texture` (sampler2D) gives thickness, edge sculpting, and an internal depth gradient
+- **Sunset clouds become cinematic** — r17's color temperature modulator (`getR17SunModulator`) is applied to `CLOUD_COLOR` (the B-axis we revived after a sustained-viewing review), so the volumetric clouds **catch warm tone**
+- **No new asset shipped** — the existing 2D noise texture is reused; no 3D noise atlas, no preset rework
+
+Done **without heavy raymarch** (heavy per-frame full-screen ray-march is permanently dropped per chapter roadmap §6): N=4 fixed slab steps per cloud pixel, Beer-Lambert-style transmittance (45% per slab). Computational cost is bounded; live A/B reports "very impressive" without a noticeable FPS drop.
+
+### What's inside
+
+**A-axis (cloud volumetric)** — `cloudsF.glsl` slab raymarch
+- Existing 2D `cloud_noise_texture` is sampled at N=4 positions along a UV-space slab offset (`(0.013, 0.008)` per step, a view-direction proxy)
+- Per-slab transmittance accumulates Beer-Lambert style
+- Gated by `AYAR18CloudVolumetricEnabled` + master + `KNOWN_SKY_LEGACY_MIDDAY` pinpoint exclusion
+- **OFF path is arithmetically identical to the legacy flat sample** (preset compatibility is structurally preserved)
+
+**B-axis (CLOUD_COLOR × r17 modulator)** — re-applies r17's color temperature
+- `llsettingsvo.cpp::applySpecial` multiplies `psky->getCloudColor()` by `getR17SunModulator()` before pushing `CLOUD_COLOR` uniform
+- Originally part of r17 → dropped together with r17 → **revived** after sustained viewing showed "the orange sunset is gone"
+- Gated by `AYAR17ColorTemperatureEnabled` (sentinel in r17) + master + Legacy Midday pinpoint exclusion
+
+### Settings
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | Chapter master switch — toggled via `Firestorm View / AYAstorm View` combo_box in Preferences → Graphics → Shaders |
+| `AYAR18CloudVolumetricEnabled` | `1` (ON) | r18 A-axis sentinel. `0` reverts to flat 2D cloud sample (arithmetically identical to r17) |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | Sentinel from r17, also gates the B-axis CLOUD_COLOR mod here |
+
+### View Mode UI
+
+Preferences → Graphics → Shaders now exposes the chapter master via a combo_box (`AYAViewMode`):
+
+- **Firestorm View** — `AYAVisualRealismEnabled = 0`, full reversion to pre-r14 visuals
+- **AYAstorm View** — `AYAVisualRealismEnabled = 1`, the visual-realism chapter is on (default)
+
+(The combo_box was added with r17 alongside the U32 promotion of the master cvar; r18 release is where it lands publicly.)
+
+### Known limitations
+
+- **A-axis effect is most visible on cloud-rich preset** (Cloudy / Sunset). Clear-sky preset has little cloud area to express depth on — by definition.
+- **Legacy Midday preset (`KNOWN_SKY_LEGACY_MIDDAY`) is pinpoint-excluded** — A-axis falls back to flat sample, B-axis CLOUD_COLOR mod is identity. This preset is a deliberate pre-PBR noon reproduction and we don't modulate it.
+- **Cloud shadow on terrain is out of scope** — it was considered for r18 but parked for r19+ to keep the scope tight.
+- **A-axis effect coexists with WindLight `cloud_pos_density` / `cloud_scale`** — those preset uniforms remain meaningful inputs; raymarch sculpts the volume *of* what the preset already specifies.
+
+### Implementation summary
+
+- `cloudsF.glsl` — N=4 slab raymarch, gated; OFF path retained for arithmetic compatibility
+- `llsettingsvo.cpp::applySpecial` — A-axis uniform push + B-axis `CLOUD_COLOR × r17_sun_mod`
+- `LLShaderMgr` — `AYA_R18_CLOUD_VOLUMETRIC_ENABLED` enum + reserved uniform
+- `settings.xml` — `AYAR18CloudVolumetricEnabled` Boolean default 1
+
+### Documentation
+
+- r18 spec / slab raymarch parameters / B-axis revival history: `docs/ayastorm-r18-cloud-volumetric.md`
+- P0 cloud-shader survey: `doc/r18/cloud_volumetric_survey.md`
+- r17 spec (drop / revert lesson that drove the B-axis revival): `docs/ayastorm-r17-color-temperature.md`
+- Visual-realism chapter roadmap (A-axis completion = r18): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r18-release-note.ja.md
+++ b/docs/ayastorm-r18-release-note.ja.md
@@ -1,0 +1,72 @@
+# AYAstorm r18 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r18 は視覚的リアリティ章 (r14〜r20) の第 5 弾、A 軸 (大気) 完走リリース**。既存 2D `cloud_noise_texture` を視線方向の軽量 slab raymarch で多 sample することで、雲が「平らな板」から厚みと奥行きを持つ立体に変わり、r17 の色温度連動と合わせて **cinematic な orange 夕焼け雲** が出ます。
+
+> **配信形態**: r18 は **r23 リリースに同梱配信** されます (r18 単独タグは発行しません)。r23 リリースページから本ノートと r18 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r18-cloud-volumetric.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r18 — 雲の体積化 + 色温度連動
+
+### r18 の柱: 雲に奥行きを、夕焼け雲に cinematic を
+
+r14 → r17 で空気・光線・遠景 haze・夕焼けの暖色を積み上げてきました。r18 は「**写真撮るに値する空の核**」を取りに行きます:
+
+- **雲が「板」じゃなくなる** — 既存 `cloud_noise_texture` (sampler2D) を視線方向に 4 step slab raymarch、厚みとエッジの立体感、内部 depth gradient を得る
+- **夕焼け雲が cinematic に** — r17 の色温度 modulator (`getR17SunModulator`) を `CLOUD_COLOR` にも適用 (sustained viewing の評価で復活させた B 軸)、体積化された雲面に warm tone が乗る
+- **新 asset 同梱なし** — 既存 2D noise texture を再利用、3D noise atlas 不要、preset 改修不要
+
+実装は **heavy raymarch 不採用** (毎フレーム全画面 ray-march は章 roadmap §6 で永久 drop): cloud 1 pixel あたり N=4 fixed slab step、Beer-Lambert 風 transmittance (45%/slab)。計算コストは有界、AYA 実機評価「とても素晴らしい」かつ FPS 顕著低下なし。
+
+### 中身
+
+**A 軸 (雲体積化)** — `cloudsF.glsl` slab raymarch
+- 既存 2D `cloud_noise_texture` を N=4 sample (UV 空間 slab offset `(0.013, 0.008)`/step、視線方向 proxy)
+- per-slab transmittance を Beer-Lambert 風に累積
+- `AYAR18CloudVolumetricEnabled` + master + `KNOWN_SKY_LEGACY_MIDDAY` pinpoint 除外で gate
+- **OFF パスは legacy flat sample と数式上完全一致** (preset 互換は構造的に維持)
+
+**B 軸 (CLOUD_COLOR × r17 modulator)** — r17 色温度の再適用
+- `llsettingsvo.cpp::applySpecial` で `psky->getCloudColor() * getR17SunModulator()` を `CLOUD_COLOR` uniform に push
+- 当初 r17 の一部 → r17 drop と同伴 drop → sustained viewing で「orange 夕焼けが失われた」と判定され **revival**
+- `AYAR17ColorTemperatureEnabled` (r17 sentinel) + master + Legacy Midday pinpoint 除外で gate
+
+### 設定
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | 章 master switch — Preferences → Graphics → Shaders の `Firestorm View / AYAstorm View` combo_box で切替 |
+| `AYAR18CloudVolumetricEnabled` | `1` (ON) | r18 A 軸 sentinel。`0` で flat 2D sample に戻る (r17 までと数式一致) |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | r17 由来 sentinel、本リリースで B 軸 CLOUD_COLOR mod も gate |
+
+### View Mode UI
+
+Preferences → Graphics → Shaders に章 master を combo_box (`AYAViewMode`) で露出:
+
+- **Firestorm View** — `AYAVisualRealismEnabled = 0`、r14 以前の見え方に完全復帰
+- **AYAstorm View** — `AYAVisualRealismEnabled = 1`、視覚的リアリティ章 ON (デフォルト)
+
+(combo_box は r17 で master cvar の U32 昇格と同時に追加、r18 リリースで公開デビュー。)
+
+### 既知の制約
+
+- **A 軸効果は雲が多い preset (Cloudy / Sunset) で顕著**。Clear-sky preset は雲面積が小さく奥行きを表現する余地が少ない (定義上)
+- **昼間 (レガシー) preset (`KNOWN_SKY_LEGACY_MIDDAY`) は pinpoint 除外** — A 軸は flat sample に fallback、B 軸 CLOUD_COLOR mod は identity。PBR 前 noon 再現 preset の意図を歪めない
+- **地表の雲影は scope 外** — r18 で同梱検討したが scope 膨張回避のため r19+ に分離
+- **A 軸効果は WindLight `cloud_pos_density` / `cloud_scale` と共存** — これらの preset uniform は引き続き意味を持ち、raymarch は preset が定義した雲量の「立体側面」を彫る形
+
+### 実装概要
+
+- `cloudsF.glsl` — N=4 slab raymarch、gated、OFF パスは数式互換のため温存
+- `llsettingsvo.cpp::applySpecial` — A 軸 uniform push + B 軸 `CLOUD_COLOR × r17_sun_mod`
+- `LLShaderMgr` — `AYA_R18_CLOUD_VOLUMETRIC_ENABLED` enum + reserved uniform 追加
+- `settings.xml` — `AYAR18CloudVolumetricEnabled` Boolean default 1
+
+### ドキュメント
+
+- r18 spec / slab raymarch パラメータ / B 軸 revival 経緯: `docs/ayastorm-r18-cloud-volumetric.md`
+- P0 cloud shader 調査: `doc/r18/cloud_volumetric_survey.md`
+- r17 spec (drop / revert の教訓、B 軸 revival の根拠): `docs/ayastorm-r17-color-temperature.md`
+- 視覚的リアリティ章ロードマップ (A 軸完走 = r18): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r18-release-note.zh.md
+++ b/docs/ayastorm-r18-release-note.zh.md
@@ -1,0 +1,72 @@
+# AYAstorm r18 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r18 是视觉真实感章 (r14–r20) 的第五弹,也是 A 轴 (大气) 完走 release**。通过对既有 2D `cloud_noise_texture` 在视线方向做轻量 slab raymarch 多重采样,云从「平面板」变成具有厚度与深度的立体,与 r17 的色温联动结合后形成 **cinematic 的 orange 夕烧云**。
+
+> **发布形态**: r18 与 **r23 发布版本一同捆绑发布** (不单独发行 r18 tag)。r23 发布页面会回链至本说明及 r18 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r18-cloud-volumetric.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r18 — 云体积化 + 色温联动
+
+### r18 主轴: 让云有深度,让夕烧云 cinematic
+
+r14 → r17 把空气、光束、远景 haze、夕烧暖色一层层叠上去。r18 收下「**值得拍照的天空核心**」:
+
+- **云不再是「板」** — 在既有 `cloud_noise_texture` (sampler2D) 上沿视线方向做 4 step slab raymarch,获得厚度、雕刻感的边缘、内部深度梯度
+- **夕烧云变 cinematic** — 把 r17 色温 modulator (`getR17SunModulator`) 也应用到 `CLOUD_COLOR` (sustained viewing 评估后复活的 B 轴),让体积化的云面带上 warm tone
+- **不附带新 asset** — 直接复用既有 2D noise texture,不需要 3D noise atlas,不需要 preset 改造
+
+实现 **不倒向 heavy raymarch** (按章 roadmap §6,每帧全屏 ray-march 永久 drop): 每个 cloud pixel N=4 fixed slab step、Beer-Lambert 风 transmittance (45%/slab)。计算成本有界,AYA 实机评价「非常出色」且 FPS 没有显著下降。
+
+### 内容
+
+**A 轴 (云体积化)** — `cloudsF.glsl` slab raymarch
+- 在 UV 空间 slab offset `(0.013, 0.008)`/step (视线方向 proxy) 上对既有 2D `cloud_noise_texture` 做 N=4 sample
+- 逐 slab 累积 Beer-Lambert 风 transmittance
+- 由 `AYAR18CloudVolumetricEnabled` + master + `KNOWN_SKY_LEGACY_MIDDAY` pinpoint 除外组合 gate
+- **OFF 路径与 legacy flat sample 数式上完全一致** (preset 兼容性结构上得到保证)
+
+**B 轴 (CLOUD_COLOR × r17 modulator)** — r17 色温的再应用
+- `llsettingsvo.cpp::applySpecial` 中将 `psky->getCloudColor() * getR17SunModulator()` 通过 `CLOUD_COLOR` uniform push
+- 原本属于 r17 → 随 r17 drop 同时 drop → sustained viewing 评估「orange 夕烧的世界丢失」后 **复活**
+- 由 `AYAR17ColorTemperatureEnabled` (r17 sentinel) + master + Legacy Midday pinpoint 除外 gate
+
+### 设置
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | 章节 master switch — 在 Preferences → Graphics → Shaders 的 `Firestorm View / AYAstorm View` combo_box 中切换 |
+| `AYAR18CloudVolumetricEnabled` | `1` (ON) | r18 A 轴 sentinel。`0` 时回到 flat 2D sample (与 r17 数式一致) |
+| `AYAR17ColorTemperatureEnabled` | `1` (ON) | 来自 r17 的 sentinel,本 release 中也 gate B 轴 CLOUD_COLOR mod |
+
+### View Mode UI
+
+Preferences → Graphics → Shaders 通过 combo_box (`AYAViewMode`) 暴露章节 master:
+
+- **Firestorm View** — `AYAVisualRealismEnabled = 0`,完全回到 r14 之前的画面
+- **AYAstorm View** — `AYAVisualRealismEnabled = 1`,视觉真实感章节 ON (默认)
+
+(combo_box 在 r17 与 master cvar 的 U32 升级一同加入,r18 release 是它公开亮相之处。)
+
+### 已知限制
+
+- **A 轴效果在云量多的 preset (Cloudy / Sunset) 中最明显**。Clear-sky preset 云面积小,可供表现深度的空间有限 (定义如此)
+- **昼间 (legacy) preset (`KNOWN_SKY_LEGACY_MIDDAY`) 被 pinpoint 除外** — A 轴 fallback 到 flat sample、B 轴 CLOUD_COLOR mod 为 identity。这个 preset 是 PBR 前 noon 还原意图,我们不调制它
+- **地表云影超出 scope** — r18 阶段曾考虑同捆,为防止 scope 膨胀挪至 r19+
+- **A 轴效果与 WindLight `cloud_pos_density` / `cloud_scale` 共存** — 这些 preset uniform 继续作为有意义的 input,raymarch 是在 preset 已定义的云量「立体面」上雕刻
+
+### 实现概要
+
+- `cloudsF.glsl` — N=4 slab raymarch、gated、为数学等价保留 OFF 路径
+- `llsettingsvo.cpp::applySpecial` — A 轴 uniform push + B 轴 `CLOUD_COLOR × r17_sun_mod`
+- `LLShaderMgr` — `AYA_R18_CLOUD_VOLUMETRIC_ENABLED` enum + reserved uniform
+- `settings.xml` — `AYAR18CloudVolumetricEnabled` Boolean default 1
+
+### 文档
+
+- r18 spec / slab raymarch 参数 / B 轴 revival 经过: `docs/ayastorm-r18-cloud-volumetric.md`
+- P0 cloud shader 调查: `doc/r18/cloud_volumetric_survey.md`
+- r17 spec (drop / revert 教训、B 轴 revival 的根据): `docs/ayastorm-r17-color-temperature.md`
+- 视觉真实感章节路线图 (A 轴完走 = r18): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r19-release-note.en.md
+++ b/docs/ayastorm-r19-release-note.en.md
@@ -1,0 +1,73 @@
+# AYAstorm r19 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r19 is the sixth release of the visual-realism chapter (r14–r20) and the first release of the B-axis (material color)**. Adds wrap-around diffuse + back-light transmission to the deferred lit path so thin objects — leaves, white curtains, the rim of an ear in strong backlight — start to **transmit light** instead of going flat black.
+
+> **Distribution**: r19 ships **bundled with the r23 release** (no standalone r19 tag). The r23 release page links back to this note and to the r19 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r19-translucency.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r19 — Translucency (thin-object back-light transmission)
+
+### Headline: thin objects start to transmit light
+
+A-axis (r14–r18) made the air believable. B-axis turns toward **what the air is wrapped around** — the materials themselves. r19 lands the entry point: thin objects letting sunlight transmit through:
+
+- **Leaves glow at the edge against the sun** — looking up through a tree, leaf edges catch and transmit sunlight, the silhouette stops being a flat dark cutout
+- **White curtains glow from within** — standing behind a thin curtain by a window, light wraps through it instead of being blocked
+- **Ear / nose rim / fingertips transmit red** — in strong rim-lighting on portraits, skin starts to feel *alive*
+- **Paper, candles, thin ceramics** — thin-material translucency in general
+
+Effect is visible in **instant A/B** by design — the failed predecessor (r19 albedo fidelity, frozen archive `feature/aya-r19-albedo-fidelity-spec-draft`) taught us that "mathematically correct but invisible" should be dropped early, so r19 was deliberately re-scoped to a visually-decisive effect.
+
+### How it works
+
+A single algorithm — **wrap-around diffuse (Burley wrap) + back-light transmission** — is added as a sum to `sun_contrib` in `class3/deferred/softenLightF.glsl`:
+
+```
+nl_wrap = max((N·L + w) / (1 + w), 0)           // wrap term, replaces da in Legacy
+back    = pow(max(-N·L, 0), k_back)              // back-light: strong only when the sun is behind
+view    = pow(max(V·L, 0), k_view)               // and the viewer is looking toward the sun
+transmit = back * view * tint * strength * sunlit_linear
+```
+
+Two injection sites in `softenLightF.glsl` cover the full deferred routing (per `docs/ayastorm-deferred-shader-routing.md`):
+
+- **Legacy branch** (walls, avatars, ears, older clothing → `materialF` writer): `da` is replaced by `nl_wrap`, then `transmit * baseColor.rgb` is added after `sun_contrib`
+- **PBR branch** (Mesh clothing → `pbropaqueF` writer): `transmit * baseColor.rgb` is added after the `pbrBaseLight()` call
+
+The C++ side pushes a 4-tuple per intensity tier from the slow + fast `bindDeferredShader` paths so live toggling works without rebuild.
+
+### Local lights (point / spot) and the sun
+
+r19 is **sun-driven only**. Local lights producing wrap / back-transmission is treated as a secondary effect and deferred to r20+ if needed. The sun-only design covers the photography use cases (leaves against sun, curtain behind window, portrait against window) and keeps the scope tight.
+
+### Settings
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | Chapter master switch (Firestorm View / AYAstorm View) |
+| `AYAR19TranslucencyEnabled` | `1` (ON) | r19 sentinel. `0` reverts to r18 lit calculation |
+| `AYAR19TranslucencyIntensity` | `1` (U32, 0–3) | 0=OFF / 1=subtle (default) / 2=standard / 3=strong. Tier table for `(wrap, k_back, k_view, strength)` lives in `pipeline.cpp` |
+
+The intensity slider is included intentionally because translucency is one of those effects where "subtle by default, available louder for portraits" is the right shape. Tier 1 (default) is calibrated to avoid the CG-look failure mode (everything glowing all the time).
+
+### Known limitations
+
+- **Surface transparency (`alpha > 0` prims) bypasses softenLightF** — those prims take the forward `alphaF` path which isn't touched in r19. Intensity changes don't apply there. Forward-path injection is a candidate for r20+.
+- **Subsurface depth dependence is approximate** — r19 uses `scol` (sun shadow) for self-shadow attenuation, which gives a useful secondary thickness dependence on flat prims but isn't a real diffusion profile. Physical SSS (thickness map / Burley diffusion / multi-scatter) is permanently dropped per chapter roadmap §6 (heavy, requires preset rework).
+- **`Legacy Midday` preset is unaffected** — we don't pinpoint-exclude it in r19, but its high sun angle naturally minimizes back-transmission anyway. No reports of regression on it.
+
+### Implementation summary
+
+- `class3/deferred/softenLightF.glsl` — wrap + back-transmission uniforms + helpers (`ayaTranslucencyWrap`, `ayaTranslucencyTransmit`), Legacy branch + PBR branch injection
+- `pipeline.cpp::renderDeferredLighting` — softenLightF bind site pushes the tier table after `bindDeferredShader`; both slow and fast paths covered
+- `settings.xml` — `AYAR19TranslucencyEnabled` Boolean default 1, `AYAR19TranslucencyIntensity` U32 default 1
+
+### Documentation
+
+- r19 spec / Burley wrap parameters / risk register: `docs/ayastorm-r19-translucency.md`
+- Deferred routing reference (writer → softenLightF branch mapping): `docs/ayastorm-deferred-shader-routing.md`
+- Frozen r19 albedo-fidelity archive (predecessor scope, dropped): `docs/ayastorm-r19-albedo-fidelity.md`
+- Visual-realism chapter roadmap (B-axis entry = r19): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r19-release-note.ja.md
+++ b/docs/ayastorm-r19-release-note.ja.md
@@ -1,0 +1,73 @@
+# AYAstorm r19 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r19 は視覚的リアリティ章 (r14〜r20) の第 6 弾、B 軸 (物質色) の第 1 弾**です。deferred lit 経路に wrap-around diffuse + back-light transmission を加算し、葉・白い布カーテン・逆光の耳の縁といった **薄物が太陽光を透過** する状態を作ります (これまで flat に黒く落ちていた)。
+
+> **配信形態**: r19 は **r23 リリースに同梱配信** されます (r19 単独タグは発行しません)。r23 リリースページから本ノートと r19 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r19-translucency.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r19 — 薄物の透過 (translucency / 太陽光の背面透過)
+
+### r19 の柱: 薄物が太陽光を透過する
+
+A 軸 (r14〜r18) で空気の信頼性を作りました。B 軸ではその空気の中に置かれる **物質本来の色と質感** に向かいます。r19 はその入口、薄物が太陽光を透過する効果を解きます:
+
+- **葉が太陽に向かって透ける** — 木陰から空を見上げると、葉の縁が太陽光を捉えて透過する、葉脈や輪郭の質感が出る (これまで真っ黒なシルエットだった)
+- **白い布カーテンに光が回る** — 窓辺の薄布カーテンの裏側に立つと、光が透過してカーテンが内側から発光しているように見える
+- **人物の耳・鼻翼・指先が透ける** — 強い順光で人物の耳の縁が赤く透ける、肌が生きている感じになる
+- **紙・蝋燭・薄い陶器の半透明感** — 薄物全般の質感
+
+効果は **instant A/B で誰でも分かる** ように設計。前任の r19 (アルベド忠実度、frozen archive `feature/aya-r19-albedo-fidelity-spec-draft`) は「数学的に正しいが視認困難」で全 drop した教訓から、r19 はあえて視覚的に決定的な効果へ scope を切り替えています。
+
+### 仕組み
+
+**Wrap-around diffuse (Burley wrap) + Back-light transmission の加算** を `class3/deferred/softenLightF.glsl` の `sun_contrib` 加算項として 1 経路で実装:
+
+```
+nl_wrap = max((N·L + w) / (1 + w), 0)            // wrap 項、Legacy で da を置換
+back    = pow(max(-N·L, 0), k_back)              // back-light: 太陽が背面側で強い
+view    = pow(max(V·L, 0), k_view)               // 視線が太陽方向のとき
+transmit = back * view * tint * strength * sunlit_linear
+```
+
+softenLightF.glsl 内 2 ヶ所注入で deferred routing 全分岐をカバー (`docs/ayastorm-deferred-shader-routing.md` 参照):
+
+- **Legacy 分岐** (壁・avatar・耳・旧服 → `materialF` writer): `da` を `nl_wrap` に置換 → `sun_contrib` 加算後に `transmit * baseColor.rgb` を加算
+- **PBR 分岐** (Mesh 服 → `pbropaqueF` writer): `pbrBaseLight()` 呼び出し後に `transmit * baseColor.rgb` を加算
+
+C++ 側は intensity tier ごとの 4-tuple を slow / fast の `bindDeferredShader` 両経路で push、live toggle 対応。
+
+### 局所灯 (point / spot) と太陽
+
+r19 は **太陽光のみ** 対応。局所灯の wrap / back-transmission は二次効果として r20+ に分離。太陽光主導の design で写真撮影ユースケース (太陽逆光の葉、窓越しのカーテン、窓辺ポートレート) は完全にカバーされ、scope を絞れる。
+
+### 設定
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | 章 master switch (Firestorm View / AYAstorm View) |
+| `AYAR19TranslucencyEnabled` | `1` (ON) | r19 sentinel。`0` で r18 までの lit 計算に戻る |
+| `AYAR19TranslucencyIntensity` | `1` (U32, 0-3) | 0=OFF / 1=控えめ (default) / 2=標準 / 3=強め。`(wrap, k_back, k_view, strength)` の tier table は `pipeline.cpp` に保持 |
+
+intensity slider は意図的に同梱。透過効果は「デフォルト控えめ、ポートレート用に強めも欲しい」性質で、tier 1 (default) は CG 感 (常に何でも透ける) の失敗モードを避けるように調整しています。
+
+### 既知の制約
+
+- **prim transparency (`alpha > 0`) は softenLightF を経由しない** — これらの prim は forward `alphaF` 経路を踏み、r19 は触れていない。intensity も効かない。forward 経路への注入は r20+ 候補
+- **Subsurface 厚み依存は近似** — r19 は `scol` (sun shadow) を self-shadow 減衰に流用しており、平面 prim でも副次的な厚み依存性は機能するが、本来の diffusion profile ではない。物理正確 SSS (thickness map / Burley diffusion / multi-scatter) は heavy + preset 改修要のため章 roadmap §6 で永久 drop
+- **昼間 (レガシー) preset は影響なし** — r19 では pinpoint 除外していないが、太陽が高い性質上 back-transmission は自然に minimal、回帰報告は無し
+
+### 実装概要
+
+- `class3/deferred/softenLightF.glsl` — wrap + back-transmission uniforms + helpers (`ayaTranslucencyWrap`, `ayaTranslucencyTransmit`)、Legacy 分岐 + PBR 分岐の 2 注入点
+- `pipeline.cpp::renderDeferredLighting` — softenLightF bind 直後に tier table の uniform を push、slow / fast 両経路カバー
+- `settings.xml` — `AYAR19TranslucencyEnabled` Boolean default 1、`AYAR19TranslucencyIntensity` U32 default 1
+
+### ドキュメント
+
+- r19 spec / Burley wrap パラメータ / リスク登記: `docs/ayastorm-r19-translucency.md`
+- deferred shader routing リファレンス (writer → softenLightF 分岐表): `docs/ayastorm-deferred-shader-routing.md`
+- frozen r19 albedo-fidelity archive (前任 scope、drop): `docs/ayastorm-r19-albedo-fidelity.md`
+- 視覚的リアリティ章ロードマップ (B 軸入口 = r19): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r19-release-note.zh.md
+++ b/docs/ayastorm-r19-release-note.zh.md
@@ -1,0 +1,73 @@
+# AYAstorm r19 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r19 是视觉真实感章 (r14–r20) 的第六弹、B 轴 (物质色) 的第一弹**。在 deferred lit 路径上加入 wrap-around diffuse + back-light transmission 加算,使叶片、白色窗帘、强逆光下耳缘等 **薄物开始透过太阳光** (此前一律 flat 黑掉)。
+
+> **发布形态**: r19 与 **r23 发布版本一同捆绑发布** (不单独发行 r19 tag)。r23 发布页面会回链至本说明及 r19 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r19-translucency.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r19 — 薄物的透过 (translucency / 太阳光的背面透过)
+
+### r19 主轴: 薄物开始透过太阳光
+
+A 轴 (r14–r18) 让空气变得可信。B 轴转向 **空气包裹之物本身 — 物质** 。r19 落位于入口:让薄物透过太阳光:
+
+- **叶子在太阳的方向透光** — 从树荫向上看天空,叶缘捕捉太阳光透过,叶脉 / 轮廓的质感浮现 (之前是死黑的剪影)
+- **白窗帘自内发光** — 站在窗边薄窗帘背后,光绕过窗帘,看起来像从内部发光
+- **人物的耳/鼻翼/指尖透红** — 强逆光人像中耳缘透出红色,皮肤开始有「活着」的感觉
+- **纸 / 蜡烛 / 薄陶瓷的半透明感** — 薄物质感整体
+
+效果按 **instant A/B 任何人都能看出来** 来设计。前任 r19 (albedo fidelity, 冻结归档 `feature/aya-r19-albedo-fidelity-spec-draft`) 因「数学正确但视认困难」整体 drop,从那次教训中我们把 r19 主动 re-scope 到视觉决定性强的效果。
+
+### 工作原理
+
+**Wrap-around diffuse (Burley wrap) + Back-light transmission 的加算** 在 `class3/deferred/softenLightF.glsl` 的 `sun_contrib` 加算项中以单一路径实现:
+
+```
+nl_wrap = max((N·L + w) / (1 + w), 0)            // wrap 项,Legacy 中替换 da
+back    = pow(max(-N·L, 0), k_back)              // back-light: 太阳在背面时强
+view    = pow(max(V·L, 0), k_view)               // 且视线朝向太阳时
+transmit = back * view * tint * strength * sunlit_linear
+```
+
+softenLightF.glsl 内 2 处注入覆盖 deferred routing 全部分支 (见 `docs/ayastorm-deferred-shader-routing.md`):
+
+- **Legacy 分支** (墙 / avatar / 耳 / 旧服 → `materialF` writer): 用 `nl_wrap` 替换 `da`,在 `sun_contrib` 加算后再加 `transmit * baseColor.rgb`
+- **PBR 分支** (Mesh 服 → `pbropaqueF` writer): 在 `pbrBaseLight()` 调用之后加 `transmit * baseColor.rgb`
+
+C++ 侧按 intensity tier push 4-tuple,slow / fast 两条 `bindDeferredShader` 路径都覆盖,live toggle 可用。
+
+### 局部光 (point / spot) 与太阳
+
+r19 **只对应太阳光**。局部光的 wrap / back-transmission 视为次要效果,如有需要可推迟到 r20+。太阳主导的设计完全覆盖摄影 use case (逆光叶 / 窗后窗帘 / 窗边人像),scope 也保持紧凑。
+
+### 设置
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAVisualRealismEnabled` | `1` (ON, U32) | 章节 master switch (Firestorm View / AYAstorm View) |
+| `AYAR19TranslucencyEnabled` | `1` (ON) | r19 sentinel。`0` 时回到 r18 时代的 lit 计算 |
+| `AYAR19TranslucencyIntensity` | `1` (U32, 0-3) | 0=OFF / 1=低调 (default) / 2=标准 / 3=强烈。`(wrap, k_back, k_view, strength)` 的 tier table 保存于 `pipeline.cpp` |
+
+intensity slider 是有意同捆。透过效果属于「默认低调,人像时也想强些」的性质,tier 1 (default) 校准为避免 CG 感失败模式 (所有东西常时透光)。
+
+### 已知限制
+
+- **prim transparency (`alpha > 0`) 不经过 softenLightF** — 这些 prim 走 forward `alphaF` 路径,r19 未触碰。intensity 也不生效。forward 路径注入是 r20+ 的候选
+- **Subsurface 厚度依存仅为近似** — r19 借用 `scol` (sun shadow) 作为 self-shadow 衰减,在平面 prim 上也能产生副次性的厚度依存,但并非真正的 diffusion profile。物理 SSS (thickness map / Burley diffusion / multi-scatter) 重 + 需 preset 改造,按章 roadmap §6 永久 drop
+- **昼间 (legacy) preset 不受影响** — r19 中没有 pinpoint 除外,但其太阳角度高,back-transmission 自然 minimal,无回归报告
+
+### 实现概要
+
+- `class3/deferred/softenLightF.glsl` — wrap + back-transmission uniform + helper (`ayaTranslucencyWrap`, `ayaTranslucencyTransmit`),Legacy 分支 + PBR 分支 2 个注入点
+- `pipeline.cpp::renderDeferredLighting` — softenLightF bind 之后立即 push tier table uniform,slow / fast 两条路径都覆盖
+- `settings.xml` — `AYAR19TranslucencyEnabled` Boolean default 1、`AYAR19TranslucencyIntensity` U32 default 1
+
+### 文档
+
+- r19 spec / Burley wrap 参数 / 风险登记: `docs/ayastorm-r19-translucency.md`
+- deferred shader routing 参考 (writer → softenLightF 分支表): `docs/ayastorm-deferred-shader-routing.md`
+- 冻结的 r19 albedo-fidelity 归档 (前任 scope、drop): `docs/ayastorm-r19-albedo-fidelity.md`
+- 视觉真实感章节路线图 (B 轴入口 = r19): `docs/ayastorm-visual-realism-roadmap.md`

--- a/docs/ayastorm-r20-release-note.en.md
+++ b/docs/ayastorm-r20-release-note.en.md
@@ -1,0 +1,98 @@
+# AYAstorm r20 — Release Announcement
+
+Short text intended to be pasted into the GitHub release page. **r20 is the seventh release of the visual-realism chapter (r14–r20) and completes the B-axis (material color)**. Adds **screen-space subsurface scattering (SSS) to avatar skin** — your avatar (and other avatars) get a real soft, lit-from-within skin quality with **per-pixel skin masking** via gbuffer3 `.a`, **world-space-scaled blur** that auto-fades with distance, and **right-click learning** of new mesh bodies/heads (no UUID typing).
+
+> **Distribution**: r20 ships **bundled with the r23 release** (no standalone r20 tag). The r23 release page links back to this note and to the r20 spec.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`doc/spec_avatar_skin_sss.md`). This note is link-only + diff highlights.
+
+---
+
+## AYAstorm r20 — Avatar skin SSS (subsurface scattering)
+
+### Headline: skin starts to feel alive
+
+A-axis (r14–r18) made the air believable. r19 made thin objects transmit light. r20 lands the **skin** itself — the photographic reference point for "people":
+
+- **Skin softens at the right scale** — separable 5-tap SSS blur with wavelength-dependent weights (red diffuses further than green / blue)
+- **Skin lights up subtly** — glow restore (`pow(lit, 3) × glow_gain × warm_salmon`) restores the highlight crispness that blur naturally dulls, with a warm salmon tint that pushes "blood under the skin" rather than "glowing porcelain"
+- **Works on yourself and on others** — the identifier is **mesh asset UUID**, available locally from the existing `ObjectUpdate`, zero sim cost, no creator cooperation required
+
+This is the first viewer-side avatar skin SSS in SL/OpenSim history. Mainstream Mesh body/head products (Maitreya, Legacy, Reborn, eBody, LeLutka Evolution heads, Genus, etc.) all use stable mesh UUIDs, so once a few are learned, the typical SL crowd is covered.
+
+### How it works
+
+**Identifier — mesh asset UUID** (single axis):
+
+`getVolume()->getParams().getSculptID()` is read locally from every avatar's attachments. If the UUID is in the user's whitelist cvar, the attachment is marked `mIsSSSTarget = true`. No sim roundtrip, no Description editing, no inventory item name lookup (which doesn't work for other avatars).
+
+**Right-click learning UX**:
+
+Right-click an attachment → **"Add to SSS whitelist"** → the mesh UUID is appended to the whitelist cvar → cvar-changed signal re-evaluates every avatar in view → the same body/head on everyone else lights up too, instantly. Users never see a UUID.
+
+Available from both flat context menus (`menu_attachment_self/other.xml`) and pie menus (under "More >") for self and others.
+
+**Per-pixel skin mask** (Phase C):
+
+`gbuffer3` was extended from `RGB16F` to `RGBA16F`. The `.a` channel carries a `skin` bit. The SSS pass reads this bit (via `emissiveRect`) per pixel, so only skin pixels are blurred — clothing, hair, glasses, eyes are untouched.
+
+**World-space-scaled blur** (Jimenez "Separable SSS" pattern, Phase D):
+
+```
+r_eff = aya_blur_radius / max(eye_dist_m, 1m)
+```
+
+- Up to 1m the radius is capped at `aya_blur_radius` (close-up SSS stays meaningful)
+- Past 1m, radius decreases inversely with distance
+- At ~10m, radius < 1px, blur becomes a structural no-op
+
+This **replaces the earlier smoothstep distance fade** (two cvars) which had a "blur-of-blur" failure mode at mid distance. The world-space formulation makes the distance-fade logic self-cancelling.
+
+**Glow restore** (Phase D1):
+
+```
+glow_additive = pow(blurred_lit, 3) × glow_gain × glow_color
+```
+
+Single-pass additive on top of the blurred result. No extra render target. The warm salmon default (1.0, 0.65, 0.5) was chosen because pure white reads as "skin glowing" rather than "blood under skin".
+
+### Settings (Preferences → Graphics → SSS tab)
+
+| Key | Default | Purpose |
+|---|---|---|
+| `AYAR20AvatarSkinSSSEnabled` | `1` (ON) | Master switch for SSS |
+| `AYAR20AvatarSkinSSSBlurRadius` | `1.0` | Pixel radius at eye_dist = 1m (world-space-scaled past that) |
+| `AYAR20AvatarSkinSSSStrength` | `0.7` | Blur strength |
+| `AYAR20AvatarSkinSSSGlowGain` | `3.0` (max 5.0) | Glow restore intensity |
+| `AYAR20AvatarSkinSSSGlowColor` | warm salmon (1.0, 0.65, 0.5, 1.0) | Glow tint |
+| `AYAR20AvatarSkinSSSWhitelist` | — (user-grown) | Newline-separated mesh UUIDs |
+
+UI also includes per-cvar **Default** buttons, a **Reset all to defaults** button, and a **Lock** checkbox that gates the whitelist text editor to read-only (prevents accidental edits).
+
+### Known limitations
+
+- **No seed UUID list shipped** — first-launch is "nothing is whitelisted yet". Right-click learning is the path. Seeding mainstream body/head UUIDs is considered for r21+ once community-list maintenance is designed (§6.1 of the spec).
+- **No transmittance** — true ear/finger light transmission (rim glow physics) is r21+ territory. r20 covers diffuse-side SSS only.
+- **No per-skin-tone parameters** — single global blur/strength/glow values. Adjusting per ethnicity / skin tone is parked for r21+.
+- **Non-mesh attachments grey-out the menu** — old sculpt prims and basic prims can't be added (no mesh UUID to extract).
+- **Pre-PBR / old hair shaders** may write `.a` differently in non-PBR variants; the SSS pass falls back to "no skin pixel here" and behaves safely (skin just doesn't blur).
+
+### Implementation summary
+
+- `llayaskinsss.{h,cpp}` (new) — `SkinSSSMatcher` singleton, mesh UUID extraction, whitelist parsing, per-avatar re-evaluation
+- `class1/deferred/skinSSSV.glsl` + `skinSSSF.glsl` (new) — 2-pass separable SSS blur, wavelength weights, world-space-scaled radius, `emissiveRect.a` skin mask
+- `pipeline.cpp` — `doSkinSSS()` 2-pass driver, gbuffer3 extended to RGBA16F
+- `llvoavatar.cpp` — `attachObject` / `detachObject` route into `SkinSSSMatcher`
+- `llviewermenu.cpp` — `SSS.Add` / `SSS.Remove` / `SSS.EnableAdd` / `SSS.EnableRemove` handlers
+- `panel_preferences_sss.xml` (new) — Preferences → Graphics → SSS tab
+- `menu_attachment_self/other.xml` + `menu_pie_attachment_self/other.xml` — right-click entries
+- `settings.xml` — six SSS cvars (Enabled / BlurRadius / Strength / GlowGain / GlowColor / Whitelist)
+- Shader cache tag bumped (`AYASTORM_SHADER_CACHE_TAG = "AYAstorm r20"`) so old compiled shaders auto-invalidate
+
+### Documentation
+
+- r20 full spec (Phase A–E status, identifier strategy comparison, debug-settings restore guide): `doc/spec_avatar_skin_sss.md`
+- gbuffer3 storage extension reference (RGBA16F skin bit): memory `reference_gbuffer3_storage.md`
+- Deferred shader routing reference (writer → SSS mask path): `docs/ayastorm-deferred-shader-routing.md`
+- Visual-realism chapter roadmap (B-axis complete = r20): `docs/ayastorm-visual-realism-roadmap.md`
+- Restore-debug-settings note for sustained-test override values: memory `feedback_restore_debug_settings.md`

--- a/docs/ayastorm-r20-release-note.ja.md
+++ b/docs/ayastorm-r20-release-note.ja.md
@@ -1,0 +1,98 @@
+# AYAstorm r20 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r20 は視覚的リアリティ章 (r14〜r20) の第 7 弾、B 軸 (物質色) 完走リリース**。screen-space SSS (subsurface scattering) を **アバター肌** に適用し、自分にも他人にも、柔らかく内側から灯る肌の質感をもたらします。**gbuffer3 `.a` の per-pixel skin mask**、**世界座標スケール blur** で距離自動 fade、**右クリック学習** で新規 mesh body/head を瞬時に追加 (UUID を打ち込む必要なし)。
+
+> **配信形態**: r20 は **r23 リリースに同梱配信** されます (r20 単独タグは発行しません)。r23 リリースページから本ノートと r20 spec doc にリンクする運用です。
+
+実装・既知 limits・設定の詳細は永続資料 (`doc/spec_avatar_skin_sss.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r20 — アバター肌 SSS (subsurface scattering)
+
+### r20 の柱: 肌が生きている
+
+A 軸 (r14〜r18) で空気を信頼に足るものに、r19 で薄物を太陽光で透かしました。r20 は **肌そのもの** — 「人」を写すときの中核を取りに行きます:
+
+- **肌が適切なスケールで柔らかくなる** — separable 5-tap SSS blur に波長依存重み (赤が緑/青より遠くまで diffuse)
+- **肌が subtle に光る** — glow restore (`pow(lit, 3) × glow_gain × warm_salmon`) で blur が眠くした hi-light を取り戻し、warm salmon tint で「血色のある肌」感を補強 (発光する陶器 ではなく)
+- **自分にも他人にも効く** — 識別子は **mesh asset UUID**、既存の `ObjectUpdate` で viewer ローカルに来るため sim 往復ゼロ、装着者協力不要
+
+SL/OpenSim viewer 史上初の viewer-side avatar skin SSS。主要 Mesh body/head 製品 (Maitreya、Legacy、Reborn、eBody、LeLutka Evolution heads、Genus 等) は安定した mesh UUID を使うため、いくつか覚えさせれば普通の SL 風景の 8〜9 割をカバーします。
+
+### 仕組み
+
+**識別子は mesh asset UUID** (単一軸):
+
+`getVolume()->getParams().getSculptID()` を各 avatar の attachment から viewer ローカルで取得。UUID が whitelist cvar にあれば `mIsSSSTarget = true` をマーク。sim 往復なし、Description 編集不要、inventory item 名 lookup (他人に効かない) も不要。
+
+**右クリック学習 UX**:
+
+装着物を右クリック → **「Add to SSS whitelist」** → mesh UUID が whitelist cvar に追記 → cvar 変更シグナルが全 avatar 再評価をトリガ → 同じ body/head を使っている **他の全員にも瞬時に伝播**。ユーザーは UUID を一度も見ない。
+
+フラット文脈メニュー (`menu_attachment_self/other.xml`) とパイメニュー (`More >` 配下) の自分/他人 4 経路すべてに登録。
+
+**Per-pixel skin mask** (Phase C):
+
+`gbuffer3` を `RGB16F` → `RGBA16F` に拡張。`.a` チャンネルに skin bit を持つ。SSS pass は (emissiveRect 経由で) per-pixel に bit を読み、肌 pixel だけに blur 適用 — 服 / 髪 / 眼鏡 / 目は無影響。
+
+**世界座標スケール blur** (Jimenez "Separable SSS"、Phase D):
+
+```
+r_eff = aya_blur_radius / max(eye_dist_m, 1m)
+```
+
+- 1m 以内は `aya_blur_radius` 上限で頭打ち (近接の SSS を維持)
+- 1m を超えると半径が距離に逆比例で減少
+- 約 10m で半径 < 1px = 構造的に no-op
+
+**これは以前の smoothstep 距離 fade (cvar 2 件) を置換** したもの。smoothstep は中距離で「ボケのボケ」問題が継続したため pivot。世界座標スケール式は距離 fade の判断ロジックを自動キャンセルする。
+
+**Glow restore** (Phase D1):
+
+```
+glow_additive = pow(blurred_lit, 3) × glow_gain × glow_color
+```
+
+blurred 結果に additive で 1 pass、追加 RT なし。default の warm salmon (1.0, 0.65, 0.5) は「肌が発光する」感ではなく「血色のある肌」感を出すために選択。
+
+### 設定 (Preferences → Graphics → SSS タブ)
+
+| Key | Default | 役割 |
+|---|---|---|
+| `AYAR20AvatarSkinSSSEnabled` | `1` (ON) | SSS master switch |
+| `AYAR20AvatarSkinSSSBlurRadius` | `1.0` | eye_dist=1m 基準の pixel 半径 (それ以降は世界座標スケール) |
+| `AYAR20AvatarSkinSSSStrength` | `0.7` | Blur strength |
+| `AYAR20AvatarSkinSSSGlowGain` | `3.0` (max 5.0) | Glow restore 強度 |
+| `AYAR20AvatarSkinSSSGlowColor` | warm salmon (1.0, 0.65, 0.5, 1.0) | Glow tint |
+| `AYAR20AvatarSkinSSSWhitelist` | — (ユーザーが育てる) | 改行区切りの mesh UUID 一覧 |
+
+UI には各 cvar の **Default** ボタン、**Reset all to defaults** ボタン、whitelist text editor を read-only にする **Lock** チェックボックス (誤編集防止) も同梱。
+
+### 既知の制約
+
+- **シード UUID list は出荷しない** — 初回起動は「whitelist 空」状態。右クリック学習で育てる経路。主要 body/head UUID のシード同梱は community list 維持設計 (§6.1) と合わせて r21+ で検討
+- **Transmittance は r21+** — 耳 / 指先の真の透過光 (rim glow 物理) は r20 範囲外、diffuse 側 SSS のみ
+- **skin tone 別パラメータ無し** — 単一 global の blur / strength / glow 値、人種/肌色別調整は r21+
+- **mesh でない attachment はメニュー grey out** — 古い sculpt prim や通常 prim は mesh UUID が取れないため
+- **Pre-PBR / 古い hair shader** は non-PBR variant で `.a` 書込みが異なる可能性、SSS pass は「ここに skin pixel は無い」として safely fallback (blur されないだけ)
+
+### 実装概要
+
+- `llayaskinsss.{h,cpp}` (新規) — `SkinSSSMatcher` singleton、mesh UUID 抽出、whitelist パース、全 avatar 再評価
+- `class1/deferred/skinSSSV.glsl` + `skinSSSF.glsl` (新規) — 2-pass separable SSS blur、波長依存重み、世界座標スケール半径、`emissiveRect.a` 経由 skin mask
+- `pipeline.cpp` — `doSkinSSS()` 2-pass driver、gbuffer3 を RGBA16F に拡張
+- `llvoavatar.cpp` — `attachObject` / `detachObject` で `SkinSSSMatcher` 連携
+- `llviewermenu.cpp` — `SSS.Add` / `SSS.Remove` / `SSS.EnableAdd` / `SSS.EnableRemove` ハンドラ
+- `panel_preferences_sss.xml` (新規) — Preferences → Graphics → SSS タブ
+- `menu_attachment_self/other.xml` + `menu_pie_attachment_self/other.xml` — 右クリックエントリ
+- `settings.xml` — 6 件の SSS cvar (Enabled / BlurRadius / Strength / GlowGain / GlowColor / Whitelist)
+- Shader cache tag を bump (`AYASTORM_SHADER_CACHE_TAG = "AYAstorm r20"`) して古い compiled shader を自動無効化
+
+### ドキュメント
+
+- r20 full spec (Phase A–E ステータス / 識別子戦略比較 / debug settings 戻し案内): `doc/spec_avatar_skin_sss.md`
+- gbuffer3 storage 拡張リファレンス (RGBA16F skin bit): memory `reference_gbuffer3_storage.md`
+- deferred shader routing リファレンス (writer → SSS mask path): `docs/ayastorm-deferred-shader-routing.md`
+- 視覚的リアリティ章ロードマップ (B 軸完走 = r20): `docs/ayastorm-visual-realism-roadmap.md`
+- sustained 検証で上書きした debug settings の戻し案内: memory `feedback_restore_debug_settings.md`

--- a/docs/ayastorm-r20-release-note.zh.md
+++ b/docs/ayastorm-r20-release-note.zh.md
@@ -1,0 +1,98 @@
+# AYAstorm r20 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r20 是视觉真实感章 (r14–r20) 的第七弹、B 轴 (物质色) 完走 release**。把 screen-space SSS (subsurface scattering) 应用到 **avatar 皮肤**,自己和他人都能呈现柔和、自内发光的皮肤质感。**gbuffer3 `.a` 的 per-pixel skin mask**、**世界坐标尺度 blur** 自动随距离淡出、**右键学习** 瞬时新增 mesh body/head (无需输入 UUID)。
+
+> **发布形态**: r20 与 **r23 发布版本一同捆绑发布** (不单独发行 r20 tag)。r23 发布页面会回链至本说明及 r20 spec 文档。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`doc/spec_avatar_skin_sss.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r20 — Avatar 皮肤 SSS (subsurface scattering)
+
+### r20 主轴: 皮肤变得「活着」
+
+A 轴 (r14–r18) 让空气可信,r19 让薄物透过太阳光。r20 接下 **皮肤本身** — 拍「人」时的核心:
+
+- **皮肤在合适的尺度上柔化** — separable 5-tap SSS blur + 波长依存权重 (红色比绿/蓝扩散更远)
+- **皮肤微微发亮** — glow restore (`pow(lit, 3) × glow_gain × warm_salmon`) 把 blur 弄钝的 hi-light 找回,warm salmon tint 提供「皮下血色」感而非「发光瓷器」
+- **对自己和他人都生效** — 识别用 **mesh asset UUID**,通过既有 `ObjectUpdate` 在 viewer 本地获取,sim 往返为零,无需着装者配合
+
+SL/OpenSim viewer 史上首个 viewer 侧 avatar 皮肤 SSS。主流 Mesh body/head 产品 (Maitreya、Legacy、Reborn、eBody、LeLutka Evolution heads、Genus 等) 使用稳定的 mesh UUID,只要记住几个,普通 SL 场景 8–9 成已覆盖。
+
+### 工作原理
+
+**识别 — mesh asset UUID** (单一轴):
+
+在每个 avatar 的 attachment 上本地读 `getVolume()->getParams().getSculptID()`。如果 UUID 在用户的 whitelist cvar 中,则把该 attachment 标记 `mIsSSSTarget = true`。无 sim 往返、无需编辑 Description、不依赖 inventory item 名 (对他人无效)。
+
+**右键学习 UX**:
+
+右键 attachment → **「Add to SSS whitelist」** → mesh UUID 追加到 whitelist cvar → cvar 变更信号触发全 avatar 重新评估 → 使用同 body/head 的 **其他人也瞬时跟着发光**。用户永远看不到 UUID。
+
+flat 上下文菜单 (`menu_attachment_self/other.xml`) 与饼菜单 (`More >` 下) × 自己 / 他人 4 处全注册。
+
+**Per-pixel skin mask** (Phase C):
+
+`gbuffer3` 由 `RGB16F` 扩展为 `RGBA16F`。`.a` 通道携带 skin bit。SSS pass 逐 pixel (经 `emissiveRect`) 读 bit,仅在皮肤 pixel 上 blur — 衣服 / 头发 / 眼镜 / 眼睛不受影响。
+
+**世界坐标尺度 blur** (Jimenez "Separable SSS"、Phase D):
+
+```
+r_eff = aya_blur_radius / max(eye_dist_m, 1m)
+```
+
+- 1m 以内半径以 `aya_blur_radius` 为上限 (维持近景 SSS)
+- 超过 1m 后半径与距离成反比衰减
+- 约 10m 处半径 < 1px,blur 结构性退化为 no-op
+
+**这替代了此前的 smoothstep 距离 fade (2 个 cvar)**,smoothstep 在中距离持续出现「模糊之模糊」问题。世界坐标尺度公式让距离 fade 逻辑自动消除。
+
+**Glow restore** (Phase D1):
+
+```
+glow_additive = pow(blurred_lit, 3) × glow_gain × glow_color
+```
+
+在 blurred 结果上做 additive 单 pass,无附加 RT。default 的 warm salmon (1.0, 0.65, 0.5) 是为「皮下血色」而非「皮肤发光」选取。
+
+### 设置 (Preferences → Graphics → SSS 标签)
+
+| 键 | 默认 | 用途 |
+|---|---|---|
+| `AYAR20AvatarSkinSSSEnabled` | `1` (ON) | SSS master switch |
+| `AYAR20AvatarSkinSSSBlurRadius` | `1.0` | eye_dist=1m 基准 pixel 半径 (之后为世界坐标尺度) |
+| `AYAR20AvatarSkinSSSStrength` | `0.7` | Blur strength |
+| `AYAR20AvatarSkinSSSGlowGain` | `3.0` (max 5.0) | Glow restore 强度 |
+| `AYAR20AvatarSkinSSSGlowColor` | warm salmon (1.0, 0.65, 0.5, 1.0) | Glow 染色 |
+| `AYAR20AvatarSkinSSSWhitelist` | — (用户自维护) | 换行分隔的 mesh UUID 列表 |
+
+UI 还包含每个 cvar 的 **Default** 按钮、**Reset all to defaults** 按钮,以及把 whitelist text editor 设为只读的 **Lock** 复选框 (防止误编辑)。
+
+### 已知限制
+
+- **不附带种子 UUID list** — 首次启动 whitelist 为空,通过右键学习成长。主流 body/head UUID 的种子同捆与 community list 维护设计 (§6.1) 一起在 r21+ 讨论
+- **无 Transmittance** — 耳 / 指尖的真透过光 (rim glow 物理) 属 r21+,r20 只覆盖 diffuse 侧 SSS
+- **无 skin tone 区分参数** — 单一全局 blur / strength / glow 值,人种 / 肤色调节延后到 r21+
+- **非 mesh 的 attachment 菜单 grey out** — 旧 sculpt prim 与基本 prim 无 mesh UUID 可提取
+- **Pre-PBR / 旧发型 shader** 在非 PBR 变体中对 `.a` 的写入方式可能不同,SSS pass 会以「此处无 skin pixel」安全 fallback (仅不 blur)
+
+### 实现概要
+
+- `llayaskinsss.{h,cpp}` (新增) — `SkinSSSMatcher` singleton、mesh UUID 抽取、whitelist 解析、全 avatar 重新评估
+- `class1/deferred/skinSSSV.glsl` + `skinSSSF.glsl` (新增) — 2-pass separable SSS blur、波长依存权重、世界坐标尺度半径、`emissiveRect.a` 经由的 skin mask
+- `pipeline.cpp` — `doSkinSSS()` 2-pass driver、gbuffer3 扩展为 RGBA16F
+- `llvoavatar.cpp` — `attachObject` / `detachObject` 接入 `SkinSSSMatcher`
+- `llviewermenu.cpp` — `SSS.Add` / `SSS.Remove` / `SSS.EnableAdd` / `SSS.EnableRemove` 处理器
+- `panel_preferences_sss.xml` (新增) — Preferences → Graphics → SSS 标签
+- `menu_attachment_self/other.xml` + `menu_pie_attachment_self/other.xml` — 右键菜单项
+- `settings.xml` — 6 个 SSS cvar (Enabled / BlurRadius / Strength / GlowGain / GlowColor / Whitelist)
+- shader cache tag 上升 (`AYASTORM_SHADER_CACHE_TAG = "AYAstorm r20"`),让旧 compiled shader 自动失效
+
+### 文档
+
+- r20 完整 spec (Phase A–E 状态 / 识别子策略比较 / debug settings 回退指南): `doc/spec_avatar_skin_sss.md`
+- gbuffer3 storage 扩展参考 (RGBA16F skin bit): memory `reference_gbuffer3_storage.md`
+- deferred shader routing 参考 (writer → SSS mask path): `docs/ayastorm-deferred-shader-routing.md`
+- 视觉真实感章节路线图 (B 轴完走 = r20): `docs/ayastorm-visual-realism-roadmap.md`
+- sustained 验证后 debug settings 回退备忘: memory `feedback_restore_debug_settings.md`

--- a/docs/ayastorm-r21-release-note.en.md
+++ b/docs/ayastorm-r21-release-note.en.md
@@ -1,4 +1,4 @@
-# AYAstorm r21 — Release Announcement Draft
+# AYAstorm r21 — Release Announcement
 
 Short text intended to be pasted into the GitHub release page. **r21 is a single-feature UX release** outside the visual-realism chapter (r14-r20) — a complete redesign of the right-click picker for the user's own rigged attachments, switching from upstream CPU bind-pose mesh-ray to a GPU-rendered object-ID buffer.
 

--- a/docs/ayastorm-r21-release-note.ja.md
+++ b/docs/ayastorm-r21-release-note.ja.md
@@ -1,4 +1,4 @@
-# AYAstorm r21 — リリース告知文案
+# AYAstorm r21 — リリース告知
 
 GitHub release ページ貼り付け用の文案。**r21 は視覚的リアリティ章 (r14-r20) の外側にある UX 修正系の単機能リリース**で、自分の rigged attachment に対する右クリック picker を「上流 CPU bind-pose mesh ray」から「GPU 専用 object-ID buffer」に作り直したものを 1 本で提供します。
 

--- a/docs/ayastorm-r21-release-note.zh.md
+++ b/docs/ayastorm-r21-release-note.zh.md
@@ -1,4 +1,4 @@
-# AYAstorm r21 — 发布公告草案
+# AYAstorm r21 — 发布公告
 
 用于粘贴到 GitHub release 页面的短文。**r21 是位于视觉真实感章 (r14-r20) 之外的 UX 修复型单功能 release**，把自身 rigged attachment 的右键 picker 由「上游 CPU bind-pose mesh ray」改写为「GPU 专用 object-ID buffer」并以一次发布交付。
 

--- a/docs/ayastorm-r22-release-note.en.md
+++ b/docs/ayastorm-r22-release-note.en.md
@@ -1,4 +1,4 @@
-# AYAstorm r22 — Release Announcement Draft
+# AYAstorm r22 — Release Announcement
 
 Short text intended to be pasted into the GitHub release page. **r22 is a chat-UX release** that splits the Nearby Chat / IM history into two tabs — "human avatar speech" and "System & Object notifications (LSL + system + TP / Region)".
 

--- a/docs/ayastorm-r22-release-note.ja.md
+++ b/docs/ayastorm-r22-release-note.ja.md
@@ -1,4 +1,4 @@
-# AYAstorm r22 — リリース告知文案
+# AYAstorm r22 — リリース告知
 
 GitHub release ページ貼り付け用の文案。**r22 は Chat 表示の UX 改良リリース**で、Nearby Chat / IM の history を「人間アバター発言」と「System & Object 系通知 (LSL 発言 + システム通知 + TP / Region)」の 2 タブに分離します。
 

--- a/docs/ayastorm-r22-release-note.zh.md
+++ b/docs/ayastorm-r22-release-note.zh.md
@@ -1,4 +1,4 @@
-# AYAstorm r22 — 发布公告文案
+# AYAstorm r22 — 发布公告
 
 用于粘贴到 GitHub release 页面的简短文案。**r22 是聊天 UX 改进版本**,将 Nearby Chat / IM 的历史记录分离为「人类阿凡达发言」和「System & Object 系通知 (LSL + 系统 + TP / Region)」两个标签页。
 

--- a/docs/ayastorm-r23-github-release-page.en.md
+++ b/docs/ayastorm-r23-github-release-page.en.md
@@ -1,0 +1,72 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.zh.md)
+
+# AYAstorm r23 — Parcel-bound 3D stream + visual realism chapter (r14–r20) + tag-based OBB occlusion + GPU self-rigged picker + chat tab split
+
+A single jump from r12.1 to r23 bundles eleven releases (r13 through r23) into one tag. For the full notes per release, see the per-language release notes in the repo (tag-pinned permalinks — they will not break when docs are updated later).
+
+## Release notes (per release × language)
+
+### Audio chapter close-out
+- **r13** — Tag-based OBB occlusion (audio chapter flagship): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.zh.md)
+- **r23** — Parcel-bound 3D stream (this tag's headline feature): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.zh.md)
+
+### Visual realism chapter (r14–r20)
+- **r14** — Volumetric atmosphere (chapter opener, `AYAVisualRealismEnabled` master switch): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.zh.md)
+- **r15** — Godrays: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.zh.md)
+- **r16** — Aerial perspective (Rayleigh λ⁻⁴ wavelength-dependent haze): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.zh.md)
+- **r17** — Time-of-day color temperature (Kelvin curve, sunset warmth): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.zh.md)
+- **r18** — Cloud volumetric + color-temperature coupling (A-axis complete): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.zh.md)
+- **r19** — Translucency (thin-object back-light, B-axis opener): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.zh.md)
+- **r20** — Avatar skin SSS (B-axis complete, right-click learning): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.zh.md)
+
+### Chat UX & picker
+- **r21** — GPU self-rigged picker: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.zh.md)
+- **r22** — Chat tab split (Human vs System & Object): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.zh.md)
+
+## Key documents (tag-pinned)
+
+### Audio chapter
+- r13 OBB occlusion spec: [docs/ayastorm-r13-occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-occlusion.md) / [doc/spec_obb_occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_obb_occlusion.md)
+- r23 parcel-bound 3D stream spec: [docs/ayastorm-r23-parcel-bound-3d-stream.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-parcel-bound-3d-stream.md)
+- Cumulative 3D stream tag guide (r6 onward): [doc/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.zh.md)
+
+### Visual realism chapter
+- Visual realism roadmap (A/B-axis overview): [docs/ayastorm-visual-realism-roadmap.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-visual-realism-roadmap.md)
+- r14 volumetric atmosphere spec: [docs/ayastorm-r14-volumetric-atmosphere.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-volumetric-atmosphere.md)
+- r15 godrays spec: [docs/ayastorm-r15-godrays.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-godrays.md)
+- r16 aerial perspective spec: [docs/ayastorm-r16-aerial-perspective.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-aerial-perspective.md)
+- r17 color temperature spec: [docs/ayastorm-r17-color-temperature.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-color-temperature.md)
+- r18 cloud volumetric spec: [docs/ayastorm-r18-cloud-volumetric.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-cloud-volumetric.md)
+- r19 translucency spec: [docs/ayastorm-r19-translucency.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-translucency.md)
+- r20 avatar skin SSS spec: [docs/ayastorm-r20-avatar-skin-sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-avatar-skin-sss.md) / [doc/spec_avatar_skin_sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_avatar_skin_sss.md)
+- Deferred shader routing reference: [docs/ayastorm-deferred-shader-routing.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-deferred-shader-routing.md)
+
+### Chat UX & picker
+- r21 GPU self-rigged picker spec: [docs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-self-rigged-picker.md)
+- r22 chat tab split spec: [docs/ayastorm-r22-chat-tab-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-chat-tab-spec.md)
+
+## Compatibility with existing setups
+
+All features ship without breaking r12.1 setups:
+
+- **r23 parcel-bound 3D stream**: streamers without `PARCEL_FLAG_SOUND_LOCAL` set are unaffected. Parcels that have SOUND_LOCAL ON now correctly stop spilling to neighbours, matching what gestures / object sounds have always done.
+- **r14–r20 visual realism**: master switch `AYAVisualRealismEnabled` (default ON). Set to OFF to return to r12.1 visual baseline.
+- **r21 self-rigged picker**: GPU object-ID buffer replaces the CPU self-rigged picker. No setting required; `FSSelfRiggedPickerGPU` kill-switch retained for macOS.
+- **r22 chat tab split**: existing Nearby Chat / IM history is preserved; Human / System & Object tabs gain per-tab unread badges. Default ON for Nearby Chat, off-by-default for IMs (per user feedback).
+- **r13 OBB occlusion**: broadcaster opt-in via build tag; listener-side experience unchanged unless tag is set on a venue.
+
+## IR license
+
+Venue IRs bundled in r11 (and still shipping) are from OpenAIR (CC-BY 4.0). Sources in [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/indra/newview/app_settings/venue_ir/CREDITS.md).
+
+## Downloads
+
+_To be filled in by @mayatonton after the 3 OS build completes._
+
+- Windows Installer: _TBD_
+- macOS Installer: _TBD_
+- Linux Installer: _TBD_
+
+## Contributer
+
+@t-noami @mayatonton

--- a/docs/ayastorm-r23-github-release-page.ja.md
+++ b/docs/ayastorm-r23-github-release-page.ja.md
@@ -1,0 +1,72 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.zh.md)
+
+# AYAstorm r23 — Parcel-bound 3D stream + 視覚的リアリティ章 (r14〜r20) + タグベース OBB occlusion + GPU self-rigged picker + chat tab 分離
+
+r12.1 から r23 へのジャンプで 11 リリース (r13〜r23) を 1 タグに同梱します。各リリースの詳細は repo 内の言語別 release note を参照ください (タグ pin の permalink — 後で docs を更新しても壊れません)。
+
+## リリースノート (リリース × 言語)
+
+### 音響章クローズアウト
+- **r13** — タグベース OBB occlusion (音響章フラッグシップ): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.zh.md)
+- **r23** — Parcel-bound 3D stream (本タグの主機能): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.zh.md)
+
+### 視覚的リアリティ章 (r14〜r20)
+- **r14** — Volumetric atmosphere (章開幕、`AYAVisualRealismEnabled` master switch): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.zh.md)
+- **r15** — Godrays: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.zh.md)
+- **r16** — Aerial perspective (Rayleigh λ⁻⁴ 波長依存 haze): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.zh.md)
+- **r17** — 時間帯色温度 (Kelvin カーブ、夕焼け暖色): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.zh.md)
+- **r18** — Cloud volumetric + 色温度連動 (A 軸完走): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.zh.md)
+- **r19** — Translucency (薄物の透過、B 軸入口): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.zh.md)
+- **r20** — アバター肌 SSS (B 軸完走、右クリック学習): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.zh.md)
+
+### Chat UX & picker
+- **r21** — GPU self-rigged picker: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.zh.md)
+- **r22** — Chat tab 分離 (Human vs System & Object): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.zh.md)
+
+## 主要ドキュメント (タグ pin)
+
+### 音響章
+- r13 OBB occlusion spec: [docs/ayastorm-r13-occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-occlusion.md) / [doc/spec_obb_occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_obb_occlusion.md)
+- r23 parcel-bound 3D stream spec: [docs/ayastorm-r23-parcel-bound-3d-stream.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-parcel-bound-3d-stream.md)
+- 累積 3D stream タグガイド (r6 以降): [doc/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.zh.md)
+
+### 視覚的リアリティ章
+- 視覚的リアリティ章ロードマップ (A/B 軸 overview): [docs/ayastorm-visual-realism-roadmap.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-visual-realism-roadmap.md)
+- r14 volumetric atmosphere spec: [docs/ayastorm-r14-volumetric-atmosphere.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-volumetric-atmosphere.md)
+- r15 godrays spec: [docs/ayastorm-r15-godrays.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-godrays.md)
+- r16 aerial perspective spec: [docs/ayastorm-r16-aerial-perspective.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-aerial-perspective.md)
+- r17 color temperature spec: [docs/ayastorm-r17-color-temperature.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-color-temperature.md)
+- r18 cloud volumetric spec: [docs/ayastorm-r18-cloud-volumetric.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-cloud-volumetric.md)
+- r19 translucency spec: [docs/ayastorm-r19-translucency.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-translucency.md)
+- r20 avatar skin SSS spec: [docs/ayastorm-r20-avatar-skin-sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-avatar-skin-sss.md) / [doc/spec_avatar_skin_sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_avatar_skin_sss.md)
+- Deferred shader routing リファレンス: [docs/ayastorm-deferred-shader-routing.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-deferred-shader-routing.md)
+
+### Chat UX & picker
+- r21 GPU self-rigged picker spec: [docs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-self-rigged-picker.md)
+- r22 chat tab 分離 spec: [docs/ayastorm-r22-chat-tab-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-chat-tab-spec.md)
+
+## 既存環境との互換性
+
+全機能、r12.1 環境を壊さずに出荷します:
+
+- **r23 parcel-bound 3D stream**: `PARCEL_FLAG_SOUND_LOCAL` を立てていない配信者は変化なし。SOUND_LOCAL ON の parcel は隣接 parcel への漏れが正しく止まります — gesture / object sound が常に行ってきた挙動と一致。
+- **r14〜r20 視覚的リアリティ**: master switch `AYAVisualRealismEnabled` (default ON)。OFF にすると r12.1 のビジュアル基準に戻ります。
+- **r21 self-rigged picker**: GPU object-ID buffer が CPU self-rigged picker を置換。設定不要、macOS 用 kill-switch `FSSelfRiggedPickerGPU` は残置。
+- **r22 chat tab 分離**: 既存の Nearby Chat / IM history は保持され、Human / System & Object タブにそれぞれ未読バッジが付きます。Nearby Chat は default ON、IM は default off (ユーザーフィードバック反映)。
+- **r13 OBB occlusion**: ビルドタグによる配信者 opt-in、listener 側は venue にタグが立っていない限り変化なし。
+
+## IR ライセンス
+
+r11 で同梱した venue IR (現在も出荷中) は OpenAIR (CC-BY 4.0) より。出典は [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/indra/newview/app_settings/venue_ir/CREDITS.md)。
+
+## ダウンロード
+
+_3 OS ビルド完了後、@mayatonton が記入します。_
+
+- Windows Installer: _TBD_
+- macOS Installer: _TBD_
+- Linux Installer: _TBD_
+
+## Contributer
+
+@t-noami @mayatonton

--- a/docs/ayastorm-r23-github-release-page.zh.md
+++ b/docs/ayastorm-r23-github-release-page.zh.md
@@ -1,0 +1,72 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-github-release-page.zh.md)
+
+# AYAstorm r23 — Parcel-bound 3D stream + 视觉真实感章 (r14–r20) + 基于 tag 的 OBB 遮蔽 + GPU self-rigged picker + chat 标签拆分
+
+从 r12.1 直接跳到 r23, 一并打包 11 个 release (r13〜r23) 至此 tag。各 release 的详细请参考 repo 内的语言别 release note (tag pin 的 permalink — 后续 docs 更新也不会断链)。
+
+## Release notes (各 release × 语言)
+
+### 音响章 close-out
+- **r13** — 基于 tag 的 OBB 遮蔽 (音响章旗舰): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-release-note.zh.md)
+- **r23** — Parcel-bound 3D stream (本 tag 的主功能): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-release-note.zh.md)
+
+### 视觉真实感章 (r14–r20)
+- **r14** — Volumetric atmosphere (章节开幕、`AYAVisualRealismEnabled` master switch): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-release-note.zh.md)
+- **r15** — Godrays: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-release-note.zh.md)
+- **r16** — Aerial perspective (Rayleigh λ⁻⁴ 波长依存 haze): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-release-note.zh.md)
+- **r17** — 时间带色温 (Kelvin 曲线、夕烧暖色): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-release-note.zh.md)
+- **r18** — Cloud volumetric + 色温联动 (A 轴完走): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-release-note.zh.md)
+- **r19** — Translucency (薄物透过、B 轴入口): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-release-note.zh.md)
+- **r20** — Avatar 皮肤 SSS (B 轴完走、右键学习): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-release-note.zh.md)
+
+### Chat UX & picker
+- **r21** — GPU self-rigged picker: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-release-note.zh.md)
+- **r22** — Chat 标签拆分 (Human vs System & Object): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-release-note.zh.md)
+
+## 主要文档 (tag pin)
+
+### 音响章
+- r13 OBB occlusion spec: [docs/ayastorm-r13-occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r13-occlusion.md) / [doc/spec_obb_occlusion.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_obb_occlusion.md)
+- r23 parcel-bound 3D stream spec: [docs/ayastorm-r23-parcel-bound-3d-stream.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r23-parcel-bound-3d-stream.md)
+- 累积 3D stream tag 指南 (r6 以降): [doc/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/3dstream-tag-guide.zh.md)
+
+### 视觉真实感章
+- 视觉真实感章路线图 (A/B 轴 overview): [docs/ayastorm-visual-realism-roadmap.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-visual-realism-roadmap.md)
+- r14 volumetric atmosphere spec: [docs/ayastorm-r14-volumetric-atmosphere.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r14-volumetric-atmosphere.md)
+- r15 godrays spec: [docs/ayastorm-r15-godrays.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r15-godrays.md)
+- r16 aerial perspective spec: [docs/ayastorm-r16-aerial-perspective.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r16-aerial-perspective.md)
+- r17 color temperature spec: [docs/ayastorm-r17-color-temperature.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r17-color-temperature.md)
+- r18 cloud volumetric spec: [docs/ayastorm-r18-cloud-volumetric.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r18-cloud-volumetric.md)
+- r19 translucency spec: [docs/ayastorm-r19-translucency.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r19-translucency.md)
+- r20 avatar skin SSS spec: [docs/ayastorm-r20-avatar-skin-sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r20-avatar-skin-sss.md) / [doc/spec_avatar_skin_sss.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/doc/spec_avatar_skin_sss.md)
+- Deferred shader routing 参考: [docs/ayastorm-deferred-shader-routing.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-deferred-shader-routing.md)
+
+### Chat UX & picker
+- r21 GPU self-rigged picker spec: [docs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r21-self-rigged-picker.md)
+- r22 chat 标签拆分 spec: [docs/ayastorm-r22-chat-tab-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/docs/ayastorm-r22-chat-tab-spec.md)
+
+## 与既有环境的兼容性
+
+全部功能在不破坏 r12.1 环境的前提下出货:
+
+- **r23 parcel-bound 3D stream**: 未立 `PARCEL_FLAG_SOUND_LOCAL` 的配信者无变化。立有 SOUND_LOCAL ON 的 parcel 现在会正确停止漏到邻接 parcel — 这与 gesture / object sound 一直以来的行为一致。
+- **r14〜r20 视觉真实感**: master switch `AYAVisualRealismEnabled` (default ON)。设为 OFF 即可回到 r12.1 的视觉基准。
+- **r21 self-rigged picker**: GPU object-ID buffer 替换 CPU self-rigged picker。无需设置, macOS 用 kill-switch `FSSelfRiggedPickerGPU` 保留。
+- **r22 chat 标签拆分**: 既有 Nearby Chat / IM history 保持不变, Human / System & Object 标签各自有未读徽章。Nearby Chat default ON, IM default off (用户反馈反映)。
+- **r13 OBB occlusion**: 通过 build tag 配信者 opt-in, listener 侧除非 venue 立了 tag 否则无变化。
+
+## IR 许可
+
+r11 同捆的 venue IR (现在仍在出货) 来自 OpenAIR (CC-BY 4.0)。来源参见 [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r23/indra/newview/app_settings/venue_ir/CREDITS.md)。
+
+## 下载
+
+_3 OS 构建完成后, @mayatonton 填写。_
+
+- Windows Installer: _TBD_
+- macOS Installer: _TBD_
+- Linux Installer: _TBD_
+
+## Contributer
+
+@t-noami @mayatonton

--- a/docs/ayastorm-r23-parcel-bound-3d-stream.md
+++ b/docs/ayastorm-r23-parcel-bound-3d-stream.md
@@ -1,8 +1,8 @@
 # AYAstorm r23 — Parcel-bound 3D stream 仕様 (draft)
 
 **作成日**: 2026-05-16
-**最終更新**: 2026-05-16 (M3 / M4 完了)
-**ステータス**: M1〜M4 完了、M5 (Release) 着手前
+**最終更新**: 2026-05-16 (M5 release notes 完成、tag 切り前)
+**ステータス**: M1〜M5 release notes 完成、release tag 待ち
 **対象ブランチ**: `feat/ayastorm-r23-parcel-bound-3d-stream`
 
 このドキュメントは r23 で実装予定の「AYAstorm 3D stream を SL の parcel "Restrict gestures and object sounds to this parcel" フラグに連動させる」機能の仕様 draft。AYA との対話で順次確定していく。
@@ -181,4 +181,4 @@ precedent: `LLAudioSourceVO::updateMute()` (object sound) も canHearSound を�
 | M2 | 実装 — `LLPositionalStreamMgr` に `canHearSound()` フック追加 | ✅ 完了 (commit `673ca4ae9c`、Linux ビルド PASS) |
 | M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | ✅ 完了 (2026-05-16、全項目 PASS) |
 | M4 | 3 OS ビルド (Linux → Win → Mac) | ✅ 完了 (2026-05-16、3 OS ビルド + 動作確認 PASS) |
-| M5 | Release — spec doc 更新、release note 3 言語、tag | ⏳ 着手前 |
+| M5 | Release — spec doc 更新、release note 3 言語、tag | ✅ release notes 完成 (r14/r16-r20/r23 × en/ja/zh 計 21 + bundle release page × en/ja/zh 計 3)、tag 切りは AYA 手動 |

--- a/docs/ayastorm-r23-parcel-bound-3d-stream.md
+++ b/docs/ayastorm-r23-parcel-bound-3d-stream.md
@@ -64,9 +64,22 @@ mute の実装は FMOD channel の `volume` を 0 にする (paused にしない
 - paused だと再開時にクリックノイズ / 再シーク必要のリスク
 - per-channel 別判定モデルは音像が「片寄せ」になって不自然なので **採用しない** (M1 確定)
 
-### 3.3 評価頻度
+### 3.3 評価頻度 — 2 tier モデル
 
-avatar の `parcel_change` シグナル + 配信者の position 変化通知で **逐次再評価**。毎フレーム回さない (gesture/object sound と同じ流儀)。
+**Tier 1: 据置 stream (大多数、source 位置が静止)**
+- `LLAgent::addParcelChangedCallback` シグナルでだけ再評価
+- avatar が parcel を跨いだ瞬間に走り、それ以外は完全に静止
+- source 位置が動かないので source 側の監視は不要 → 平時の per-frame コストはゼロ
+
+**Tier 2: 装着 stream (稀、source 位置 = 装着 avatar 位置)**
+- binding 構築時に `LLViewerObject::isAttachment()` で判定し、attachment フラグを binding に立てる
+- attachment フラグが立っている binding に限り `update()` (per-frame) で `canHearSound()` 再評価
+- 装着 stream が無い場面では Tier 2 ループ自体が走らない
+- 装着 stream が一部存在する場面でも、追加コストは「装着 binding 数 × 1 query × 60 fps」で十分に安い
+
+判定結果が変わったときだけ `setVolume()` を呼ぶ idempotent ガードを入れることで、FMOD への無駄な API call を抑える。
+
+precedent: `LLAudioSourceVO::updateMute()` (object sound) も canHearSound を毎 audio tick で評価しているが、3D stream は据置が大多数なので Tier 分離して負荷を最小化する。
 
 ---
 

--- a/docs/ayastorm-r23-parcel-bound-3d-stream.md
+++ b/docs/ayastorm-r23-parcel-bound-3d-stream.md
@@ -1,8 +1,8 @@
 # AYAstorm r23 — Parcel-bound 3D stream 仕様 (draft)
 
 **作成日**: 2026-05-16
-**最終更新**: 2026-05-16 (M2 実装完了)
-**ステータス**: M1 / M2 完了、Linux 単 OS ビルド PASS、M3 受入テストは舞台準備待ち
+**最終更新**: 2026-05-16 (M3 / M4 完了)
+**ステータス**: M1〜M4 完了、M5 (Release) 着手前
 **対象ブランチ**: `feat/ayastorm-r23-parcel-bound-3d-stream`
 
 このドキュメントは r23 で実装予定の「AYAstorm 3D stream を SL の parcel "Restrict gestures and object sounds to this parcel" フラグに連動させる」機能の仕様 draft。AYA との対話で順次確定していく。
@@ -136,17 +136,17 @@ precedent: `LLAudioSourceVO::updateMute()` (object sound) も canHearSound を�
 
 ---
 
-## 7. 受入基準 (実装後の予定)
+## 7. 受入基準
 
-- [ ] 配信 parcel が SOUND_LOCAL=on、隣接 parcel に居る listener → 3D stream が聞こえない
-- [ ] 配信 parcel が SOUND_LOCAL=on、同一 parcel 内の listener → 普通に聞こえる
-- [ ] listener parcel が SOUND_LOCAL=on、隣接 parcel の 3D stream → 聞こえない
-- [ ] どちらの parcel も SOUND_LOCAL=off → 従来通り聞こえる
-- [ ] parcel 境界を跨いで walk すると mute / unmute が滑らかに切り替わる (クリックノイズなし)
-- [ ] 5.1ch 配置で speaker が parcel boundary を跨いでいても、判定は配信タグ prim 1 点で完結し全 ch 一律
-- [ ] region 跨ぎ TP 直後に正しい mute 状態が反映される
-- [ ] venue reverb の tail が残っていても本体 mute と整合 (tail 単独で残り続けない)
-- [ ] 3 OS (Linux / Win / Mac) でビルド通過
+- [x] 配信 parcel が SOUND_LOCAL=on、隣接 parcel に居る listener → 3D stream が聞こえない
+- [x] 配信 parcel が SOUND_LOCAL=on、同一 parcel 内の listener → 普通に聞こえる
+- [x] listener parcel が SOUND_LOCAL=on、隣接 parcel の 3D stream → 聞こえない
+- [x] どちらの parcel も SOUND_LOCAL=off → 従来通り聞こえる
+- [x] parcel 境界を跨いで walk すると mute / unmute が滑らかに切り替わる (クリックノイズなし)
+- [x] 5.1ch 配置で speaker が parcel boundary を跨いでいても、判定は配信タグ prim 1 点で完結し全 ch 一律
+- [x] region 跨ぎ TP 直後に正しい mute 状態が反映される
+- [x] venue reverb の tail が残っていても本体 mute と整合 (tail 単独で残り続けない)
+- [x] 3 OS (Linux / Win / Mac) でビルド通過 + 動作確認
 
 ---
 
@@ -179,6 +179,6 @@ precedent: `LLAudioSourceVO::updateMute()` (object sound) も canHearSound を�
 |---|---|---|
 | M1 | 仕様確定 + 構造調査 + escape hatch 方針確定 | ✅ 確定 (追加機能なし、SL parcel 規約準拠を default) |
 | M2 | 実装 — `LLPositionalStreamMgr` に `canHearSound()` フック追加 | ✅ 完了 (commit `673ca4ae9c`、Linux ビルド PASS) |
-| M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | ⏳ 舞台 (隣接 parcel × SOUND_LOCAL on/off) 準備待ち |
-| M4 | 3 OS ビルド (Linux → Win → Mac) | Linux のみ PASS、Win/Mac は M3 後 |
-| M5 | Release — spec doc 更新、release note 3 言語、tag | — |
+| M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | ✅ 完了 (2026-05-16、全項目 PASS) |
+| M4 | 3 OS ビルド (Linux → Win → Mac) | ✅ 完了 (2026-05-16、3 OS ビルド + 動作確認 PASS) |
+| M5 | Release — spec doc 更新、release note 3 言語、tag | ⏳ 着手前 |

--- a/docs/ayastorm-r23-parcel-bound-3d-stream.md
+++ b/docs/ayastorm-r23-parcel-bound-3d-stream.md
@@ -1,0 +1,171 @@
+# AYAstorm r23 — Parcel-bound 3D stream 仕様 (draft)
+
+**作成日**: 2026-05-16
+**最終更新**: 2026-05-16 (M1 確定)
+**ステータス**: M1 確定、M2 実装着手前
+**対象ブランチ**: `feat/ayastorm-r23-parcel-bound-3d-stream`
+
+このドキュメントは r23 で実装予定の「AYAstorm 3D stream を SL の parcel "Restrict gestures and object sounds to this parcel" フラグに連動させる」機能の仕様 draft。AYA との対話で順次確定していく。
+
+---
+
+## 1. 狙い
+
+AYAstorm の 3D stream (positional / distributed-stereo / 5.1ch placement / venue reverb / binaural — r6 系列以降) が **隣接 parcel まで無条件で漏れて聞こえる** 現状を解消する。
+
+SL の vanilla flow では gesture / object sound / parcel music は **送出 parcel 側 or 受信 parcel 側のいずれかが `PARCEL_FLAG_SOUND_LOCAL` (UI 上は "Restrict gestures and object sounds to this parcel") を立てている時、parcel boundary を越えて聞こえなくなる** という規約がある。3D stream はこの規約から外れているため、配信を仕込んだ parcel の外でも音が届いてしまい、近隣区画の体験を侵害する。
+
+r23 は 3D stream をこの SL 既存規約に "素直に乗せる" 拡張。
+
+---
+
+## 2. スコープ
+
+| 項目 | 対象 / 対象外 |
+|---|---|
+| AYAstorm 3D positional stream (r6+) | ✅ 対象 |
+| 5.1ch placement (r10) | ✅ 対象 (source 1 点で判定、全 ch 一律) |
+| distributed stereo (r8) の N 拠点 | ✅ 対象 (拠点ごとに source 1 点で判定) |
+| venue reverb (r11) | ✅ stream 本体が mute されたら reverb tail も自然に消える |
+| binaural / HRTF (r11) | ✅ 上位 mute が効くので追加対応不要 |
+| 非 positional な parcel music (SL vanilla URL ストリーム) | ❌ 対象外 (sim 側で既に parcel boundary を尊重) |
+| voice chat | ❌ 対象外 |
+| gesture / object sound | ❌ 対象外 (既に vanilla で対応済み) |
+
+---
+
+## 3. 確定方針 (M1 仮)
+
+### 3.1 リスナー側 parcel 判定モデルを採用
+
+SL の `LLViewerParcelMgr::canHearSound(pos_global)` を **そのまま** 3D stream channel にも適用する。
+
+`canHearSound()` の判定ロジック (既存):
+1. listener (agent) と source の position が **同じ parcel** → 聞こえる
+2. 違う parcel で agent parcel が `SOUND_LOCAL` → 聞こえない
+3. 違う parcel で source parcel が `SOUND_LOCAL` → 聞こえない
+4. それ以外 → 聞こえる
+
+→ 配信者主導タグ (r11 流儀) を新規追加せず、**parcel フラグそのものを root truth** として扱う。SL の既存規約と 100% 一致するので、ユーザーの直感に合致。
+
+### 3.2 mute の実装単位 — source 1 点で判定、全 ch 一律
+
+判定は **配信タグ prim (3D stream の root) の position 1 点** で `canHearSound()` を呼ぶ。結果を 5.1ch / distributed stereo の **全 channel に一律適用** する (全鳴る or 全 mute)。
+
+per-channel position はあくまで **音像 (空間音響)** のためのもので、parcel 規約判定には使わない。たとえば 5.1ch の FR speaker が物理的に隣 parcel にはみ出ていても、parcel 判定そのものは配信タグ prim 位置で完結する:
+
+- 配信者 parcel 内の listener → 全 ch 聞こえる (FR の音像が隣 parcel 方向から聞こえても OK)
+- 隣 parcel の listener → 全 ch mute (はみ出た FR が物理的にすぐ近くにあっても mute)
+
+mute の実装は FMOD channel の `volume` を 0 にする (paused にしない)。
+
+理由:
+- volume=0 は channel position / spatial attenuation の計算を続けるので、parcel boundary を跨いだ瞬間に滑らかに復帰
+- paused だと再開時にクリックノイズ / 再シーク必要のリスク
+- per-channel 別判定モデルは音像が「片寄せ」になって不自然なので **採用しない** (M1 確定)
+
+### 3.3 評価頻度
+
+avatar の `parcel_change` シグナル + 配信者の position 変化通知で **逐次再評価**。毎フレーム回さない (gesture/object sound と同じ流儀)。
+
+---
+
+## 4. 判定境界
+
+| ケース | 例 | 振る舞い |
+|---|---|---|
+| 同一 parcel 内 | 配信タグの prim と listener が同じ区画 | 聞こえる (現状維持) |
+| 隣接 parcel・どちらも non-SOUND_LOCAL | 公共音楽イベント | 聞こえる (現状維持) |
+| 隣接 parcel・source parcel が SOUND_LOCAL | 個室 DJ が囲い込み設定 | **聞こえない (new)** |
+| 隣接 parcel・listener parcel が SOUND_LOCAL | 静寂を求めて自宅区画に隔離設定 | **聞こえない (new)** |
+| 5.1ch の一部 channel が parcel 境界をはみ出た | 配置失敗 / 境界跨ぎ | **判定は配信タグ prim 1 点で完結、speaker 位置は無関係** (全鳴る or 全 mute) |
+| 装着 stream を持つ avatar が parcel A→B を walk | 装着型 3D stream の移動 | source position が avatar に追従、跨いだ瞬間に新 parcel の SOUND_LOCAL 設定で再判定。装着者自身は常に same parcel なので聞こえ続ける、周囲は装着者と同 parcel の listener だけ聞こえる |
+| 配信者が region 跨ぎ移動 | TP / fly | 移動直後の reevaluation で正しい状態に |
+
+---
+
+## 5. データ層
+
+### 5.1 source position の取得
+
+判定には **配信タグ prim (3D stream の root) の position** を使う。per-channel position は使わない (§3.2 参照)。
+
+- `LLPositionalStreamMgr` (or 同等) が保持する stream の root position
+- parcel フラグは sim から `LLViewerRegion::mParcelOverlay` 経由で取得 (既に viewer cache されている)
+
+### 5.2 listener position
+
+`gAgent.getPositionGlobal()` で取得。`canHearSound()` は内部で `inAgentParcel()` 経由で listener parcel を解決するので、追加実装不要。
+
+---
+
+## 6. 実装スケッチ
+
+### 6.1 影響ファイル (現時点の想定)
+
+- `indra/newview/llpositionalstreammgr.cpp` / `.h` — 3D stream channel の volume 更新 hook に `canHearSound()` チェック追加
+- `indra/newview/llviewerparcelmgr.h` (既存)、`llparcel.h` (既存) — 追加変更なし、API を利用するのみ
+- 設定追加なし (§8 で確定)。SL parcel 規約準拠が default 動作、escape hatch cvar も逆タグも入れない
+
+### 6.2 既存の参考パターン (viewer 内)
+
+- `LLViewerParcelMgr::canHearSound()` — 同一の判定ロジックは既に gesture / object sound / 一部 attached sound で使用されている
+- 配信者主導タグでなく parcel flag 直読の前例として、`llvoiceclient` の voice cutoff も類似の sim-truth フォロー
+
+### 6.3 構造調査メモ (2026-05-16 時点)
+
+- `LLViewerParcelMgr::canHearSound(LLVector3d pos_global)` 既存 (`llviewerparcelmgr.cpp:843`)
+- `LLParcel::getSoundLocal()` 既存 (`llparcel.h:477`)
+- `LLViewerParcelOverlay::isSoundLocal(pos_region)` 既存
+- 3D stream channel の position 管理は r10 で per-channel 化済み (`project_ayastorm_r10_5_1ch_placement.md` 参照)
+
+→ **viewer 単独実装、sim 変更なし、新しい LSL タグ不要**
+
+---
+
+## 7. 受入基準 (実装後の予定)
+
+- [ ] 配信 parcel が SOUND_LOCAL=on、隣接 parcel に居る listener → 3D stream が聞こえない
+- [ ] 配信 parcel が SOUND_LOCAL=on、同一 parcel 内の listener → 普通に聞こえる
+- [ ] listener parcel が SOUND_LOCAL=on、隣接 parcel の 3D stream → 聞こえない
+- [ ] どちらの parcel も SOUND_LOCAL=off → 従来通り聞こえる
+- [ ] parcel 境界を跨いで walk すると mute / unmute が滑らかに切り替わる (クリックノイズなし)
+- [ ] 5.1ch 配置で speaker が parcel boundary を跨いでいても、判定は配信タグ prim 1 点で完結し全 ch 一律
+- [ ] region 跨ぎ TP 直後に正しい mute 状態が反映される
+- [ ] venue reverb の tail が残っていても本体 mute と整合 (tail 単独で残り続けない)
+- [ ] 3 OS (Linux / Win / Mac) でビルド通過
+
+---
+
+## 8. 残る未確定論点
+
+すべて M1 で「追加機能なし」で確定。SL parcel 規約準拠を default 動作とし、cvar / 逆タグ / tail 制御は一切追加しない。
+
+| 論点 | 優先 | 対処タイミング | 状況 |
+|---|---|---|---|
+| ~~escape hatch cvar (`FSParcelBoundStream3D` 等) を入れるか~~ | — | — | ✅ **なし**で確定。SL parcel 規約準拠を default 動作にする、cvar 追加しない |
+| ~~配信者主導タグで「parcel フラグ無視して global broadcast」する逆 escape hatch~~ | — | — | ✅ **なし**で確定。global broadcast したい配信者は parcel SOUND_LOCAL を off にすれば足りる (SL 既存規約と一致) |
+| ~~5.1ch 配置 で channel 単位 mute が「片寄せ感」で違和感を生まないか~~ | — | — | ✅ §3.2 で source 1 点判定に確定、論点消滅 |
+| ~~venue reverb tail の打ち切りタイミング~~ | — | — | ✅ **追加対応なし**で確定。本体 mute で reverb 入力が止まり tail は自然減衰する、M2 実装中に挙動確認のみ |
+
+---
+
+## 9. リスク登録
+
+| リスク | 影響 | 対策 |
+|---|---|---|
+| `canHearSound()` の per-frame コール頻度が高すぎる | 低 | `parcel_change` シグナルベース更新で抑制 |
+| parcel overlay cache が region 跨ぎ直後に未到着の状態で判定 | 中 | overlay が無い時は "聞こえる" にフォールバック (`canHearSound()` の既存挙動) |
+| 既存配信者が「俺の音が止まった」と困惑 | 中 | release note で「SL parcel 規約 (gesture/object sound と同等) に従うよう拡張、global broadcast したい場合は parcel の SOUND_LOCAL を off に」と明記 |
+
+---
+
+## 10. マイルストーン
+
+| M | 内容 | ステータス |
+|---|---|---|
+| M1 | 仕様確定 + 構造調査 + escape hatch 方針確定 | ✅ 確定 (追加機能なし、SL parcel 規約準拠を default) |
+| M2 | 実装 — `LLPositionalStreamMgr` に `canHearSound()` フック追加 | ⏳ 次着手 |
+| M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | — |
+| M4 | 3 OS ビルド (Linux → Win → Mac) | — |
+| M5 | Release — spec doc 更新、release note 3 言語、tag | — |

--- a/docs/ayastorm-r23-parcel-bound-3d-stream.md
+++ b/docs/ayastorm-r23-parcel-bound-3d-stream.md
@@ -1,8 +1,8 @@
 # AYAstorm r23 — Parcel-bound 3D stream 仕様 (draft)
 
 **作成日**: 2026-05-16
-**最終更新**: 2026-05-16 (M1 確定)
-**ステータス**: M1 確定、M2 実装着手前
+**最終更新**: 2026-05-16 (M2 実装完了)
+**ステータス**: M1 / M2 完了、Linux 単 OS ビルド PASS、M3 受入テストは舞台準備待ち
 **対象ブランチ**: `feat/ayastorm-r23-parcel-bound-3d-stream`
 
 このドキュメントは r23 で実装予定の「AYAstorm 3D stream を SL の parcel "Restrict gestures and object sounds to this parcel" フラグに連動させる」機能の仕様 draft。AYA との対話で順次確定していく。
@@ -178,7 +178,7 @@ precedent: `LLAudioSourceVO::updateMute()` (object sound) も canHearSound を�
 | M | 内容 | ステータス |
 |---|---|---|
 | M1 | 仕様確定 + 構造調査 + escape hatch 方針確定 | ✅ 確定 (追加機能なし、SL parcel 規約準拠を default) |
-| M2 | 実装 — `LLPositionalStreamMgr` に `canHearSound()` フック追加 | ⏳ 次着手 |
-| M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | — |
-| M4 | 3 OS ビルド (Linux → Win → Mac) | — |
+| M2 | 実装 — `LLPositionalStreamMgr` に `canHearSound()` フック追加 | ✅ 完了 (commit `673ca4ae9c`、Linux ビルド PASS) |
+| M3 | 受入テスト — 同一/隣接 parcel、装着 stream の parcel 跨ぎ移動、region 跨ぎ TP | ⏳ 舞台 (隣接 parcel × SOUND_LOCAL on/off) 準備待ち |
+| M4 | 3 OS ビルド (Linux → Win → Mac) | Linux のみ PASS、Win/Mac は M3 後 |
 | M5 | Release — spec doc 更新、release note 3 言語、tag | — |

--- a/docs/ayastorm-r23-release-note.en.md
+++ b/docs/ayastorm-r23-release-note.en.md
@@ -1,0 +1,82 @@
+# AYAstorm r23 — Release Announcement
+
+GitHub release page copy. **r23 brings AYAstorm 3D stream (positional / 5.1ch / distributed-stereo / binaural — r6 onward) into compliance with SL's `PARCEL_FLAG_SOUND_LOCAL` boundary**, the same rule gestures and object sounds have always followed. No new cvar, no inverse tag — the parcel flag itself is the source of truth.
+
+> **Distribution**: r23 ships as the headline feature of the r13–r23 bundle tag. Other release notes for the bundled releases are linked directly from the GitHub Release page.
+
+Implementation details / known limits / configuration reference live in the permanent spec (`docs/ayastorm-r23-parcel-bound-3d-stream.md`). This note is the entry point and diff highlight.
+
+---
+
+## AYAstorm r23 — Parcel-bound 3D stream
+
+### Headline: 3D streams now stop at the parcel boundary, the way SL has always intended
+
+Through r22, AYAstorm's 3D stream (positional / distributed-stereo / 5.1ch placement / venue reverb / binaural — r6 onward) could be heard **across parcel boundaries unconditionally**. SL's vanilla flow for gestures, object sounds, and parcel music already respects `PARCEL_FLAG_SOUND_LOCAL` ("Restrict gestures and object sounds to this parcel") on either the source or listener parcel. 3D stream was an exception — and that exception was a problem for streamers running events while not wanting to spill into neighbouring parcels.
+
+r23 brings 3D stream onto the same rule. No new cvar, no streamer-side opt-in tag, no escape hatch — the parcel flag itself is the source of truth, matching what listeners already expect from gesture and object sound behaviour.
+
+### How it works
+
+A single call to `LLViewerParcelMgr::canHearSound(pos_global)` is added to the 3D stream channel's volume-update hook. Behaviour:
+
+1. Listener and source in the **same parcel** → audible (unchanged)
+2. Different parcels, **agent parcel** has SOUND_LOCAL → muted
+3. Different parcels, **source parcel** has SOUND_LOCAL → muted
+4. Otherwise → audible (unchanged)
+
+This is the **same logic** SL already uses for gestures, object sounds, and some attached sounds — we're not inventing a new rule, just bringing 3D stream into compliance.
+
+### Per-channel position vs source position
+
+For 5.1ch placement and distributed-stereo (r8–r10), each FMOD channel has its own spatial position — but **parcel judgment uses one point: the 3D stream root prim's position**. The result applies uniformly to every channel (all play or all mute).
+
+- Listener inside source parcel → all channels audible, even if a 5.1 FR speaker's spatial position physically extends into a neighbour parcel
+- Listener in neighbour parcel → all channels muted, even if a spatial FR position is near the listener
+
+Per-channel parcel judgment would create a "lopsided audio image" effect that's musically unpleasant, so it's intentionally not adopted (spec §3.2).
+
+### Mute strategy: volume=0, not paused
+
+The mute is implemented by `setVolume(0)` rather than pausing the FMOD channel. This:
+- Keeps channel position / spatial attenuation calculations running, so re-entering the parcel resumes smoothly
+- Avoids the click-noise / re-seek risk of pause/resume
+- Lets `parcel_change` signals do the heavy lifting (with an idempotent guard so FMOD isn't called when state hasn't changed)
+
+### Two-tier evaluation cadence
+
+**Tier 1 (stationary sources, the majority)**: only re-evaluated on `LLAgent::addParcelChangedCallback` — fires when the avatar crosses a parcel line. Per-frame cost is zero.
+
+**Tier 2 (worn streams, where source position = wearer position)**: `LLViewerObject::isAttachment()` flag in the binding triggers per-frame `canHearSound()` evaluation. The Tier 2 loop only runs when worn streams exist; even then, "1 query × 60fps × few attachments" is cheap.
+
+### Settings
+
+**Intentionally none.** No new cvar is introduced.
+
+- An escape-hatch cvar (e.g. "FSParcelBoundStream3D") would let streamers bypass the rule, but that defeats the point of conforming to parcel regulation
+- A streamer-side inverse tag (e.g. "ignore parcel boundary") would also bypass the rule and require everyone to be aware of it
+- Streamers who want global broadcast can simply leave their parcel's SOUND_LOCAL off — exactly the SL native pathway
+
+### Migration note for streamers
+
+If you're a streamer using AYAstorm 3D stream and your event setup currently relies on neighbour-parcel listeners hearing you:
+
+- The default parcel flag is **off** — if you haven't enabled SOUND_LOCAL, **nothing changes** for you
+- If you have enabled SOUND_LOCAL on your parcel, neighbour-parcel listeners will now correctly stop hearing the stream — this matches what SL has always done for gestures and object sounds, the 3D stream was simply an unintentional exception
+
+### Known limitations
+
+- **Region-crossing TP**: state is correctly reapplied immediately after the parcel-changed signal fires for the new region. Brief audible window during very fast crossings is possible but bounded.
+- **Worn stream walking out of parcel**: the wearer themselves stays in the same parcel as the source (always audible). Bystanders only hear the wearer while in the same parcel as the wearer.
+- **Venue reverb tail**: when the main stream mutes, reverb input stops; the tail decays naturally. No special handling needed.
+
+### Implementation summary
+
+- `llpositionalstreammgr.cpp` / `.h` — volume-update hook now calls `canHearSound()`
+- No new cvar, no new uniform, no UI changes
+- 3 OS (Linux / macOS / Windows) build + verification passed
+
+### Documentation
+
+- r23 full spec / source position / two-tier evaluation / risk register: `docs/ayastorm-r23-parcel-bound-3d-stream.md`
+- Prior 3D stream releases (r6–r12, listener bindings): see in-tree spec docs and prior release notes (r10 5.1ch placement, r11 binaural + venue reverb, etc.)

--- a/docs/ayastorm-r23-release-note.ja.md
+++ b/docs/ayastorm-r23-release-note.ja.md
@@ -1,0 +1,82 @@
+# AYAstorm r23 — リリース告知
+
+GitHub release ページ貼り付け用の文案。**r23 は AYAstorm の 3D stream (positional / 5.1ch / distributed-stereo / binaural — r6 系列以降) を SL の `PARCEL_FLAG_SOUND_LOCAL` 境界に準拠させるリリース** — gesture / object sound と同じ規約。新規 cvar なし、逆向きタグなし、parcel フラグそのものが root truth。
+
+> **配信形態**: r23 は r13〜r23 を一括配信するタグの主機能として出荷されます。同梱される他リリースの release note は GitHub Release ページから直接リンクされます。
+
+実装・既知 limits・設定の詳細は永続資料 (`docs/ayastorm-r23-parcel-bound-3d-stream.md`) に常駐させ、本ノートはそこへの誘導と差分ハイライトに徹します。
+
+---
+
+## AYAstorm r23 — Parcel-bound 3D stream
+
+### r23 の柱: 3D stream を SL の parcel 規約に乗せる
+
+r22 までは AYAstorm の 3D stream (positional / distributed-stereo / 5.1ch placement / venue reverb / binaural — r6 系列以降) が **隣接 parcel まで無条件で漏れる** 状態でした。SL の vanilla flow では gesture / object sound / parcel music は送出 / 受信 parcel いずれかが `PARCEL_FLAG_SOUND_LOCAL` ("Restrict gestures and object sounds to this parcel") を立てている時、parcel boundary を越えて聞こえない規約があります。3D stream はこの規約から外れていたため、配信を仕込んだ parcel の外でも音が届いてしまい、近隣区画の体験を侵害していました。
+
+r23 は 3D stream をこの SL 既存規約に **素直に乗せる** だけ。新規 cvar なし、配信者側の opt-in タグなし、escape hatch なし — parcel フラグそのものが root truth、gesture / object sound と同じ。
+
+### 仕組み
+
+3D stream channel の volume update hook に `LLViewerParcelMgr::canHearSound(pos_global)` を 1 行追加。挙動:
+
+1. listener と source が **同一 parcel** → 聞こえる (現状維持)
+2. 違う parcel で **agent parcel** が SOUND_LOCAL → mute
+3. 違う parcel で **source parcel** が SOUND_LOCAL → mute
+4. それ以外 → 聞こえる (現状維持)
+
+これは SL が gesture / object sound / 一部の attached sound で既に使っている **同一ロジック** — 新しい規約を発明したわけではなく、3D stream を既存規約に compliance させただけ。
+
+### per-channel position vs source position
+
+5.1ch placement / distributed-stereo (r8〜r10) では各 FMOD channel に固有の spatial position がありますが、**parcel 判定は 1 点 = 3D stream root prim の position** で完結し、結果を全 channel に一律適用 (全鳴る or 全 mute)。
+
+- 配信者 parcel 内の listener → 全 ch 聞こえる (5.1 FR speaker の音像が物理的に隣 parcel にはみ出ていても OK)
+- 隣 parcel の listener → 全 ch mute (はみ出た FR の音像が物理的にすぐ近くにあっても mute)
+
+per-channel parcel 判定は「片寄せ」な音像になり musically 不自然なので、意図的に採用しません (spec §3.2)。
+
+### mute 方式: volume=0 (paused にしない)
+
+mute は FMOD channel の `setVolume(0)` で実装。理由:
+- volume=0 は channel position / spatial attenuation の計算を継続するので、parcel 復帰時に滑らかに戻る
+- paused だと再開時のクリックノイズ / 再シーク必要のリスク
+- `parcel_change` シグナル + idempotent guard (状態未変化時は FMOD コール抑制) で「無駄な API call」も防ぐ
+
+### 2 tier 評価モデル
+
+**Tier 1 (据置 stream、大多数)**: `LLAgent::addParcelChangedCallback` でだけ再評価。avatar が parcel を跨いだ瞬間に走る。per-frame コストはゼロ。
+
+**Tier 2 (装着 stream、稀)**: binding 構築時に `LLViewerObject::isAttachment()` でフラグを立て、attachment 付き binding のみ per-frame で `canHearSound()` を再評価。装着 stream が無い場面では Tier 2 ループ自体が走らない。あっても「装着 binding 数 × 1 query × 60 fps」で十分に安い。
+
+### 設定
+
+**意図的にゼロ。** 新 cvar を追加していません。
+
+- escape-hatch cvar (例: "FSParcelBoundStream3D") は配信者が規約を bypass する穴になるため、不採用
+- 配信者側の逆向きタグ (例: "parcel boundary 無視") も同様の穴になり、関係者全員の認識が必要になるため不採用
+- global broadcast したい配信者は parcel の SOUND_LOCAL を off にすれば足ります — これは SL 既存の native pathway そのもの
+
+### 配信者向け移行ノート
+
+AYAstorm 3D stream で配信していて、隣接 parcel の listener にも聞こえることを前提に運用している場合:
+
+- parcel フラグの default は **off** — SOUND_LOCAL を立てていない配信者は **何も変わりません**
+- parcel に SOUND_LOCAL を立てている配信者は、隣接 parcel の listener には聞こえなくなります — これは SL が gesture / object sound で常に行ってきた挙動と一致し、3D stream は単に意図せず例外になっていただけ
+
+### 既知の制約
+
+- **region 跨ぎ TP**: 新 region の parcel-changed signal 直後に正しい状態が再適用されます。極めて高速な跨ぎでは短い再生窓が出る可能性があるが有界
+- **装着 stream が parcel を跨いで歩く**: 装着者自身は常に source と same parcel (常時聞こえる)。周囲は装着者と同 parcel の listener のみ聞こえる
+- **Venue reverb tail**: 本体 mute で reverb 入力が止まり、tail は自然減衰。特別な対応は不要
+
+### 実装概要
+
+- `llpositionalstreammgr.cpp` / `.h` — volume update hook に `canHearSound()` 1 行追加
+- 新 cvar なし、新 uniform なし、UI 変更なし
+- 3 OS (Linux / macOS / Windows) ビルド + 動作確認 PASS
+
+### ドキュメント
+
+- r23 full spec / source position / 2 tier evaluation / リスク登録: `docs/ayastorm-r23-parcel-bound-3d-stream.md`
+- 過去の 3D stream リリース (r6〜r12、listener binding 含む): in-tree spec doc および過去 release note (r10 5.1ch placement、r11 binaural + venue reverb 等) 参照

--- a/docs/ayastorm-r23-release-note.zh.md
+++ b/docs/ayastorm-r23-release-note.zh.md
@@ -1,0 +1,82 @@
+# AYAstorm r23 — 发布公告
+
+用于粘贴到 GitHub release 页面的简短文案。**r23 把 AYAstorm 的 3D stream (positional / 5.1ch / distributed-stereo / binaural — r6 系以来) 接入 SL 的 `PARCEL_FLAG_SOUND_LOCAL` 边界规约** — 与 gesture / object sound 同规约。无新增 cvar、无反向 tag,parcel flag 本身就是 root truth。
+
+> **发布形态**: r23 作为 r13〜r23 一并发布 tag 的主功能出货。同捆的其它 release note 由 GitHub Release 页面直接给出链接。
+
+实现细节 / 已知限制 / 设置说明都保留在永久规格 (`docs/ayastorm-r23-parcel-bound-3d-stream.md`) 中。本说明仅作为该文档的入口及差异亮点。
+
+---
+
+## AYAstorm r23 — Parcel-bound 3D stream
+
+### r23 主轴: 把 3D stream 接入 SL 的 parcel 规约
+
+到 r22 为止,AYAstorm 的 3D stream (positional / distributed-stereo / 5.1ch placement / venue reverb / binaural — r6 系以来) **无条件地漏到隔壁 parcel**。SL 的 vanilla 流程中,gesture / object sound / parcel music 已经在 source / listener 任一 parcel 立 `PARCEL_FLAG_SOUND_LOCAL` ("Restrict gestures and object sounds to this parcel") 时会被 parcel boundary 截断。3D stream 一直是这个规约的例外 — 对希望举办活动且不想外溢到邻接 parcel 的配信者来说,这是个问题。
+
+r23 把 3D stream 直接接入同一规约。无新 cvar、无配信者侧 opt-in tag、无 escape hatch — parcel flag 本身即 root truth,与 listeners 对 gesture / object sound 的既有期待完全一致。
+
+### 工作原理
+
+在 3D stream channel 的 volume update hook 上加一行 `LLViewerParcelMgr::canHearSound(pos_global)`。行为:
+
+1. listener 与 source 处于 **同一 parcel** → 可听 (现状维持)
+2. 不同 parcel,**agent parcel** 立有 SOUND_LOCAL → 静音
+3. 不同 parcel,**source parcel** 立有 SOUND_LOCAL → 静音
+4. 其他 → 可听 (现状维持)
+
+这是 SL 已用于 gesture / object sound / 部分 attached sound 的 **同一逻辑** — 没有发明新规约,只是把 3D stream 接入既有规约。
+
+### per-channel position 与 source position
+
+5.1ch placement / distributed-stereo (r8–r10) 中每个 FMOD channel 都有各自的空间位置,但 **parcel 判定使用 1 个点 — 3D stream root prim 的位置**,结果一律应用到全 channel (全鸣 or 全静)。
+
+- 配信者 parcel 内的 listener → 全 ch 可听 (5.1 FR speaker 的音像即使物理上跨到邻 parcel 也 OK)
+- 邻 parcel 的 listener → 全 ch 静音 (即使 FR 音像物理上就在 listener 附近也静)
+
+per-channel parcel 判定会形成「偏侧」的音像,musically 不自然,故有意不采用 (spec §3.2)。
+
+### 静音方式: volume=0 (不 paused)
+
+静音通过 `setVolume(0)` 实现,不暂停 FMOD channel:
+- volume=0 仍持续计算 channel 位置 / 空间衰减,parcel 回归时无缝恢复
+- paused 在恢复时会有 click 噪音 / 需要 re-seek 的风险
+- 由 `parcel_change` 信号驱动 + idempotent guard (状态未变化时不调 FMOD) 防止多余 API call
+
+### 2 tier 评估模型
+
+**Tier 1 (据置 stream,绝大多数)**: 仅在 `LLAgent::addParcelChangedCallback` 触发时重评。avatar 越过 parcel 边界的瞬间运行,per-frame 成本为零。
+
+**Tier 2 (装着 stream,少见)**: binding 构建时在 attachment 上立 flag,仅装着 binding 在 per-frame 中重评 `canHearSound()`。没有装着 stream 时 Tier 2 循环不跑。有时也只是「装着 binding 数 × 1 query × 60 fps」,成本足够低。
+
+### 设置
+
+**有意不提供任何新 cvar。**
+
+- escape-hatch cvar (如 "FSParcelBoundStream3D") 会让配信者绕过规约,不符合本 release 的初衷
+- 配信者侧的反向 tag (如 "ignore parcel boundary") 同样会绕过规约且要求所有人感知,故不采用
+- 想要 global broadcast 的配信者,只需保持 parcel 的 SOUND_LOCAL 为 off — 这恰是 SL 既有的 native pathway
+
+### 配信者迁移备注
+
+如果你正用 AYAstorm 3D stream 做配信,并依赖邻接 parcel 的 listener 也能听到:
+
+- parcel flag 的 default 是 **off** — 若你没有开启 SOUND_LOCAL,**对你来说没有任何变化**
+- 若你已在自己的 parcel 上开了 SOUND_LOCAL,邻接 parcel 的 listener 现在会正确停止收听 — 这与 SL 一直以来对 gesture / object sound 的行为一致,3D stream 此前只是一个无意的例外
+
+### 已知限制
+
+- **region 越境 TP**: 新 region 的 parcel-changed signal 触发后立即正确重适用。在极快的越境瞬间可能出现短暂的播放窗口,但有界
+- **装着 stream 跨 parcel 行走**: 装着者本人始终与 source 同一 parcel (持续可听)。周围只有与装着者同 parcel 的 listener 才能听到
+- **Venue reverb tail**: 本体 mute 后 reverb 输入停止,tail 自然衰减。无需特别处理
+
+### 实现概要
+
+- `llpositionalstreammgr.cpp` / `.h` — volume update hook 添加 `canHearSound()` 一行
+- 无新增 cvar、无新增 uniform、无 UI 变更
+- 3 OS (Linux / macOS / Windows) 构建 + 动作确认 PASS
+
+### 文档
+
+- r23 完整 spec / source position / 2 tier 评估 / 风险登记: `docs/ayastorm-r23-parcel-bound-3d-stream.md`
+- 过去的 3D stream releases (r6–r12,含 listener binding): 参考 in-tree spec 文档及历次 release note (r10 5.1ch placement、r11 binaural + venue reverb 等)

--- a/indra/newview/llpositionalstreammgr.cpp
+++ b/indra/newview/llpositionalstreammgr.cpp
@@ -46,8 +46,11 @@
 #include "llinstantmessage.h"
 #include "llnotificationsutil.h"
 #include "llselectmgr.h"
+#include "llviewerparcelmgr.h"
 #include "llviewerregion.h"
 #include "message.h"
+
+#include <cmath>
 
 #include "llstring.h"
 #include "lltimer.h"
@@ -1195,6 +1198,20 @@ void LLPositionalStreamMgr::evaluateLinkset(LLUUID root_id)
     binding.upmix_effective_applied = upmix_effective;
     binding.speakers = std::move(speakers);
     binding.dropped_speakers = dropped;
+
+    // r23: seed parcel-gate state for the distributed binding. Source
+    // position = root prim position (per §3.2: single-point judgment, not
+    // per-speaker). Reset last_pushed_volume too so the next update() pass
+    // pushes the gated value even when the master volume is unchanged from
+    // the previous binding instance — important for a teardown/rebuild
+    // that lands on a different audible state.
+    if (LLViewerObject* root_obj = gObjectList.findObject(root_id))
+    {
+        binding.is_attached = root_obj->isAttachment();
+        binding.parcel_audible = LLViewerParcelMgr::getInstance()->canHearSound(
+            root_obj->getPositionGlobal());
+    }
+    binding.last_pushed_volume = std::numeric_limits<F32>::quiet_NaN();
     // r11 P8: push venue selection before the stream comes up so the
     // first audio block out of process() already convolves through the
     // right slot (avoids a momentary "dry then wet" pop on first start).
@@ -1760,6 +1777,11 @@ void LLPositionalStreamMgr::evaluateMonoBinding(const LLUUID& id, const TagData&
     b.applied_min = want_min;
     b.applied_max = want_max;
     b.stream = std::move(stream);
+    // r23: seed parcel-gate state. is_attached pins the eval tier (per-frame
+    // vs. signal-driven); parcel_audible is the initial gate so the first
+    // per-poll push in update() converges immediately without a 1-frame leak.
+    b.is_attached = obj->isAttachment();
+    b.parcel_audible = LLViewerParcelMgr::getInstance()->canHearSound(obj->getPositionGlobal());
     mBindings.emplace(id, std::move(b));
 
     LL_INFOS("Stream3D") << "Bound positional stream to " << id
@@ -1778,6 +1800,12 @@ void LLPositionalStreamMgr::update()
     {
         return;
     }
+
+    // r23: late-bind the parcel-change callback. The static singleton is
+    // built at process start when gAgent may not yet be alive, so we defer
+    // the connect to here where update() can only run post-login. Once
+    // connected, the early-return is a single bool load per tick.
+    ensureParcelCallbackRegistered();
 
     // M8: re-arm the cap notification once we drop back under the cap, so a
     // future cap-hit triggers a fresh toast rather than being suppressed by
@@ -1888,6 +1916,9 @@ void LLPositionalStreamMgr::update()
                 const LLVector3 pos = toFloatVec(obj->getPositionGlobal());
                 b.stream->setRolloffDistances(b.applied_min, b.applied_max);
                 b.stream->setVolume(gSavedSettings.getF32("Stream3DVolumeMaster"));
+                // r23: reset the idempotent guard so the per-poll push next
+                // frame applies the parcel gate to the fresh FMOD channel.
+                b.last_pushed_volume = std::numeric_limits<F32>::quiet_NaN();
                 LL_INFOS("Stream3D") << "Reconnect attempt " << b.reconnect_attempts
                                       << "/" << max_attempts << " for " << id
                                       << " url=" << b.url << LL_ENDL;
@@ -1918,10 +1949,29 @@ void LLPositionalStreamMgr::update()
         }
 
         b.stream->setPosition(toFloatVec(obj->getPositionGlobal()));
+        // r23: Tier 2 — attached source moves per-frame, so re-evaluate the
+        // parcel gate every tick for this binding. Static-source (Tier 1)
+        // bindings rely on the cached value last refreshed by the
+        // parcel-change signal in onAgentParcelChanged().
+        if (b.is_attached)
+        {
+            b.parcel_audible = computeParcelAudible(id, b.parcel_audible);
+        }
         // r12.1: same per-poll master-volume push as the distributed
         // bindings loop below, so a Stream3DVolumeMaster edit propagates
         // without waiting for the next reconnect.
-        b.stream->setVolume(gSavedSettings.getF32("Stream3DVolumeMaster"));
+        // r23: gate volume by parcel_audible (0 when muted by SL parcel
+        // SOUND_LOCAL rule), and skip the FMOD setVolume call when the
+        // effective value hasn't changed since the last push.
+        {
+            const F32 master_vol = gSavedSettings.getF32("Stream3DVolumeMaster");
+            const F32 effective_vol = b.parcel_audible ? master_vol : 0.f;
+            if (std::isnan(b.last_pushed_volume) || b.last_pushed_volume != effective_vol)
+            {
+                b.stream->setVolume(effective_vol);
+                b.last_pushed_volume = effective_vol;
+            }
+        }
         b.stream->update();
         ++it;
     }
@@ -2076,6 +2126,10 @@ void LLPositionalStreamMgr::update()
                     configs.push_back(c);
                 }
                 b.stream->setVolume(gSavedSettings.getF32("Stream3DVolumeMaster"));
+                // r23: reset idempotent guard (see mono path); per-poll
+                // push next frame applies the parcel gate to the new
+                // FMOD channels.
+                b.last_pushed_volume = std::numeric_limits<F32>::quiet_NaN();
                 LL_INFOS("Stream3D") << "[3dstream-stereo] reconnect attempt "
                                       << b.reconnect_attempts << "/" << max_attempts_dist
                                       << " for root " << root_id
@@ -2158,7 +2212,22 @@ void LLPositionalStreamMgr::update()
         // that's a no-op when unchanged.
         applyVenueToBinding(b, b.venue_tag);
         applyWetGainToBinding(b, b.wetgain_tag);
-        b.stream->setVolume(gSavedSettings.getF32("Stream3DVolumeMaster"));
+        // r23: Tier 2 refresh for attached-source distributed bindings.
+        // Source = root prim position; same evaluation as the mono path.
+        if (b.is_attached)
+        {
+            b.parcel_audible = computeParcelAudible(root_id, b.parcel_audible);
+        }
+        // r23: same parcel-gated, idempotent volume push as the mono loop.
+        {
+            const F32 master_vol = gSavedSettings.getF32("Stream3DVolumeMaster");
+            const F32 effective_vol = b.parcel_audible ? master_vol : 0.f;
+            if (std::isnan(b.last_pushed_volume) || b.last_pushed_volume != effective_vol)
+            {
+                b.stream->setVolume(effective_vol);
+                b.last_pushed_volume = effective_vol;
+            }
+        }
         b.stream->update();
 
         // r13: per-frame OBB occlusion eval. The shipped libfmod
@@ -2329,17 +2398,68 @@ void LLPositionalStreamMgr::applyMasterVolume(F32 volume)
     {
         mDebugStereoStream->setVolume(volume);
     }
+    // r23: gate by the cached parcel_audible for prim-bound streams. The
+    // per-poll loop in update() also pushes effective volume every tick;
+    // this path covers the Stream3DVolumeMaster signal-driven case so the
+    // user-visible slider responds in the same frame as the setting change.
     for (auto& [id, b] : mBindings)
     {
-        b.stream->setVolume(volume);
+        const F32 effective = b.parcel_audible ? volume : 0.f;
+        b.stream->setVolume(effective);
+        b.last_pushed_volume = effective;
     }
     for (auto& [root_id, b] : mDistributedBindings)
     {
         if (b.stream)
         {
-            b.stream->setVolume(volume);
+            const F32 effective = b.parcel_audible ? volume : 0.f;
+            b.stream->setVolume(effective);
+            b.last_pushed_volume = effective;
         }
     }
+}
+
+// r23: lazy callback registration. Called on every update() tick; the
+// `connected()` early-return makes the steady-state cost a single bool load.
+void LLPositionalStreamMgr::ensureParcelCallbackRegistered()
+{
+    if (mParcelChangedConn.connected())
+    {
+        return;
+    }
+    mParcelChangedConn = gAgent.addParcelChangedCallback(
+        boost::bind(&LLPositionalStreamMgr::onAgentParcelChanged, this));
+}
+
+// r23: Tier 1 refresh on agent parcel-change. Walks every binding (mono +
+// distributed) and re-evaluates its cached parcel_audible. Tier 2 (attached)
+// bindings will also be refreshed in update()'s per-frame pass, but we
+// eagerly refresh here too so the very first frame after the signal already
+// reflects the new gate state.
+void LLPositionalStreamMgr::onAgentParcelChanged()
+{
+    for (auto& [id, b] : mBindings)
+    {
+        b.parcel_audible = computeParcelAudible(id, b.parcel_audible);
+    }
+    for (auto& [root_id, b] : mDistributedBindings)
+    {
+        b.parcel_audible = computeParcelAudible(root_id, b.parcel_audible);
+    }
+}
+
+// r23: one canHearSound() probe at the source prim's world position. When
+// the prim has gone away or its position can't be resolved, return the
+// caller-supplied fallback (typically the previous cached value) so a
+// transient miss doesn't flip a binding to muted.
+bool LLPositionalStreamMgr::computeParcelAudible(const LLUUID& source_id, bool fallback) const
+{
+    LLViewerObject* obj = gObjectList.findObject(source_id);
+    if (!obj || obj->isDead())
+    {
+        return fallback;
+    }
+    return LLViewerParcelMgr::getInstance()->canHearSound(obj->getPositionGlobal());
 }
 
 void LLPositionalStreamMgr::startDebug(const std::string& url, const LLVector3& world_pos)

--- a/indra/newview/llpositionalstreammgr.h
+++ b/indra/newview/llpositionalstreammgr.h
@@ -29,6 +29,8 @@
 #include "stdtypes.h"
 #include "v3math.h"
 
+#include <boost/signals2/connection.hpp>
+
 #include <deque>
 #include <limits>
 #include <map>
@@ -321,6 +323,20 @@ private:
         // toasts on every reconnect-success transition (only the *initial*
         // bind notifies; rebinds inherit a fresh false because new Binding).
         bool notified_played = false;
+        // r23: source prim is an attachment (= attached to an avatar). When
+        // true, the source position moves per-frame and the parcel gate is
+        // re-evaluated in update() every tick (Tier 2). When false, the
+        // source is static so the gate is refreshed only on agent
+        // parcel-change events (Tier 1) and cached here.
+        bool is_attached = false;
+        // r23: cached canHearSound() result for this binding's source vs.
+        // the listener parcel. True = audible (default = audible so an
+        // un-evaluated binding plays rather than silently muting).
+        bool parcel_audible = true;
+        // r23: idempotent guard for setVolume churn. The per-poll push
+        // skips when the new effective volume equals the last pushed value.
+        // Sentinel NaN means "never pushed", so the first push always goes.
+        F32 last_pushed_volume = std::numeric_limits<F32>::quiet_NaN();
         std::unique_ptr<LLPositionalStream> stream;
     };
 
@@ -427,6 +443,14 @@ private:
         // last_diagnostic_key on structural rebuild so a fresh start
         // (re)announces the bypass once.
         std::string last_upmix_notice_key;
+
+        // r23: same parcel-gate fields as the mono Binding above. See
+        // those comments for full semantics; behaviour is identical
+        // (source = root prim of the linkset, gate decision applied
+        // uniformly to every channel of the multi stream).
+        bool is_attached = false;
+        bool parcel_audible = true;
+        F32 last_pushed_volume = std::numeric_limits<F32>::quiet_NaN();
     };
 
     // r10 P5 / r10.x P2: routing-diagnostic emitter. Called from update()
@@ -499,6 +523,23 @@ private:
 
     void evaluateBinding(const LLUUID& id);
     void evaluateMonoBinding(const LLUUID& id, const TagData& tag);
+
+    // r23: register the parcel-change callback once gAgent is alive. Called
+    // lazily on the first update() tick. Tier 1 (static-source bindings)
+    // refresh their cached parcel_audible only on this signal, so the
+    // per-frame cost stays zero in the common case.
+    void ensureParcelCallbackRegistered();
+
+    // r23: slot for `gAgent.addParcelChangedCallback`. Walks every binding
+    // and refreshes its cached `parcel_audible`. Cheap — one canHearSound
+    // call per binding (one parcel overlay lookup each, ~O(1)).
+    void onAgentParcelChanged();
+
+    // r23: evaluate canHearSound() at the given source prim's world
+    // position. Returns the previous cached value when the prim is gone
+    // or its position is unavailable, so a transient lookup miss doesn't
+    // mute a binding spuriously.
+    bool computeParcelAudible(const LLUUID& source_id, bool fallback) const;
 
     // r8 F2-a: (re)build the distributed-stereo binding rooted at root_id by
     // walking the linkset and harvesting whatever speaker descriptions are
@@ -638,6 +679,11 @@ private:
     // population in practice tracks the user's tagged prim count, so a prune
     // pass is not yet required. Cleared by shutdownAll().
     std::map<std::pair<LLUUID, DistErrorKind>, F64> mErrorThrottle;
+
+    // r23: parcel-change signal connection. Connected lazily on the first
+    // update() tick (gAgent is guaranteed alive by then). scoped_connection
+    // auto-disconnects in the singleton's destructor at process exit.
+    boost::signals2::scoped_connection mParcelChangedConn;
 
     // r9 P6.5: roots whose source URL was permanently rejected by
     // LLPositionalStreamMulti (FailReason::FormatUnsupported, e.g. 5ch


### PR DESCRIPTION
## Summary
- AYAstorm 3D stream (positional / 5.1ch / distributed-stereo / binaural / venue reverb — r6 系以降) を SL の `PARCEL_FLAG_SOUND_LOCAL` 規約に準拠させる viewer 側変更
- r13–r23 を 1 タグ (`v7.2.4-ayastorm-r23`) でまとめて公開するための release docs を 3 言語で整備
- 6 commits、33 files changed, +2126 / -10

## 主要変更
- **r23 viewer 実装** (`673ca4ae9c`): `LLPositionalStreamMgr` の volume update hook に `LLViewerParcelMgr::canHearSound()` を追加。2 tier 評価 (Tier 1 据置 stream は `parcel_change` シグナル / Tier 2 装着 stream のみ per-frame) で per-frame コストを最小化、idempotent guard 付き
- **release docs (3 言語)**: r14 / r16-r20 / r23 の per-feature release note × en/ja/zh (21 ファイル新規)、bundle GitHub release page × en/ja/zh (3 ファイル新規、tag-pinned permalink + 言語切替ナビ)、r21 / r22 release note の Draft 表記削除
- **spec finalize**: `docs/ayastorm-r23-parcel-bound-3d-stream.md` の M5 status を release notes 完成・tag 切り前に更新

## Test plan
- [x] 同一 parcel 内 listener: 聞こえる (現状維持)
- [x] 配信 parcel SOUND_LOCAL=ON、隣接 parcel listener: 聞こえない (new)
- [x] listener parcel SOUND_LOCAL=ON、隣接 parcel source: 聞こえない (new)
- [x] 5.1ch / distributed-stereo: source 1 点判定で全 ch 一律 (片寄せなし)
- [x] parcel 越境 walk: volume=0 経由でクリックノイズなしで切替
- [x] 装着 stream の parcel 跨ぎ歩行
- [x] region 越境 TP 後の状態反映
- [x] venue reverb tail 自然減衰
- [x] 3 OS (Linux / Win / Mac) ビルド + 動作確認 PASS

## 設計判断
- **escape hatch cvar なし**: parcel フラグそのものを root truth とし、`FSParcelBoundStream3D` 等の bypass cvar は追加しない。SL の gesture / object sound と同じ規約に compliance させるのが本 release の主旨
- **per-channel parcel 判定なし**: 5.1ch / distributed-stereo は source 1 点 (root prim) で判定。channel 単位で別判定すると「片寄せ」音像になり musically 不自然 (spec §3.2)
- **mute は `volume=0`, paused にしない**: parcel 復帰時の seamless 再開とクリックノイズ回避

## Tag
`v7.2.4-ayastorm-r23` (タグ切りは AYA 側で release notes 確認後に手動)