### PR TITLE
r24: CEF/MOAP 音声を FMOD 2D media channel 経由にする

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -720,11 +720,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>2c81fa7aa03b427088ab54ce3b71088a0003126b</string>
+              <string>1b7fe88b3dcdc4bca341af139f1b69c14e0ccbd0</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-18568015445.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3/dullahan-1.26.0.202605151520_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-25925705109.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -734,11 +734,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>8e06d060729250c5bfcb993c8f818f36ea17de16</string>
+              <string>f343f444f36e1afb56683035ac6c54850a723b96</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139-linux64-18568015445.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3/dullahan-1.26.0.202605151519_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25925705109.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -748,11 +748,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>7ca6db37f019b47e230c0861607c546d45535367</string>
+              <string>cfa31aa85b4a0e2ee94eec916abf6f01a000d5c2</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161628_139.0.40_g465474a_chromium-139.0.7258.139-windows64-18568015445.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3/dullahan-1.26.0.202605151520_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25925705109.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -765,7 +765,7 @@
         <key>copyright</key>
         <string>Copyright (c) 2017, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139</string>
+        <string>1.26.0.202605151520_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.3</string>
         <key>name</key>
         <string>dullahan</string>
         <key>description</key>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -720,6 +720,66 @@
             <key>archive</key>
             <map>
               <key>hash</key>
+              <string>2c81fa7aa03b427088ab54ce3b71088a0003126b</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-18568015445.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>darwin64</string>
+          </map>
+          <key>linux64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>8e06d060729250c5bfcb993c8f818f36ea17de16</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139-linux64-18568015445.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>linux64</string>
+          </map>
+          <key>windows64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
+              <string>7ca6db37f019b47e230c0861607c546d45535367</string>
+              <key>hash_algorithm</key>
+              <string>sha1</string>
+              <key>url</key>
+              <string>https://github.com/secondlife/dullahan/releases/download/v1.26.0-CEF_139.0.40/dullahan-1.26.0.202510161628_139.0.40_g465474a_chromium-139.0.7258.139-windows64-18568015445.tar.zst</string>
+            </map>
+            <key>name</key>
+            <string>windows64</string>
+          </map>
+        </map>
+        <key>license</key>
+        <string>MPL</string>
+        <key>license_file</key>
+        <string>LICENSES/LICENSE.txt</string>
+        <key>copyright</key>
+        <string>Copyright (c) 2017, Linden Research, Inc.</string>
+        <key>version</key>
+        <string>1.26.0.202510161627_139.0.40_g465474a_chromium-139.0.7258.139</string>
+        <key>name</key>
+        <string>dullahan</string>
+        <key>description</key>
+        <string>A headless browser SDK that uses the Chromium Embedded Framework (CEF). It is designed to make it easier to write applications that render modern web content directly to a memory buffer, inject synthesized mouse and keyboard events as well as interact with web based features like JavaScript or cookies.</string>
+      </map>
+      <key>dullahan_aya_audio</key>
+      <map>
+        <key>platforms</key>
+        <map>
+          <key>darwin64</key>
+          <map>
+            <key>archive</key>
+            <map>
+              <key>hash</key>
               <string>1b7fe88b3dcdc4bca341af139f1b69c14e0ccbd0</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
@@ -767,9 +827,9 @@
         <key>version</key>
         <string>1.26.0.202605151520_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.3</string>
         <key>name</key>
-        <string>dullahan</string>
+        <string>dullahan_aya_audio</string>
         <key>description</key>
-        <string>A headless browser SDK that uses the Chromium Embedded Framework (CEF). It is designed to make it easier to write applications that render modern web content directly to a memory buffer, inject synthesized mouse and keyboard events as well as interact with web based features like JavaScript or cookies.</string>
+        <string>t-noami/dullahan fork of Dullahan that exposes audio stream callbacks. Drop-in replacement for the upstream "dullahan" installable; selected at configure time via -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE so media_plugin_cef can route CEF/MOAP audio through FMOD.</string>
       </map>
       <key>emoji_shortcodes</key>
       <map>

--- a/doc/building_ayastorm_macos.md
+++ b/doc/building_ayastorm_macos.md
@@ -112,6 +112,24 @@ rg -n 'fmodstudio|darwin64|file://' my_autobuild.xml
 
 FMOD を使わないビルドにする場合は、以降の configure から `--fmodstudio` を外してください。
 
+## Dullahan audio callback
+
+AYAstorm Mac ビルド手順のデフォルトは Dullahan audio callback 経路を有効にします。
+
+`autobuild.xml` または `my_autobuild.xml` に `t-noami/dullahan` fork の installable (`dullahan_aya_audio`) が存在している場合:
+
+```bash
+-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
+```
+
+`t-noami/dullahan` fork が存在しておらず、upstream の `secondlife/dullahan` installable (`dullahan`) が存在している場合:
+
+```bash
+-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=FALSE
+```
+
+configure 後は `build-darwin-universal/CMakeCache.txt` で `LL_DULLAHAN_AUDIO_CALLBACK:BOOL=` の値を確認してください。
+
 ## 環境変数
 
 ```bash
@@ -141,13 +159,14 @@ autobuild configure -A 64 -c ReleaseFS_open -- \
   --openal \
   --package \
   --chan AYAstorm-release \
-  -DLL_TESTS:BOOL=FALSE
+  -DLL_TESTS:BOOL=FALSE \
+  -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
 ```
 
 configure 後に主要な設定を確認します。
 
 ```bash
-rg -n 'CMAKE_BUILD_TYPE|ADDRESS_SIZE|CMAKE_OSX_ARCHITECTURES|VIEWER_CHANNEL|USE_FMODSTUDIO|USE_OPENAL|OPENSIM|PACKAGE|VIEWER_BINARY_NAME' \
+rg -n 'CMAKE_BUILD_TYPE|ADDRESS_SIZE|CMAKE_OSX_ARCHITECTURES|VIEWER_CHANNEL|USE_FMODSTUDIO|USE_OPENAL|OPENSIM|PACKAGE|VIEWER_BINARY_NAME|LL_DULLAHAN_AUDIO_CALLBACK' \
   build-darwin-universal/CMakeCache.txt
 ```
 
@@ -163,6 +182,7 @@ USE_FMODSTUDIO:BOOL=ON
 USE_OPENAL:BOOL=ON
 VIEWER_BINARY_NAME:STRING=ayastorm-bin
 VIEWER_CHANNEL:STRING=Firestorm-AYAstorm-release
+LL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
 ```
 
 ## Build / Package

--- a/docs/ayastorm-media-playback-audio-path-report.md
+++ b/docs/ayastorm-media-playback-audio-path-report.md
@@ -1,0 +1,340 @@
+# AYAstorm MOAP media playback and audio path report
+
+検証ブランチ: `feature/media-playback-validation-release`
+
+検証日: 2026-05-15
+
+## 目的
+
+現在の AYAstorm / Firestorm 系コードで、MOAP (Media on a Prim) / Shared Media / Web page media の再生と音声がどの経路を通っているかを整理する。
+
+ここで主対象にする「メディア再生」は、基本的に Web ページや動画をプリム面に表示する MOAP 系の media playback を指す。
+
+次の経路は、MOAP の位置づけを明確にするための比較対象として確認した。
+
+- Parcel Music / Streaming Music
+- Media on a Prim / Shared Media / Browser media
+- AYAstorm 3D Stream
+- それぞれの音量制御と macOS での注意点
+
+この報告は現時点ではコード調査ベースであり、実機再生テスト結果ではない。
+
+## 開発計画の柱
+
+この調査を踏まえた開発計画は、次の 2 段階に分けて扱う。
+
+### Phase 1: macOS の MOAP 音量制御を有効化する
+
+目的は、macOS で MOAP / Web media の音量を Viewer 側から調整できるようにすること。
+
+現状では、macOS の CEF media plugin が `mac_volume_catcher_null.cpp` を使っているため、CEF 経路の音声に対する Media volume が実際の出力音量へ反映されない可能性が高い。
+
+この段階では、音声を 3D Stream に接続することはしない。まずは従来の MOAP 音声経路のまま、Viewer の Media volume / mute が macOS でも正しく効く状態を目標にする。
+
+対象:
+
+- `media_plugin_cef` の macOS 音量制御
+- `AudioLevelMedia`
+- `AudioStreamingMedia`
+- `MuteMedia`
+- Web page / HTML5 video / HTML5 audio / YouTube などの CEF 経路
+
+### Phase 2: MOAP 音声を 3D Stream 経路へ接続する
+
+目的は、MOAP で再生される Web media の音声を、AYAstorm の 3D Stream と同じようにプリムスピーカーから鳴らせるようにすること。
+
+現状の MOAP 音声は media plugin process から OS audio device へ直接出ており、FMOD の Stream3D bus には入っていない。
+
+この段階では、MOAP 音声を viewer 側で受け取り、既存の `LLPositionalStreamMulti` / Stream3D speaker routing に接続できる構造を検討する。
+
+対象:
+
+- media plugin からの音声取り出し方法
+- Viewer / FMOD 側への PCM 受け渡し
+- MOAP source と speaker prim の対応付け
+- 既存 Stream3D の range / volume / position / speaker role との統合
+- 従来の media plugin 音声出力との排他、または併用設計
+
+## 結論
+
+このコードベースでは、「音楽・メディア再生」と呼ばれ得るものが少なくとも 3 系統に分かれている。
+
+1. Parcel Music は FMOD の `LLStreamingAudio_FMODSTUDIO` で再生される。
+2. MOAP / Shared Media / Web / Movie は `SLPlugin` 経由の media plugin で再生される。
+3. AYAstorm 3D Stream は `LLPositionalStreamMgr` と `LLPositionalStreamMulti` による独自の FMOD 3D 経路で再生される。
+
+今回の主対象である MOAP / Web media の音声は、現状では FMOD の Stream3D bus には入っていない。
+
+そのため、Media on a Prim の音声は AYAstorm 3D Stream の upmix、LFE、venue reverb、speaker placement とは別系統である。
+
+開発上は、まず macOS でこの既存 MOAP 音声経路の volume control を直し、その次に MOAP 音声を Stream3D 側へ接続する、という順序が妥当である。
+
+## 全体構造
+
+大きく見ると、音声経路は次のようになる。
+
+```text
+Parcel Music URL
+  -> LLViewerParcelMgr / LLViewerMedia
+  -> LLViewerAudio::startInternetStreamWithAutoFade()
+  -> LLAudioEngine::startInternetStream()
+  -> LLStreamingAudio_FMODSTUDIO
+  -> FMOD 2D stream channel
+  -> OS audio device
+
+MOAP / Shared Media / Web / Movie URL
+  -> LLViewerMediaImpl
+  -> MIME 判定
+  -> LLPluginClassMedia
+  -> SLPlugin
+  -> media_plugin_cef or media_plugin_libvlc
+  -> plugin process audio output
+  -> OS audio device
+
+AYAstorm 3D Stream tag
+  -> prim Description
+  -> LLPositionalStreamMgr
+  -> LLPositionalStreamMulti
+  -> FMOD source stream + OPENUSER per-speaker channels
+  -> Stream3D FMOD channel group
+  -> OS audio device
+```
+
+## 比較対象: Parcel Music / Streaming Music
+
+Parcel Music は通常の media plugin 経由ではなく、デフォルトでは FMOD ネイティブのストリーミング実装を使う。
+
+初期化では `UseMediaPluginsForStreamingAudio` が false の場合、FMOD の実装が選ばれる。
+
+関連箇所:
+
+- `indra/newview/llstartup.cpp`
+  - `UseMediaPluginsForStreamingAudio == false` なら `createDefaultStreamingAudioImpl()` を使用
+- `indra/llaudio/llaudioengine_fmodstudio.cpp`
+  - `LLAudioEngine_FMODSTUDIO::createDefaultStreamingAudioImpl()`
+  - `LLStreamingAudio_FMODSTUDIO` を生成
+- `indra/llaudio/llstreamingaudio_fmodstudio.cpp`
+  - `LLStreamingAudio_FMODSTUDIO::start()`
+  - `FMOD::System::createStream()`
+  - `FMOD::System::playSound()`
+
+Parcel Music の開始は主に次の経路で行われる。
+
+```text
+LLViewerParcelMgr::optionallyStartMusic()
+  -> LLViewerAudio::startInternetStreamWithAutoFade()
+  -> LLAudioEngine::startInternetStream()
+  -> LLStreamingAudio_FMODSTUDIO::start()
+```
+
+`LLStreamingAudio_FMODSTUDIO` は `FMOD_2D | FMOD_NONBLOCKING | FMOD_IGNORETAGS` で `createStream()` している。つまり Parcel Music は 2D のストリーミング音声であり、スピーカー位置を持たない。
+
+音量は `LLViewerAudio::audio_update_volume()` から `gAudiop->setInternetStreamGain()` に入り、最終的に FMOD channel volume に反映される。
+
+## Media on a Prim / Shared Media
+
+MOAP やブラウザ、動画再生は `LLViewerMediaImpl` が入口になる。
+
+関連箇所:
+
+- `indra/newview/llviewermedia.cpp`
+  - `LLViewerMediaImpl::newSourceFromMediaType()`
+  - `LLViewerMediaImpl::initializePlugin()`
+  - `LLViewerMediaImpl::updateVolume()`
+  - `LLViewerMediaImpl::preMediaTexUpdate()`
+- `indra/llplugin/llpluginclassmedia.cpp`
+  - `LLPluginClassMedia::init()`
+  - `LLPluginClassMedia::setVolume()`
+  - shared memory texture update handling
+- `indra/media_plugins/cef/media_plugin_cef.cpp`
+- `indra/media_plugins/libvlc/media_plugin_libvlc.cpp`
+
+MIME type から media plugin が選ばれる。
+
+macOS の `mime_types_mac.xml` では、おおむね次の割り当てになっている。
+
+- `text/html`, `text/plain`, `image/*` など: `media_plugin_cef`
+- `audio/*`, `video/*`, `video/mp4`, `video/quicktime` など: `media_plugin_libvlc`
+- default implementation: `media_plugin_cef`
+
+映像は media plugin が shared memory にピクセルを書き、viewer 側が dirty rect を拾って media texture に転送する。
+
+音声はこの shared memory 経路ではなく、media plugin process 側の CEF / libVLC がそれぞれ OS audio device へ出す。
+
+## MOAP 音声の距離処理
+
+`LLViewerMediaImpl::updateVolume()` には `mProximityCamera` による距離減衰がある。
+
+これは `MediaRollOffMin`, `MediaRollOffMax`, `MediaRollOffRate` を使って、media plugin に渡す volume を viewer 側で計算する仕組みである。
+
+ただし、これは FMOD の 3D channel ではない。実体は media plugin process の音声出力であり、viewer 側で計算した音量を plugin に `set_volume` で渡している。
+
+したがって、MOAP 音声は「距離で音量が変わる」ことはあっても、AYAstorm 3D Stream のような per-speaker placement、upmix、LFE、venue reverb の対象ではない。
+
+## Media plugin 別の音声経路
+
+### CEF
+
+CEF plugin の音量制御は次の流れ。
+
+```text
+LLViewerMediaImpl::updateVolume()
+  -> LLPluginClassMedia::setVolume()
+  -> media time message: set_volume
+  -> MediaPluginCEF::setVolume()
+  -> VolumeCatcher::setVolume()
+```
+
+ただし macOS では `media_plugins/cef/CMakeLists.txt` で `mac_volume_catcher_null.cpp` が使われている。
+
+`mac_volume_catcher_null.cpp` は値を保持するだけで、実際の AudioUnit / OS 出力音量へ反映しない null 実装である。
+
+このため、macOS の CEF media audio については、Viewer の Media volume が実音量に効かない可能性がある。これは実機で確認すべき重要ポイントである。
+
+### libVLC
+
+libVLC plugin の音量制御は次の流れ。
+
+```text
+LLViewerMediaImpl::updateVolume()
+  -> LLPluginClassMedia::setVolume()
+  -> media time message: set_volume
+  -> MediaPluginLibVLC::setVolume()
+  -> libvlc_audio_set_volume()
+```
+
+`media_plugin_libvlc.cpp` では `libvlc_audio_set_volume()` が呼ばれているため、動画ファイルや `video/mp4` / `audio/*` のような libVLC 経路では plugin 内で音量が反映される構造になっている。
+
+Windows では追加で `waveOutSetVolume()` の回避処理があるが、macOS では libVLC の音量 API が主経路になる。
+
+## Streaming audio の media plugin fallback
+
+`UseMediaPluginsForStreamingAudio` を true にすると、Parcel Music も `LLStreamingAudio_MediaPlugins` 経由に切り替わる可能性がある。
+
+関連箇所:
+
+- `indra/newview/llviewermedia_streamingaudio.cpp`
+- `LLStreamingAudio_MediaPlugins::start()`
+
+この場合は `audio/mpeg` として media plugin を初期化し、`LLPluginClassMedia` 経由で再生する。
+
+ただし現在の設定デフォルトは `UseMediaPluginsForStreamingAudio = false` なので、通常の Parcel Music は FMOD 経路である。
+
+## 接続先候補: AYAstorm 3D Stream
+
+AYAstorm 3D Stream は通常の MOAP / media plugin ではない。
+
+ただし Phase 2 では、MOAP 音声を接続する先の候補になる。
+
+入口は prim Description の `[3dstream:...]` / `[3dstream-stereo:...]` / legacy `[ayastream:...]` 系タグである。
+
+関連箇所:
+
+- `indra/newview/llselectmgr.cpp`
+  - ObjectProperties 受信時に Description を `LLPositionalStreamMgr` へ渡す
+- `indra/newview/llappviewer.cpp`
+  - frame update で `LLPositionalStreamMgr::update()` を呼ぶ
+- `indra/newview/llpositionalstreammgr.cpp`
+  - Description scan、tag parse、binding 管理
+- `indra/llaudio/llpositionalstreammulti.cpp`
+  - FMOD source stream、per-speaker OPENUSER channel
+- `indra/llaudio/llaudioengine_fmodstudio.cpp`
+  - `Stream3D` channel group と venue reverb DSP
+
+構造は次の通り。
+
+```text
+prim Description
+  -> LLPositionalStreamMgr::onObjectPropertiesReceived()
+  -> tag parse / linkset binding
+  -> LLPositionalStreamMulti::start()
+  -> FMOD::System::createStream(source)
+  -> source PCM read
+  -> per-speaker OPENUSER FMOD::Sound
+  -> per-speaker FMOD::Channel
+  -> set3DAttributes / set3DMinMaxDistance
+  -> Stream3D channel group
+```
+
+`LLPositionalStreamMulti` は source stream をそのまま FMOD channel として鳴らすのではなく、source を読み出し、各 speaker 用の OPENUSER sound / channel に分配する。
+
+このため、speaker ごとの位置、range、volume、upmix、LFE、occlusion、lite-HRTF、venue reverb を扱える。
+
+## 音量カテゴリ
+
+UI 上の音量カテゴリは、おおむね次のように分かれている。
+
+| UI / setting | 主な対象 | 主経路 |
+| --- | --- | --- |
+| `AudioLevelMusic` / `AudioStreamingMusic` | Parcel Music | FMOD streaming audio |
+| `AudioLevelMedia` / `AudioStreamingMedia` | MOAP / Browser / Movie | media plugin |
+| `Stream3DVolumeMaster` / `Stream3DEnabled` | AYAstorm 3D Stream | FMOD Stream3D channel group |
+| SFX / UI / Ambient | 通常の viewer sounds | FMOD audio engine |
+| Voice | voice client | 別系統 |
+
+## 現時点の注意点
+
+### この報告の主対象は MOAP
+
+Parcel Music と既存 AYAstorm 3D Stream は、この報告では主対象ではない。
+
+Parcel Music は、MOAP と異なる既存ストリーミング音楽経路を説明するための比較対象である。
+
+AYAstorm 3D Stream は、将来的に MOAP 音声をプリムスピーカーへ接続するための接続先候補として扱う。
+
+### macOS CEF media volume
+
+macOS では CEF volume catcher が null 実装である。
+
+そのため、HTML5 video、Web audio、YouTube のような CEF 経路の media audio では、viewer の Media volume が期待通り効かない可能性がある。
+
+libVLC 経路の動画 / 音声は `libvlc_audio_set_volume()` があるため、CEF とは別に検証する必要がある。
+
+### 現状の MOAP と 3D Stream は混ぜて考えない
+
+MOAP media audio は media plugin process の音声であり、Stream3D bus には入らない。
+
+そのため、現状の AYAstorm 3D Stream 機能を検証する場合、MOAP の Web/Video 再生ではなく、prim Description の `[3dstream...]` タグ経路を使う必要がある。
+
+一方、Phase 2 の開発では、この分離されている MOAP 音声経路を Stream3D 側へ接続することを目標にする。
+
+### Parcel Music と 3D Stream も別系統
+
+Parcel Music は FMOD だが 2D streaming music である。
+
+FMOD を使っている点は共通だが、Stream3D の per-speaker 3D channel group とは別である。
+
+## 実機検証で見るべき項目
+
+次のケースを分けて確認するのがよい。
+
+1. MOAP text/html / YouTube / HTML5 audio
+   - `media_plugin_cef` 経路になる想定
+   - macOS で Media volume が効くか
+   - `mac_volume_catcher_null.cpp` の影響を確認
+
+2. MOAP video/mp4
+   - macOS では `media_plugin_libvlc` 経路になる想定
+   - Media volume が効くか
+   - `libvlc_audio_set_volume()` 経路のログ追加も検討
+
+3. Parcel Music
+   - `AudioStreamingMusic` on/off
+   - Music volume が効くか
+   - `AudioImpl`, `AudioEngine`, `ParcelMgr` ログ
+
+4. AYAstorm 3D Stream
+   - `[3dstream-stereo:...]` タグの検出
+   - `Stream3D` ログ
+   - speaker channel / range / volume
+   - `Stream3DVolumeMaster`
+   - upmix / LFE / venue reverb / occlusion の有無
+
+## 追加調査候補
+
+- Phase 1: macOS の CEF 音量制御を null 実装のままにするか、別の音量制御経路を実装するか。
+- Phase 2: MOAP media audio を Stream3D へ載せるために、media plugin audio をどの段階で取り出すか。
+- Phase 2: 取り出した MOAP 音声を `LLPositionalStreamMulti` 相当の speaker fan-out に流すか、別の MOAP 専用 3D media stream wrapper を作るか。
+- Phase 2: MOAP の従来音声出力を mute し、Stream3D 側だけを鳴らす制御が必要か。
+- `UseMediaPluginsForStreamingAudio` を有効にした場合の Parcel Music 挙動。現在の通常経路とは異なるため、必要なら別テストにする。
+- CEF と libVLC で Media volume の効き方が一致しているか。

--- a/docs/ayastorm-media-playback-audio-path-report.md
+++ b/docs/ayastorm-media-playback-audio-path-report.md
@@ -1,340 +1,180 @@
-# AYAstorm MOAP media playback and audio path report
+# AYAstorm MOAP audio to FMOD 2D implementation report
 
 検証ブランチ: `feature/media-playback-validation-release`
 
 検証日: 2026-05-15
 
-## 目的
+文書更新: 2026-05-16
 
-現在の AYAstorm / Firestorm 系コードで、MOAP (Media on a Prim) / Shared Media / Web page media の再生と音声がどの経路を通っているかを整理する。
+## 目次
 
-ここで主対象にする「メディア再生」は、基本的に Web ページや動画をプリム面に表示する MOAP 系の media playback を指す。
+- [PR 前サマリ](#pr-前サマリ)
+- [このブランチの範囲](#このブランチの範囲)
+- [実装後の音声経路](#実装後の音声経路)
+- [実装内容](#実装内容)
+- [Dullahan package](#dullahan-package)
+- [macOS 検証結果](#macos-検証結果)
+- [Windows / Linux 担当者向け確認手順](#windows--linux-担当者向け確認手順)
+- [未確認項目](#未確認項目)
+- [別ブランチで扱う項目](#別ブランチで扱う項目)
 
-次の経路は、MOAP の位置づけを明確にするための比較対象として確認した。
+## PR 前サマリ
 
-- Parcel Music / Streaming Music
-- Media on a Prim / Shared Media / Browser media
-- AYAstorm 3D Stream
-- それぞれの音量制御と macOS での注意点
+このブランチの目的は、MOAP / Web / HTML5 / YouTube など CEF 経路の音声を Viewer 側の FMOD 2D channel へ接続し、Viewer の Media volume / mute で制御できるようにすることである。
 
-この報告は現時点ではコード調査ベースであり、実機再生テスト結果ではない。
+macOS 実機では、MOAP / YouTube の音声が FMOD 2D channel 経由で鳴り、Viewer の Media volume / mute で調整できることを確認した。実装途中で発生していたプチプチノイズは、FMOD 側の buffer 長調整で解消したと判断している。
 
-## 開発計画の柱
+このブランチでは libVLC direct media の FMOD 接続は扱わない。libVLC / direct media / MP3 / MP4 の統合は優先度を下げ、別ブランチで改めて検証する。
 
-この調査を踏まえた開発計画は、次の 2 段階に分けて扱う。
-
-### Phase 1: macOS の MOAP 音量制御を有効化する
-
-目的は、macOS で MOAP / Web media の音量を Viewer 側から調整できるようにすること。
-
-現状では、macOS の CEF media plugin が `mac_volume_catcher_null.cpp` を使っているため、CEF 経路の音声に対する Media volume が実際の出力音量へ反映されない可能性が高い。
-
-この段階では、音声を 3D Stream に接続することはしない。まずは従来の MOAP 音声経路のまま、Viewer の Media volume / mute が macOS でも正しく効く状態を目標にする。
+## このブランチの範囲
 
 対象:
 
-- `media_plugin_cef` の macOS 音量制御
-- `AudioLevelMedia`
-- `AudioStreamingMedia`
-- `MuteMedia`
-- Web page / HTML5 video / HTML5 audio / YouTube などの CEF 経路
+- MOAP
+- Shared Media
+- Web page media
+- HTML5 audio / video
+- YouTube など、CEF / Dullahan を通るメディア
+- Viewer の Media volume / mute による音量制御
+- FMOD 2D channel への接続
 
-### Phase 2: MOAP 音声を 3D Stream 経路へ接続する
+対象外:
 
-目的は、MOAP で再生される Web media の音声を、AYAstorm の 3D Stream と同じようにプリムスピーカーから鳴らせるようにすること。
+- libVLC direct media
+- URL 末尾が `.mp3` / `.mp4` などの直メディア再生
+- Linux の GStreamer direct media
+- MOAP 音声の 3D Stream / プリムスピーカー接続
+- Parcel Music / Streaming Music の動作変更
 
-現状の MOAP 音声は media plugin process から OS audio device へ直接出ており、FMOD の Stream3D bus には入っていない。
+## 実装後の音声経路
 
-この段階では、MOAP 音声を viewer 側で受け取り、既存の `LLPositionalStreamMulti` / Stream3D speaker routing に接続できる構造を検討する。
-
-対象:
-
-- media plugin からの音声取り出し方法
-- Viewer / FMOD 側への PCM 受け渡し
-- MOAP source と speaker prim の対応付け
-- 既存 Stream3D の range / volume / position / speaker role との統合
-- 従来の media plugin 音声出力との排他、または併用設計
-
-## 結論
-
-このコードベースでは、「音楽・メディア再生」と呼ばれ得るものが少なくとも 3 系統に分かれている。
-
-1. Parcel Music は FMOD の `LLStreamingAudio_FMODSTUDIO` で再生される。
-2. MOAP / Shared Media / Web / Movie は `SLPlugin` 経由の media plugin で再生される。
-3. AYAstorm 3D Stream は `LLPositionalStreamMgr` と `LLPositionalStreamMulti` による独自の FMOD 3D 経路で再生される。
-
-今回の主対象である MOAP / Web media の音声は、現状では FMOD の Stream3D bus には入っていない。
-
-そのため、Media on a Prim の音声は AYAstorm 3D Stream の upmix、LFE、venue reverb、speaker placement とは別系統である。
-
-開発上は、まず macOS でこの既存 MOAP 音声経路の volume control を直し、その次に MOAP 音声を Stream3D 側へ接続する、という順序が妥当である。
-
-## 全体構造
-
-大きく見ると、音声経路は次のようになる。
+今回の主経路:
 
 ```text
-Parcel Music URL
-  -> LLViewerParcelMgr / LLViewerMedia
-  -> LLViewerAudio::startInternetStreamWithAutoFade()
-  -> LLAudioEngine::startInternetStream()
-  -> LLStreamingAudio_FMODSTUDIO
-  -> FMOD 2D stream channel
-  -> OS audio device
+MOAP / Web / HTML5 / YouTube
+  -> CEF / Dullahan
+  -> Dullahan audio callback
+  -> media_plugin_cef
+  -> shared memory audio ring
+  -> Viewer
+  -> LLMediaAudioStream
+  -> FMOD 2D channel
+  -> audio device
+```
 
-MOAP / Shared Media / Web / Movie URL
+音量制御:
+
+```text
+Viewer Media volume / mute
   -> LLViewerMediaImpl
-  -> MIME 判定
-  -> LLPluginClassMedia
-  -> SLPlugin
-  -> media_plugin_cef or media_plugin_libvlc
-  -> plugin process audio output
-  -> OS audio device
-
-AYAstorm 3D Stream tag
-  -> prim Description
-  -> LLPositionalStreamMgr
-  -> LLPositionalStreamMulti
-  -> FMOD source stream + OPENUSER per-speaker channels
-  -> Stream3D FMOD channel group
-  -> OS audio device
+  -> LLMediaAudioStream
+  -> FMOD channel volume
 ```
 
-## 比較対象: Parcel Music / Streaming Music
+この構成により、macOS の CEF native output や VolumeCatcher に依存せず、Viewer 側で Media 音量を制御できる。
 
-Parcel Music は通常の media plugin 経由ではなく、デフォルトでは FMOD ネイティブのストリーミング実装を使う。
+## 実装内容
 
-初期化では `UseMediaPluginsForStreamingAudio` が false の場合、FMOD の実装が選ばれる。
+### Dullahan / CEF
 
-関連箇所:
+Dullahan fork に CEF audio callback API を追加し、CEF が decode した PCM を Viewer 側へ渡せるようにした。
 
-- `indra/newview/llstartup.cpp`
-  - `UseMediaPluginsForStreamingAudio == false` なら `createDefaultStreamingAudioImpl()` を使用
-- `indra/llaudio/llaudioengine_fmodstudio.cpp`
-  - `LLAudioEngine_FMODSTUDIO::createDefaultStreamingAudioImpl()`
-  - `LLStreamingAudio_FMODSTUDIO` を生成
-- `indra/llaudio/llstreamingaudio_fmodstudio.cpp`
-  - `LLStreamingAudio_FMODSTUDIO::start()`
-  - `FMOD::System::createStream()`
-  - `FMOD::System::playSound()`
+Viewer 側では `media_plugin_cef` が Dullahan audio callback を登録し、受け取った PCM を shared memory audio ring へ書き込む。
 
-Parcel Music の開始は主に次の経路で行われる。
+### Shared Memory
+
+media plugin process と Viewer process の間に audio 用 shared memory ring を追加した。
+
+目的:
+
+- media plugin から Viewer へ PCM を渡す
+- callback thread と Viewer / FMOD 側の読み取りを分離する
+- 一時的な供給揺れを吸収する
+- buffer が溜まり続けないよう ring buffer として扱う
+
+### Viewer / FMOD
+
+Viewer 側に `LLMediaAudioStream` を追加し、shared memory ring から PCM を読み出して FMOD 2D `OPENUSER` stream として再生する。
+
+Media volume / mute は FMOD channel 側へ反映する。フェーダー操作時だけ volume update が送られる状態をログで確認済み。
+
+## Dullahan package
+
+Dullahan package はこの Viewer repository には入っていない。
+
+この repository に入っているのは、Viewer 側の実装コードと、外部 package を取得するための `autobuild.xml` の参照設定である。
+
+audio callback 対応 Dullahan package:
 
 ```text
-LLViewerParcelMgr::optionallyStartMusic()
-  -> LLViewerAudio::startInternetStreamWithAutoFade()
-  -> LLAudioEngine::startInternetStream()
-  -> LLStreamingAudio_FMODSTUDIO::start()
+https://github.com/t-noami/dullahan/releases/tag/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3
 ```
 
-`LLStreamingAudio_FMODSTUDIO` は `FMOD_2D | FMOD_NONBLOCKING | FMOD_IGNORETAGS` で `createStream()` している。つまり Parcel Music は 2D のストリーミング音声であり、スピーカー位置を持たない。
+Viewer 側では `autobuild.xml` が上記 release asset を参照する。
 
-音量は `LLViewerAudio::audio_update_volume()` から `gAudiop->setInternetStreamGain()` に入り、最終的に FMOD channel volume に反映される。
+## macOS 検証結果
 
-## Media on a Prim / Shared Media
+確認済み:
 
-MOAP やブラウザ、動画再生は `LLViewerMediaImpl` が入口になる。
+- macOS Viewer build 成功。
+- test app rebuild 済み。
+- MOAP / YouTube の音声が FMOD 2D channel 経由で再生される。
+- Viewer の Media volume / mute が MOAP / YouTube 音声に反映される。
+- フェーダーを動かしていない間、volume update が出続ける状態ではない。
+- 実装途中のプチプチノイズは FMOD buffer 長調整で解消したと判断。
+- `ring_dropped=0` / `frames_silenced=0` の状態を確認済み。
 
-関連箇所:
+注意:
 
-- `indra/newview/llviewermedia.cpp`
-  - `LLViewerMediaImpl::newSourceFromMediaType()`
-  - `LLViewerMediaImpl::initializePlugin()`
-  - `LLViewerMediaImpl::updateVolume()`
-  - `LLViewerMediaImpl::preMediaTexUpdate()`
-- `indra/llplugin/llpluginclassmedia.cpp`
-  - `LLPluginClassMedia::init()`
-  - `LLPluginClassMedia::setVolume()`
-  - shared memory texture update handling
-- `indra/media_plugins/cef/media_plugin_cef.cpp`
-- `indra/media_plugins/libvlc/media_plugin_libvlc.cpp`
+- CEF / MOAP が対象であり、libVLC direct media の検証結果ではない。
+- `media_plugin_cef.cpp` の `GL_RGB` / `GL_BGRA` は CEF の texture params であり、libVLC direct media の不具合とは別系統。
 
-MIME type から media plugin が選ばれる。
+## Windows / Linux 担当者向け確認手順
 
-macOS の `mime_types_mac.xml` では、おおむね次の割り当てになっている。
-
-- `text/html`, `text/plain`, `image/*` など: `media_plugin_cef`
-- `audio/*`, `video/*`, `video/mp4`, `video/quicktime` など: `media_plugin_libvlc`
-- default implementation: `media_plugin_cef`
-
-映像は media plugin が shared memory にピクセルを書き、viewer 側が dirty rect を拾って media texture に転送する。
-
-音声はこの shared memory 経路ではなく、media plugin process 側の CEF / libVLC がそれぞれ OS audio device へ出す。
-
-## MOAP 音声の距離処理
-
-`LLViewerMediaImpl::updateVolume()` には `mProximityCamera` による距離減衰がある。
-
-これは `MediaRollOffMin`, `MediaRollOffMax`, `MediaRollOffRate` を使って、media plugin に渡す volume を viewer 側で計算する仕組みである。
-
-ただし、これは FMOD の 3D channel ではない。実体は media plugin process の音声出力であり、viewer 側で計算した音量を plugin に `set_volume` で渡している。
-
-したがって、MOAP 音声は「距離で音量が変わる」ことはあっても、AYAstorm 3D Stream のような per-speaker placement、upmix、LFE、venue reverb の対象ではない。
-
-## Media plugin 別の音声経路
-
-### CEF
-
-CEF plugin の音量制御は次の流れ。
+1. この Viewer branch を checkout する。
 
 ```text
-LLViewerMediaImpl::updateVolume()
-  -> LLPluginClassMedia::setVolume()
-  -> media time message: set_volume
-  -> MediaPluginCEF::setVolume()
-  -> VolumeCatcher::setVolume()
+feature/media-playback-validation-release
 ```
 
-ただし macOS では `media_plugins/cef/CMakeLists.txt` で `mac_volume_catcher_null.cpp` が使われている。
+2. `autobuild.xml` の `dullahan` dependency が `t-noami/dullahan` の audio callback 対応 release asset を参照していることを確認する。
 
-`mac_volume_catcher_null.cpp` は値を保持するだけで、実際の AudioUnit / OS 出力音量へ反映しない null 実装である。
-
-このため、macOS の CEF media audio については、Viewer の Media volume が実音量に効かない可能性がある。これは実機で確認すべき重要ポイントである。
-
-### libVLC
-
-libVLC plugin の音量制御は次の流れ。
+期待する参照:
 
 ```text
-LLViewerMediaImpl::updateVolume()
-  -> LLPluginClassMedia::setVolume()
-  -> media time message: set_volume
-  -> MediaPluginLibVLC::setVolume()
-  -> libvlc_audio_set_volume()
+https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3/
 ```
 
-`media_plugin_libvlc.cpp` では `libvlc_audio_set_volume()` が呼ばれているため、動画ファイルや `video/mp4` / `audio/*` のような libVLC 経路では plugin 内で音量が反映される構造になっている。
+3. 各 OS の通常手順で Viewer build を実行する。
 
-Windows では追加で `waveOutSetVolume()` の回避処理があるが、macOS では libVLC の音量 API が主経路になる。
+Dullahan package をこの repository に手動コピーする必要はない。`autobuild` が `autobuild.xml` の設定に従って取得する。
 
-## Streaming audio の media plugin fallback
+4. build が通ったら、MOAP / Web / YouTube など CEF 経路の media を再生する。
 
-`UseMediaPluginsForStreamingAudio` を true にすると、Parcel Music も `LLStreamingAudio_MediaPlugins` 経由に切り替わる可能性がある。
+確認する動作:
 
-関連箇所:
+- Viewer の Media volume を下げると MOAP / YouTube 音声が下がる。
+- Media volume を 0 または mute にすると MOAP / YouTube 音声が消える。
+- CEF native output と FMOD output の二重再生になっていない。
+- 長時間再生しても `ring_dropped` / `frames_silenced` が継続的に増えない。
 
-- `indra/newview/llviewermedia_streamingaudio.cpp`
-- `LLStreamingAudio_MediaPlugins::start()`
+## 未確認項目
 
-この場合は `audio/mpeg` として media plugin を初期化し、`LLPluginClassMedia` 経由で再生する。
+- Windows Viewer build。
+- Windows 実機での MOAP / YouTube 再生。
+- Windows 実機での Media volume / mute。
+- Linux Viewer build。
+- Linux 実機での MOAP / YouTube 再生。
+- Linux 実機での Media volume / mute。
+- 長時間再生で audio ring が破綻しないこと。
 
-ただし現在の設定デフォルトは `UseMediaPluginsForStreamingAudio = false` なので、通常の Parcel Music は FMOD 経路である。
+## 別ブランチで扱う項目
 
-## 接続先候補: AYAstorm 3D Stream
+次はこのブランチには含めない。
 
-AYAstorm 3D Stream は通常の MOAP / media plugin ではない。
+- libVLC direct media の FMOD 2D 接続。
+- `.mp3` / `.mp4` など direct media の再生不良調査。
+- Linux GStreamer direct media の FMOD 2D 接続。
+- MOAP 音声の 3D Stream / プリムスピーカー接続。
 
-ただし Phase 2 では、MOAP 音声を接続する先の候補になる。
-
-入口は prim Description の `[3dstream:...]` / `[3dstream-stereo:...]` / legacy `[ayastream:...]` 系タグである。
-
-関連箇所:
-
-- `indra/newview/llselectmgr.cpp`
-  - ObjectProperties 受信時に Description を `LLPositionalStreamMgr` へ渡す
-- `indra/newview/llappviewer.cpp`
-  - frame update で `LLPositionalStreamMgr::update()` を呼ぶ
-- `indra/newview/llpositionalstreammgr.cpp`
-  - Description scan、tag parse、binding 管理
-- `indra/llaudio/llpositionalstreammulti.cpp`
-  - FMOD source stream、per-speaker OPENUSER channel
-- `indra/llaudio/llaudioengine_fmodstudio.cpp`
-  - `Stream3D` channel group と venue reverb DSP
-
-構造は次の通り。
-
-```text
-prim Description
-  -> LLPositionalStreamMgr::onObjectPropertiesReceived()
-  -> tag parse / linkset binding
-  -> LLPositionalStreamMulti::start()
-  -> FMOD::System::createStream(source)
-  -> source PCM read
-  -> per-speaker OPENUSER FMOD::Sound
-  -> per-speaker FMOD::Channel
-  -> set3DAttributes / set3DMinMaxDistance
-  -> Stream3D channel group
-```
-
-`LLPositionalStreamMulti` は source stream をそのまま FMOD channel として鳴らすのではなく、source を読み出し、各 speaker 用の OPENUSER sound / channel に分配する。
-
-このため、speaker ごとの位置、range、volume、upmix、LFE、occlusion、lite-HRTF、venue reverb を扱える。
-
-## 音量カテゴリ
-
-UI 上の音量カテゴリは、おおむね次のように分かれている。
-
-| UI / setting | 主な対象 | 主経路 |
-| --- | --- | --- |
-| `AudioLevelMusic` / `AudioStreamingMusic` | Parcel Music | FMOD streaming audio |
-| `AudioLevelMedia` / `AudioStreamingMedia` | MOAP / Browser / Movie | media plugin |
-| `Stream3DVolumeMaster` / `Stream3DEnabled` | AYAstorm 3D Stream | FMOD Stream3D channel group |
-| SFX / UI / Ambient | 通常の viewer sounds | FMOD audio engine |
-| Voice | voice client | 別系統 |
-
-## 現時点の注意点
-
-### この報告の主対象は MOAP
-
-Parcel Music と既存 AYAstorm 3D Stream は、この報告では主対象ではない。
-
-Parcel Music は、MOAP と異なる既存ストリーミング音楽経路を説明するための比較対象である。
-
-AYAstorm 3D Stream は、将来的に MOAP 音声をプリムスピーカーへ接続するための接続先候補として扱う。
-
-### macOS CEF media volume
-
-macOS では CEF volume catcher が null 実装である。
-
-そのため、HTML5 video、Web audio、YouTube のような CEF 経路の media audio では、viewer の Media volume が期待通り効かない可能性がある。
-
-libVLC 経路の動画 / 音声は `libvlc_audio_set_volume()` があるため、CEF とは別に検証する必要がある。
-
-### 現状の MOAP と 3D Stream は混ぜて考えない
-
-MOAP media audio は media plugin process の音声であり、Stream3D bus には入らない。
-
-そのため、現状の AYAstorm 3D Stream 機能を検証する場合、MOAP の Web/Video 再生ではなく、prim Description の `[3dstream...]` タグ経路を使う必要がある。
-
-一方、Phase 2 の開発では、この分離されている MOAP 音声経路を Stream3D 側へ接続することを目標にする。
-
-### Parcel Music と 3D Stream も別系統
-
-Parcel Music は FMOD だが 2D streaming music である。
-
-FMOD を使っている点は共通だが、Stream3D の per-speaker 3D channel group とは別である。
-
-## 実機検証で見るべき項目
-
-次のケースを分けて確認するのがよい。
-
-1. MOAP text/html / YouTube / HTML5 audio
-   - `media_plugin_cef` 経路になる想定
-   - macOS で Media volume が効くか
-   - `mac_volume_catcher_null.cpp` の影響を確認
-
-2. MOAP video/mp4
-   - macOS では `media_plugin_libvlc` 経路になる想定
-   - Media volume が効くか
-   - `libvlc_audio_set_volume()` 経路のログ追加も検討
-
-3. Parcel Music
-   - `AudioStreamingMusic` on/off
-   - Music volume が効くか
-   - `AudioImpl`, `AudioEngine`, `ParcelMgr` ログ
-
-4. AYAstorm 3D Stream
-   - `[3dstream-stereo:...]` タグの検出
-   - `Stream3D` ログ
-   - speaker channel / range / volume
-   - `Stream3DVolumeMaster`
-   - upmix / LFE / venue reverb / occlusion の有無
-
-## 追加調査候補
-
-- Phase 1: macOS の CEF 音量制御を null 実装のままにするか、別の音量制御経路を実装するか。
-- Phase 2: MOAP media audio を Stream3D へ載せるために、media plugin audio をどの段階で取り出すか。
-- Phase 2: 取り出した MOAP 音声を `LLPositionalStreamMulti` 相当の speaker fan-out に流すか、別の MOAP 専用 3D media stream wrapper を作るか。
-- Phase 2: MOAP の従来音声出力を mute し、Stream3D 側だけを鳴らす制御が必要か。
-- `UseMediaPluginsForStreamingAudio` を有効にした場合の Parcel Music 挙動。現在の通常経路とは異なるため、必要なら別テストにする。
-- CEF と libVLC で Media volume の効き方が一致しているか。
+libVLC については、このブランチで入れた試行実装を戻した。優先度を下げ、別ブランチで改めて調査・実装する。

--- a/docs/ayastorm-media-playback-audio-path-report.md
+++ b/docs/ayastorm-media-playback-audio-path-report.md
@@ -12,6 +12,7 @@
 - [このブランチの範囲](#このブランチの範囲)
 - [実装後の音声経路](#実装後の音声経路)
 - [実装内容](#実装内容)
+- [メンテナ指摘への回答](#メンテナ指摘への回答)
 - [Dullahan package](#dullahan-package)
 - [macOS 検証結果](#macos-検証結果)
 - [Windows / Linux 担当者向け確認手順](#windows--linux-担当者向け確認手順)
@@ -97,6 +98,90 @@ media plugin process と Viewer process の間に audio 用 shared memory ring �
 Viewer 側に `LLMediaAudioStream` を追加し、shared memory ring から PCM を読み出して FMOD 2D `OPENUSER` stream として再生する。
 
 Media volume / mute は FMOD channel 側へ反映する。フェーダー操作時だけ volume update が送られる状態をログで確認済み。
+
+## メンテナ指摘への回答
+
+### media format 切り替え時の FMOD sound 再作成
+
+指摘:
+
+CEF が新しい media に切り替わり、sample rate が 44.1 kHz から 48 kHz へ変わるような場合、`onAudioStreamStartedCallback` は ring の `mSampleRate` を更新する。しかし `LLMediaAudioStream::update()` が `!mChannel` のときだけ `start()` する実装だと、FMOD sound が古い sample rate のまま残るのではないか。
+
+対応:
+
+現在の実装では、audio ring に `mFormatSerial` を追加している。
+
+`media_plugin_cef.cpp` 側では、CEF audio stream の開始 / 停止時に次の値を更新し、`mFormatSerial` を進める。
+
+- `mSampleRate`
+- `mChannels`
+- `mBytesPerSample`
+- `mReadFrame`
+- `mWriteFrame`
+- `mFormatSerial`
+
+`LLMediaAudioStream::update()` 側では、既存の FMOD channel がある場合でも、ring 側の `sample rate` / `channels` / `format serial` と、現在の FMOD sound 作成時に保持した値を比較する。
+
+差異があれば `stop()` してから `start(engine)` を呼び直すため、FMOD sound は新しい sample rate / channel count で作り直される。
+
+また、FMOD の `pcmreadcallback` 実行中に format 差異を検出した場合は、その callback では silence を返し、prebuffer を要求する。これにより、format 切り替え途中の古い channel / sample rate 前提で PCM を読み続けないようにしている。
+
+### audio ring の read/write pointer 競合
+
+指摘:
+
+`media_plugin_cef.cpp` 側で writer が `mReadFrame` を進めると、reader が frame 計算中に read pointer を変更される危険がある。
+
+対応:
+
+現在の実装では、writer 側から `mReadFrame` を進める処理を削除している。
+
+現在の責務は次の通り。
+
+- writer: CEF audio callback から受け取った PCM を ring に書き、最後に `mWriteFrame` を release store する
+- reader: FMOD callback で `mWriteFrame` を acquire load し、読み終えたあと `mReadFrame` を release store する
+
+ring が満杯の場合、writer は `mReadFrame` を再読み込みして空きができているか確認する。それでも満杯なら、未読の古い frame を上書きしたり read pointer を進めたりせず、その時点の入力 frame を書き込まずに捨て、`mTotalFramesDropped` を増やす。
+
+つまり現在は、writer が reader 側の read pointer を強制的に動かさない。これにより、指摘された read/write pointer 競合の主要因を避けている。
+
+この実装は、CEF audio callback 側の単一 writer と、FMOD callback 側の単一 reader を前提にしている。
+
+### macOS VolumeCatcher を残している理由
+
+指摘:
+
+`indra/media_plugins/cef/CMakeLists.txt` で macOS の `mac_volume_catcher_null.cpp` を `mac_volume_catcher.cpp` に切り替え、QuickTime ではなく CoreServices / AudioUnit を使う理由が分かりにくい。Viewer 側で FMOD volume control をするなら VolumeCatcher に依存する必要はないのではないか。
+
+回答:
+
+このブランチでの Viewer 側音量制御は FMOD channel 側で行う。VolumeCatcher は、Media volume のユーザー操作を反映する主経路ではない。
+
+現在 `media_plugin_cef.cpp` の `setVolume()` では、VolumeCatcher に常に `0.0f` を設定している。目的は、CEF native output を無音化し、同じ MOAP 音声が CEF native output と FMOD output の両方から二重再生されるのを防ぐことである。
+
+したがって現在の役割は次の分担になる。
+
+- Viewer Media volume / mute: `LLMediaAudioStream` から FMOD channel に反映する
+- macOS VolumeCatcher: CEF native output を mute するためだけに使う
+
+`mac_volume_catcher_null.cpp` のままだと、CEF native output を確実に無音化できず、FMOD 経由の音声と重なって聞こえる可能性がある。そのため macOS では `mac_volume_catcher.cpp` を使っている。
+
+QuickTime へ戻すのは避けるべきである。QuickTime framework は旧来の macOS メディア API であり、現行 macOS SDK / Apple Silicon arm64 build ではビルド、リンク、将来互換性の面で不利になる。さらに今回制御したい対象は QuickTime の再生音ではなく、CEF が process 内で開く native output AudioUnit である。そのため、QuickTime 依存へ戻すよりも AudioUnit 側を mute する現在の方が目的に近い。
+
+ただし、CoreServices / AudioUnit 版の VolumeCatcher も理想的な最終設計ではない。実装としては Component Manager / `CaptureComponent` を使い、process 内で開かれる Default Output AudioUnit を捕捉して volume を下げる互換ワークアラウンドである。
+
+このブランチでの主経路はあくまで Dullahan audio callback から Viewer 側 FMOD 2D channel へ PCM を流す経路であり、VolumeCatcher はその主経路ではない。macOS VolumeCatcher は、CEF native output を mute して二重再生を避けるための補助策として残している。
+
+将来的に Dullahan / CEF 側で native audio output そのものを無効化できる、または audio callback 専用出力に切り替えられるなら、VolumeCatcher への依存は削減するのが望ましい。
+
+今回その方式にしなかった理由:
+
+- この PR の主目的は、CEF audio callback で取得した PCM を Viewer 側 FMOD 2D channel へ接続し、Media volume / mute で制御できることを確認することである。
+- CEF native output を生成しない設計に踏み込むと、Dullahan / CEF 側の audio lifecycle、platform ごとの audio backend、autoplay / mute / pause の挙動まで変更範囲が広がる。
+- その変更は macOS だけでなく Windows / Linux の CEF 動作にも影響する可能性があり、この PR の macOS 実機検証だけでは十分に安全性を確認できない。
+- 現時点では、native output を mute したうえで FMOD 側を主出力にする方が、既存の CEF media 再生挙動を大きく崩さずに目的を検証しやすい。
+
+そのため、この PR では native output 無効化までは扱わず、二重再生防止を VolumeCatcher に任せる実装に留めている。native output を根本的に無効化する設計は、別ブランチで Dullahan 側の変更として検証するのが適切である。
 
 ## Dullahan package
 

--- a/docs/ayastorm-media-playback-audio-path-report.md
+++ b/docs/ayastorm-media-playback-audio-path-report.md
@@ -1,4 +1,4 @@
-# AYAstorm MOAP audio to FMOD 2D implementation report
+# AYAstorm r24 MOAP audio to FMOD 2D
 
 検証ブランチ: `feature/media-playback-validation-release`
 
@@ -267,6 +267,19 @@ libVLC については、このブランチで入れた試行実装を戻した�
 ## Fallback build (AYAstorm 拡張)
 
 t-noami fork の Dullahan が利用不可になっても upstream `secondlife/dullahan` で build できるよう、`autobuild.xml` に **2 つの dullahan installable** を並べ、CMake スイッチ 1 つで切り替える。
+
+### PR #69 mayatonton コメント反映
+
+PR #69 の mayatonton コメントでは、t-noami/dullahan fork を使った Linux での 3D stream 動作確認後、fork 側の GitHub personal release が配布停止・取り下げになった場合でも AYAstorm が即座にビルド不能にならないよう、commit `9fa27b92ec` で build-time fallback switch を追加したことが説明されている。
+
+切替は CMake フラグ `-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=` で行う。
+
+- `FALSE`: upstream `secondlife/dullahan` を使う。audio callback 経路は `#if LL_DULLAHAN_AUDIO_CALLBACK` で compile out され、fork が使えない状況でも upstream Dullahan だけでビルドを通せる。
+- `TRUE`: `t-noami/dullahan` fork を使う。FMOD audio callback 経路を有効化し、CEF/MOAP audio を Viewer 側 FMOD 経由で扱う。
+
+`autobuild.xml` には upstream 用の `dullahan` と fork 用の `dullahan_aya_audio` の 2 installable を併記する。フラグ切替時の file 衝突は `indra/cmake/CEFPlugin.cmake` が uninstall と sentinel reset を行うため、フラグを変えて configure し直すだけで切替できる。
+
+PR コメント時点では、両モードで Linux build と 3D stream 動作確認済み。Windows / macOS は別途検証予定として扱われていた。
 
 `autobuild.xml` の 2 entry:
 

--- a/docs/ayastorm-media-playback-audio-path-report.md
+++ b/docs/ayastorm-media-playback-audio-path-report.md
@@ -263,3 +263,63 @@ Dullahan package をこの repository に手動コピーする必要はない。
 - MOAP 音声の 3D Stream / プリムスピーカー接続。
 
 libVLC については、このブランチで入れた試行実装を戻した。優先度を下げ、別ブランチで改めて調査・実装する。
+
+## Fallback build (AYAstorm 拡張)
+
+t-noami fork の Dullahan が利用不可になっても upstream `secondlife/dullahan` で build できるよう、`autobuild.xml` に **2 つの dullahan installable** を並べ、CMake スイッチ 1 つで切り替える。
+
+`autobuild.xml` の 2 entry:
+
+| installable key | source | 用途 |
+|---|---|---|
+| `dullahan` | `secondlife/dullahan` v1.26.0-CEF_139.0.40 (upstream) | **default**。CEF audio callback API なし |
+| `dullahan_aya_audio` | `t-noami/dullahan` v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3 (fork) | audio callback API 4 setters を export |
+
+CMake スイッチ: `LL_DULLAHAN_AUDIO_CALLBACK` (`indra/CMakeLists.txt`、**default OFF**)
+
+`indra/cmake/CEFPlugin.cmake` がフラグを見て `use_prebuilt_binary(dullahan)` か `use_prebuilt_binary(dullahan_aya_audio)` のどちらを呼ぶか分岐する。autobuild は呼ばれた方の installable のみ fetch するので、もう片方は download されない。
+
+### A. 本家 dullahan build (default, OFF)
+
+何もしなくて良い:
+
+```bash
+autobuild configure -A 64 -c ReleaseFS_open -- --fmodstudio -DLL_TESTS:BOOL=FALSE --package --chan AYAstorm-release
+autobuild build -A 64 -c ReleaseFS_open --no-configure
+```
+
+挙動:
+
+- autobuild は `dullahan` (upstream) のみ fetch
+- `LLMediaAudioStream` / `LLPluginAudioRingHeader` / CEF audio callback コードはすべて `#ifdef LL_DULLAHAN_AUDIO_CALLBACK` で compile out
+- CEF audio callback の 4 setters は呼ばれない
+- macOS は `mac_volume_catcher_null.cpp` (no-op、upstream Firestorm と同じ)
+- MOAP / Web / YouTube 音は CEF native output → OS audio device 直行、viewer の media volume slider は `VolumeCatcher` 経由で間接制御
+
+### B. t-noami fork dullahan build (opt-in, ON)
+
+configure フラグ 1 つを追加するだけ:
+
+```bash
+autobuild configure -A 64 -c ReleaseFS_open -- --fmodstudio -DLL_TESTS:BOOL=FALSE -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE --package --chan AYAstorm-release
+autobuild build -A 64 -c ReleaseFS_open --no-configure
+```
+
+挙動:
+
+- autobuild は `dullahan_aya_audio` (t-noami fork) のみ fetch
+- `LLMediaAudioStream` / `LLPluginAudioRingHeader` / CEF audio callback すべて compile される
+- macOS は `mac_volume_catcher.cpp` (CEF native output を mute、FMOD path のみ鳴らす)
+- MOAP / Web / YouTube 音は viewer 側 FMOD 2D channel 経由で再生
+
+`autobuild.xml` は static、`git status` 常に clean、pre-DL も `--local` も sed も不要。
+
+### `#ifdef LL_DULLAHAN_AUDIO_CALLBACK` ガード対象ファイル
+
+- `indra/CMakeLists.txt`: option 定義と compile definition `LL_DULLAHAN_AUDIO_CALLBACK=1` の付与
+- `indra/cmake/CEFPlugin.cmake`: `use_prebuilt_binary` の installable 名切替
+- `indra/llaudio/CMakeLists.txt`: `llmediaaudiostream.cpp/h` の追加を flag 連動
+- `indra/media_plugins/cef/CMakeLists.txt`: macOS の `mac_volume_catcher.cpp` ↔ `mac_volume_catcher_null.cpp` 切替
+- `indra/llplugin/llpluginclassmedia.cpp`: `ensureAudioSharedMemory()` / `getAudioData()` の中身
+- `indra/media_plugins/cef/media_plugin_cef.cpp`: callback 登録、`audio_shm_set` message handler、`writeAudioPacketToRing()` 周辺
+- `indra/newview/llviewermedia.cpp` / `.h`: `mMediaAudioStream` メンバ、`mAppliedVolume` メンバ、update/destroy/updateVolume での参照

--- a/docs/ayastorm-r24-moap-audio-to-fmod-2d.md
+++ b/docs/ayastorm-r24-moap-audio-to-fmod-2d.md
@@ -1,6 +1,6 @@
 # AYAstorm r24 MOAP audio to FMOD 2D
 
-検証ブランチ: `feature/media-playback-validation-release`
+検証ブランチ: `feature/ayastorm-r24-moap-audio-to-fmod-2d`
 
 検証日: 2026-05-15
 

--- a/indra/CMakeLists.txt
+++ b/indra/CMakeLists.txt
@@ -97,6 +97,19 @@ else (FS_PF_USER_AGENT)
 endif (FS_PF_USER_AGENT)
 # </Beq>
 
+# <AYAstorm> Toggle Dullahan audio-callback (CEF/MOAP -> FMOD) integration
+# Default OFF uses upstream secondlife/dullahan (autobuild installable "dullahan").
+# Turn ON to fetch the t-noami/dullahan fork installable "dullahan_aya_audio" and
+# compile the FMOD audio-callback path in media_plugin_cef / llviewermedia.
+option(LL_DULLAHAN_AUDIO_CALLBACK "Route CEF/MOAP audio through FMOD via t-noami/dullahan audio callback" OFF)
+if (LL_DULLAHAN_AUDIO_CALLBACK)
+    add_compile_definitions(LL_DULLAHAN_AUDIO_CALLBACK=1)
+    message(STATUS "Dullahan audio callback path: ENABLED (installable dullahan_aya_audio = t-noami/dullahan fork)")
+else (LL_DULLAHAN_AUDIO_CALLBACK)
+    message(STATUS "Dullahan audio callback path: DISABLED (installable dullahan = upstream secondlife/dullahan)")
+endif (LL_DULLAHAN_AUDIO_CALLBACK)
+# </AYAstorm>
+
 # <FS:Ansariel> [AVX Optimization]
 option(USE_AVX_OPTIMIZATION "AVX optimization support" OFF)
 option(USE_AVX2_OPTIMIZATION "AVX2 optimization support" OFF)

--- a/indra/cmake/CEFPlugin.cmake
+++ b/indra/cmake/CEFPlugin.cmake
@@ -5,7 +5,28 @@ include(Prebuilt)
 include_guard()
 add_library( ll::cef INTERFACE IMPORTED )
 
-use_prebuilt_binary(dullahan)
+# <AYAstorm> select dullahan installable: upstream (default) vs t-noami fork w/ audio callback
+# Both installables extract to the same include/cef and lib/libdullahan paths, so
+# switching variants must uninstall the previously-installed one to avoid an
+# autobuild file-conflict error.  Sentinel below also resets so use_prebuilt_binary
+# re-runs install for the newly selected variant.
+if (LL_DULLAHAN_AUDIO_CALLBACK)
+    set(_dullahan_pkg dullahan_aya_audio)
+    set(_dullahan_other dullahan)
+else ()
+    set(_dullahan_pkg dullahan)
+    set(_dullahan_other dullahan_aya_audio)
+endif ()
+execute_process(COMMAND "${AUTOBUILD_EXECUTABLE}" uninstall
+                --install-dir=${AUTOBUILD_INSTALL_DIR}
+                ${_dullahan_other}
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                OUTPUT_QUIET ERROR_QUIET
+                RESULT_VARIABLE _dullahan_uninstall_unused)
+file(REMOVE "${PREBUILD_TRACKING_DIR}/${_dullahan_pkg}_installed")
+file(REMOVE "${PREBUILD_TRACKING_DIR}/${_dullahan_other}_installed")
+use_prebuilt_binary(${_dullahan_pkg})
+# </AYAstorm>
 target_include_directories( ll::cef SYSTEM INTERFACE  ${LIBS_PREBUILT_DIR}/include/cef)
 
 if (WINDOWS)

--- a/indra/llaudio/CMakeLists.txt
+++ b/indra/llaudio/CMakeLists.txt
@@ -34,7 +34,6 @@ if (TARGET ll::fmodstudio)
          llaudioengine_fmodstudio.cpp
          lllistener_fmodstudio.cpp
          llstreamingaudio_fmodstudio.cpp
-         llmediaaudiostream.cpp
          llpositionalstream.cpp
          llpositionalstreamstereo.cpp
          llpositionalstreammulti.cpp
@@ -52,7 +51,6 @@ if (TARGET ll::fmodstudio)
          llaudioengine_fmodstudio.h
          lllistener_fmodstudio.h
          llstreamingaudio_fmodstudio.h
-         llmediaaudiostream.h
          llpositionalstream.h
          llpositionalstreamstereo.h
          llpositionalstreammulti.h
@@ -65,6 +63,13 @@ if (TARGET ll::fmodstudio)
          llstream3durlresolve.h
          fmod_codec_opus.h
          )
+
+    # <AYAstorm> Dullahan audio callback path requires the t-noami/dullahan fork
+    if (LL_DULLAHAN_AUDIO_CALLBACK)
+        list(APPEND llaudio_SOURCE_FILES llmediaaudiostream.cpp)
+        list(APPEND llaudio_HEADER_FILES llmediaaudiostream.h)
+    endif ()
+    # </AYAstorm>
 endif ()
 
 if (TARGET ll::openal)

--- a/indra/llaudio/CMakeLists.txt
+++ b/indra/llaudio/CMakeLists.txt
@@ -34,6 +34,7 @@ if (TARGET ll::fmodstudio)
          llaudioengine_fmodstudio.cpp
          lllistener_fmodstudio.cpp
          llstreamingaudio_fmodstudio.cpp
+         llmediaaudiostream.cpp
          llpositionalstream.cpp
          llpositionalstreamstereo.cpp
          llpositionalstreammulti.cpp
@@ -51,6 +52,7 @@ if (TARGET ll::fmodstudio)
          llaudioengine_fmodstudio.h
          lllistener_fmodstudio.h
          llstreamingaudio_fmodstudio.h
+         llmediaaudiostream.h
          llpositionalstream.h
          llpositionalstreamstereo.h
          llpositionalstreammulti.h

--- a/indra/llaudio/llmediaaudiostream.cpp
+++ b/indra/llaudio/llmediaaudiostream.cpp
@@ -1,0 +1,296 @@
+/**
+ * @file llmediaaudiostream.cpp
+ * @brief FMOD 2D playback bridge for CEF/MOAP audio PCM.
+ */
+
+#include "linden_common.h"
+
+#include "llmediaaudiostream.h"
+
+#include "llaudioengine.h"
+#include "llaudioengine_fmodstudio.h"
+#include "llpluginaudio.h"
+#include "lltimer.h"
+
+#include "fmodstudio/fmod.hpp"
+#include "fmodstudio/fmod_errors.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+namespace
+{
+    constexpr U32 MEDIA_AUDIO_PREBUFFER_FRAMES = 4096;
+
+    bool checkFmod(FMOD_RESULT result, const char* what)
+    {
+        if (result == FMOD_OK)
+        {
+            return false;
+        }
+        LL_WARNS("AYAMediaAudio") << what << " error: " << FMOD_ErrorString(result) << LL_ENDL;
+        return true;
+    }
+}
+
+LLMediaAudioStream::LLMediaAudioStream()
+:   mRing(nullptr),
+    mSystem(nullptr),
+    mSound(nullptr),
+    mChannel(nullptr),
+    mVolume(1.f),
+    mSampleRate(0),
+    mChannels(0),
+    mPlaybackStarted(false),
+    mNeedsPrebuffer(false),
+    mCallbackCount(0),
+    mFramesRequested(0),
+    mFramesRead(0),
+    mFramesSilenced(0),
+    mMinAvailableFrames(std::numeric_limits<U32>::max()),
+    mMaxAvailableFrames(0),
+    mLastLoggedCallbackCount(0),
+    mLastLoggedFramesRequested(0),
+    mLastLoggedFramesRead(0),
+    mLastLoggedFramesSilenced(0),
+    mLastLoggedFramesDropped(0),
+    mNextStatsLogTime(0.0)
+{
+}
+
+LLMediaAudioStream::~LLMediaAudioStream()
+{
+    stop();
+}
+
+void LLMediaAudioStream::setRing(LLPluginAudioRingHeader* ring)
+{
+    if (mRing != ring)
+    {
+        stop();
+        mRing = ring;
+    }
+}
+
+void LLMediaAudioStream::setVolume(F32 volume)
+{
+    mVolume = llclamp(volume, 0.f, 1.f);
+    if (mChannel)
+    {
+        checkFmod(mChannel->setVolume(mVolume), "FMOD::Channel::setVolume(media)");
+    }
+}
+
+void LLMediaAudioStream::update(LLAudioEngine* engine)
+{
+    if (!mRing ||
+        mRing->mMagic != LL_PLUGIN_AUDIO_RING_MAGIC ||
+        mRing->mVersion != LL_PLUGIN_AUDIO_RING_VERSION ||
+        mRing->mSampleRate == 0 ||
+        mRing->mChannels == 0)
+    {
+        stop();
+        return;
+    }
+
+    if (!mChannel)
+    {
+        start(engine);
+        return;
+    }
+
+    bool playing = false;
+    if (checkFmod(mChannel->isPlaying(&playing), "FMOD::Channel::isPlaying(media)") || !playing)
+    {
+        stop();
+        return;
+    }
+
+    if (mNeedsPrebuffer.exchange(false, std::memory_order_acq_rel))
+    {
+        checkFmod(mChannel->setPaused(true), "FMOD::Channel::setPaused(media prebuffer)");
+        mPlaybackStarted = false;
+    }
+
+    if (!mPlaybackStarted)
+    {
+        if (availableFrames() >= MEDIA_AUDIO_PREBUFFER_FRAMES)
+        {
+            checkFmod(mChannel->setPaused(false), "FMOD::Channel::setPaused(media start)");
+            mPlaybackStarted = true;
+        }
+        return;
+    }
+}
+
+void LLMediaAudioStream::stop()
+{
+    if (mChannel)
+    {
+        mChannel->stop();
+        mChannel = nullptr;
+    }
+    if (mSound)
+    {
+        mSound->release();
+        mSound = nullptr;
+    }
+    mSystem = nullptr;
+    mSampleRate = 0;
+    mChannels = 0;
+    mPlaybackStarted = false;
+    mNeedsPrebuffer.store(false, std::memory_order_relaxed);
+    mCallbackCount.store(0, std::memory_order_relaxed);
+    mFramesRequested.store(0, std::memory_order_relaxed);
+    mFramesRead.store(0, std::memory_order_relaxed);
+    mFramesSilenced.store(0, std::memory_order_relaxed);
+    mMinAvailableFrames.store(std::numeric_limits<U32>::max(), std::memory_order_relaxed);
+    mMaxAvailableFrames.store(0, std::memory_order_relaxed);
+    mLastLoggedCallbackCount = 0;
+    mLastLoggedFramesRequested = 0;
+    mLastLoggedFramesRead = 0;
+    mLastLoggedFramesSilenced = 0;
+    mLastLoggedFramesDropped = 0;
+    mNextStatsLogTime = 0.0;
+}
+
+bool LLMediaAudioStream::start(LLAudioEngine* engine)
+{
+    LLAudioEngine_FMODSTUDIO* fmod_engine = dynamic_cast<LLAudioEngine_FMODSTUDIO*>(engine);
+    if (!fmod_engine || !mRing)
+    {
+        return false;
+    }
+
+    mSystem = fmod_engine->getSystem();
+    if (!mSystem)
+    {
+        return false;
+    }
+
+    mSampleRate = mRing->mSampleRate;
+    mChannels = llclamp((U32)mRing->mChannels, 1u, LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+
+    FMOD_CREATESOUNDEXINFO ex;
+    std::memset(&ex, 0, sizeof(ex));
+    ex.cbsize = sizeof(ex);
+    ex.defaultfrequency = (int)mSampleRate;
+    ex.numchannels = (int)mChannels;
+    ex.format = FMOD_SOUND_FORMAT_PCMFLOAT;
+    ex.decodebuffersize = 4096;
+    // Length is in bytes. Keep this consistent with the existing 3D Stream
+    // OPENUSER paths so FMOD has a less aggressive loop boundary.
+    ex.length = mSampleRate * mChannels * sizeof(float) * 5;
+    ex.pcmreadcallback = &LLMediaAudioStream::pcmReadCallback;
+    ex.userdata = this;
+
+    const FMOD_MODE mode = FMOD_OPENUSER | FMOD_CREATESTREAM | FMOD_LOOP_NORMAL | FMOD_2D;
+    if (checkFmod(mSystem->createSound(nullptr, mode, &ex, &mSound),
+                  "FMOD::System::createSound(media OPENUSER)"))
+    {
+        mSound = nullptr;
+        return false;
+    }
+
+    if (checkFmod(mSystem->playSound(mSound, nullptr, true, &mChannel),
+                  "FMOD::System::playSound(media)"))
+    {
+        stop();
+        return false;
+    }
+
+    setVolume(mVolume);
+    mPlaybackStarted = false;
+    mNeedsPrebuffer.store(false, std::memory_order_relaxed);
+
+    return true;
+}
+
+U32 LLMediaAudioStream::availableFrames() const
+{
+    if (!mRing)
+    {
+        return 0;
+    }
+
+    const U32 capacity = mRing->mCapacityFrames;
+    if (capacity == 0)
+    {
+        return 0;
+    }
+
+    const U32 total = capacity + 1;
+    const U32 read = mRing->mReadFrame.load(std::memory_order_acquire);
+    const U32 write = mRing->mWriteFrame.load(std::memory_order_acquire);
+    return (write >= read) ? (write - read) : (total - read + write);
+}
+
+FMOD_RESULT LLMediaAudioStream::pcmReadCallback(FMOD_SOUND* sound, void* data, unsigned int datalen)
+{
+    void* userdata = nullptr;
+    if (sound && FMOD_Sound_GetUserData(sound, &userdata) == FMOD_OK && userdata)
+    {
+        return static_cast<LLMediaAudioStream*>(userdata)->readPCM(data, datalen);
+    }
+    std::memset(data, 0, datalen);
+    return FMOD_OK;
+}
+
+FMOD_RESULT LLMediaAudioStream::readPCM(void* data, unsigned int datalen)
+{
+    if (!mRing || mChannels == 0)
+    {
+        std::memset(data, 0, datalen);
+        return FMOD_OK;
+    }
+
+    float* dst = static_cast<float*>(data);
+    const U32 request_frames = datalen / (mChannels * sizeof(float));
+    const U32 capacity = mRing->mCapacityFrames;
+    const U32 total = capacity + 1;
+    U32 read = mRing->mReadFrame.load(std::memory_order_relaxed);
+    const U32 write = mRing->mWriteFrame.load(std::memory_order_acquire);
+    U32 available = (write >= read) ? (write - read) : (total - read + write);
+    const bool underflow = available < request_frames;
+    const U32 frames_to_read = underflow ? 0 : request_frames;
+
+    U32 min_available = mMinAvailableFrames.load(std::memory_order_relaxed);
+    while (available < min_available &&
+           !mMinAvailableFrames.compare_exchange_weak(min_available, available, std::memory_order_relaxed))
+    {
+    }
+    U32 max_available = mMaxAvailableFrames.load(std::memory_order_relaxed);
+    while (available > max_available &&
+           !mMaxAvailableFrames.compare_exchange_weak(max_available, available, std::memory_order_relaxed))
+    {
+    }
+
+    mCallbackCount.fetch_add(1, std::memory_order_relaxed);
+    mFramesRequested.fetch_add(request_frames, std::memory_order_relaxed);
+    mFramesRead.fetch_add(frames_to_read, std::memory_order_relaxed);
+
+    const float* samples = reinterpret_cast<const float*>(
+        reinterpret_cast<const unsigned char*>(mRing) + mRing->mHeaderSize);
+
+    for (U32 frame = 0; frame < frames_to_read; ++frame)
+    {
+        const float* src = samples + ((size_t)read * LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+        for (U32 ch = 0; ch < mChannels; ++ch)
+        {
+            *dst++ = src[ch];
+        }
+        read = (read + 1) % total;
+    }
+
+    if (frames_to_read < request_frames)
+    {
+        const size_t missing_samples = (request_frames - frames_to_read) * mChannels;
+        std::memset(dst, 0, missing_samples * sizeof(float));
+        mFramesSilenced.fetch_add(request_frames - frames_to_read, std::memory_order_relaxed);
+        mNeedsPrebuffer.store(true, std::memory_order_release);
+    }
+
+    mRing->mReadFrame.store(read, std::memory_order_release);
+    return FMOD_OK;
+}

--- a/indra/llaudio/llmediaaudiostream.cpp
+++ b/indra/llaudio/llmediaaudiostream.cpp
@@ -42,6 +42,7 @@ LLMediaAudioStream::LLMediaAudioStream()
     mVolume(1.f),
     mSampleRate(0),
     mChannels(0),
+    mFormatSerial(0),
     mPlaybackStarted(false),
     mNeedsPrebuffer(false),
     mCallbackCount(0),
@@ -87,15 +88,30 @@ void LLMediaAudioStream::update(LLAudioEngine* engine)
     if (!mRing ||
         mRing->mMagic != LL_PLUGIN_AUDIO_RING_MAGIC ||
         mRing->mVersion != LL_PLUGIN_AUDIO_RING_VERSION ||
-        mRing->mSampleRate == 0 ||
-        mRing->mChannels == 0)
+        mRing->mSampleRate.load(std::memory_order_acquire) == 0 ||
+        mRing->mChannels.load(std::memory_order_acquire) == 0)
     {
         stop();
         return;
     }
 
+    const U32 ring_sample_rate = mRing->mSampleRate.load(std::memory_order_acquire);
+    const U32 ring_channels = llclamp((U32)mRing->mChannels.load(std::memory_order_acquire),
+                                      1u,
+                                      LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+    const U32 ring_format_serial = mRing->mFormatSerial.load(std::memory_order_acquire);
+
     if (!mChannel)
     {
+        start(engine);
+        return;
+    }
+
+    if (ring_sample_rate != mSampleRate ||
+        ring_channels != mChannels ||
+        ring_format_serial != mFormatSerial)
+    {
+        stop();
         start(engine);
         return;
     }
@@ -139,6 +155,7 @@ void LLMediaAudioStream::stop()
     mSystem = nullptr;
     mSampleRate = 0;
     mChannels = 0;
+    mFormatSerial = 0;
     mPlaybackStarted = false;
     mNeedsPrebuffer.store(false, std::memory_order_relaxed);
     mCallbackCount.store(0, std::memory_order_relaxed);
@@ -169,8 +186,11 @@ bool LLMediaAudioStream::start(LLAudioEngine* engine)
         return false;
     }
 
-    mSampleRate = mRing->mSampleRate;
-    mChannels = llclamp((U32)mRing->mChannels, 1u, LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+    mSampleRate = mRing->mSampleRate.load(std::memory_order_acquire);
+    mChannels = llclamp((U32)mRing->mChannels.load(std::memory_order_acquire),
+                        1u,
+                        LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+    mFormatSerial = mRing->mFormatSerial.load(std::memory_order_acquire);
 
     FMOD_CREATESOUNDEXINFO ex;
     std::memset(&ex, 0, sizeof(ex));
@@ -242,6 +262,20 @@ FMOD_RESULT LLMediaAudioStream::readPCM(void* data, unsigned int datalen)
     if (!mRing || mChannels == 0)
     {
         std::memset(data, 0, datalen);
+        return FMOD_OK;
+    }
+
+    const U32 ring_sample_rate = mRing->mSampleRate.load(std::memory_order_acquire);
+    const U32 ring_channels = llclamp((U32)mRing->mChannels.load(std::memory_order_acquire),
+                                      1u,
+                                      LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+    const U32 ring_format_serial = mRing->mFormatSerial.load(std::memory_order_acquire);
+    if (ring_sample_rate != mSampleRate ||
+        ring_channels != mChannels ||
+        ring_format_serial != mFormatSerial)
+    {
+        std::memset(data, 0, datalen);
+        mNeedsPrebuffer.store(true, std::memory_order_release);
         return FMOD_OK;
     }
 

--- a/indra/llaudio/llmediaaudiostream.h
+++ b/indra/llaudio/llmediaaudiostream.h
@@ -47,6 +47,7 @@ private:
     F32 mVolume;
     U32 mSampleRate;
     U32 mChannels;
+    U32 mFormatSerial;
     bool mPlaybackStarted;
     std::atomic<bool> mNeedsPrebuffer;
     std::atomic<U64> mCallbackCount;

--- a/indra/llaudio/llmediaaudiostream.h
+++ b/indra/llaudio/llmediaaudiostream.h
@@ -1,0 +1,66 @@
+/**
+ * @file llmediaaudiostream.h
+ * @brief FMOD 2D playback bridge for CEF/MOAP audio PCM.
+ */
+
+#ifndef LL_LLMEDIAAUDIOSTREAM_H
+#define LL_LLMEDIAAUDIOSTREAM_H
+
+#include "stdtypes.h"
+
+#include "fmodstudio/fmod_common.h"
+
+#include <atomic>
+
+class LLAudioEngine;
+struct LLPluginAudioRingHeader;
+
+namespace FMOD
+{
+    class System;
+    class Sound;
+    class Channel;
+}
+
+class LLMediaAudioStream
+{
+public:
+    LLMediaAudioStream();
+    ~LLMediaAudioStream();
+
+    void setRing(LLPluginAudioRingHeader* ring);
+    void setVolume(F32 volume);
+    void update(LLAudioEngine* engine);
+    void stop();
+
+private:
+    bool start(LLAudioEngine* engine);
+    U32 availableFrames() const;
+    static FMOD_RESULT pcmReadCallback(FMOD_SOUND* sound, void* data, unsigned int datalen);
+    FMOD_RESULT readPCM(void* data, unsigned int datalen);
+
+private:
+    LLPluginAudioRingHeader* mRing;
+    FMOD::System* mSystem;
+    FMOD::Sound* mSound;
+    FMOD::Channel* mChannel;
+    F32 mVolume;
+    U32 mSampleRate;
+    U32 mChannels;
+    bool mPlaybackStarted;
+    std::atomic<bool> mNeedsPrebuffer;
+    std::atomic<U64> mCallbackCount;
+    std::atomic<U64> mFramesRequested;
+    std::atomic<U64> mFramesRead;
+    std::atomic<U64> mFramesSilenced;
+    std::atomic<U32> mMinAvailableFrames;
+    std::atomic<U32> mMaxAvailableFrames;
+    U64 mLastLoggedCallbackCount;
+    U64 mLastLoggedFramesRequested;
+    U64 mLastLoggedFramesRead;
+    U64 mLastLoggedFramesSilenced;
+    U64 mLastLoggedFramesDropped;
+    F64 mNextStatsLogTime;
+};
+
+#endif // LL_LLMEDIAAUDIOSTREAM_H

--- a/indra/llcommon/CMakeLists.txt
+++ b/indra/llcommon/CMakeLists.txt
@@ -193,6 +193,7 @@ set(llcommon_HEADER_FILES
     llmutex.h
     llnametable.h
     llpointer.h
+    llpluginaudio.h
     llprofiler.h
     llprofilercategories.h
     llpounceable.h

--- a/indra/llcommon/llpluginaudio.h
+++ b/indra/llcommon/llpluginaudio.h
@@ -1,0 +1,32 @@
+/**
+ * @file llpluginaudio.h
+ * @brief Shared-memory audio ring used by media plugins.
+ */
+
+#ifndef LL_LLPLUGINAUDIO_H
+#define LL_LLPLUGINAUDIO_H
+
+#include <atomic>
+#include <cstdint>
+
+static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_MAGIC = 0x41594141; // "AYAA"
+static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_VERSION = 1;
+static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_MAX_CHANNELS = 8;
+
+struct LLPluginAudioRingHeader
+{
+    std::uint32_t mMagic;
+    std::uint32_t mVersion;
+    std::uint32_t mHeaderSize;
+    std::uint32_t mCapacityFrames;
+    std::uint32_t mSampleRate;
+    std::uint32_t mChannels;
+    std::uint32_t mBytesPerSample;
+    std::uint32_t mReserved;
+    std::atomic<std::uint32_t> mWriteFrame;
+    std::atomic<std::uint32_t> mReadFrame;
+    std::atomic<std::uint64_t> mTotalFramesWritten;
+    std::atomic<std::uint64_t> mTotalFramesDropped;
+};
+
+#endif // LL_LLPLUGINAUDIO_H

--- a/indra/llcommon/llpluginaudio.h
+++ b/indra/llcommon/llpluginaudio.h
@@ -10,7 +10,7 @@
 #include <cstdint>
 
 static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_MAGIC = 0x41594141; // "AYAA"
-static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_VERSION = 1;
+static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_VERSION = 2;
 static constexpr std::uint32_t LL_PLUGIN_AUDIO_RING_MAX_CHANNELS = 8;
 
 struct LLPluginAudioRingHeader
@@ -19,10 +19,10 @@ struct LLPluginAudioRingHeader
     std::uint32_t mVersion;
     std::uint32_t mHeaderSize;
     std::uint32_t mCapacityFrames;
-    std::uint32_t mSampleRate;
-    std::uint32_t mChannels;
-    std::uint32_t mBytesPerSample;
-    std::uint32_t mReserved;
+    std::atomic<std::uint32_t> mSampleRate;
+    std::atomic<std::uint32_t> mChannels;
+    std::atomic<std::uint32_t> mBytesPerSample;
+    std::atomic<std::uint32_t> mFormatSerial;
     std::atomic<std::uint32_t> mWriteFrame;
     std::atomic<std::uint32_t> mReadFrame;
     std::atomic<std::uint64_t> mTotalFramesWritten;

--- a/indra/llplugin/CMakeLists.txt
+++ b/indra/llplugin/CMakeLists.txt
@@ -37,4 +37,3 @@ add_library (llplugin ${llplugin_SOURCE_FILES})
 target_include_directories( llplugin  INTERFACE   ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries( llplugin llcommon llmath llmessage llxml )
 add_subdirectory(slplugin)
-

--- a/indra/llplugin/llpluginclassmedia.cpp
+++ b/indra/llplugin/llpluginclassmedia.cpp
@@ -357,10 +357,10 @@ void LLPluginClassMedia::ensureAudioSharedMemory()
     header->mVersion = LL_PLUGIN_AUDIO_RING_VERSION;
     header->mHeaderSize = sizeof(LLPluginAudioRingHeader);
     header->mCapacityFrames = MEDIA_AUDIO_RING_CAPACITY_FRAMES;
-    header->mSampleRate = 0;
-    header->mChannels = 0;
-    header->mBytesPerSample = sizeof(float);
-    header->mReserved = 0;
+    header->mSampleRate.store(0, std::memory_order_relaxed);
+    header->mChannels.store(0, std::memory_order_relaxed);
+    header->mBytesPerSample.store(sizeof(float), std::memory_order_relaxed);
+    header->mFormatSerial.store(0, std::memory_order_relaxed);
     header->mWriteFrame.store(0, std::memory_order_relaxed);
     header->mReadFrame.store(0, std::memory_order_relaxed);
     header->mTotalFramesWritten.store(0, std::memory_order_relaxed);

--- a/indra/llplugin/llpluginclassmedia.cpp
+++ b/indra/llplugin/llpluginclassmedia.cpp
@@ -30,7 +30,9 @@
 #include "indra_constants.h"
 
 #include "llpluginclassmedia.h"
+#if LL_DULLAHAN_AUDIO_CALLBACK
 #include "llpluginaudio.h"
+#endif
 #include "llpluginmessageclasses.h"
 #include "llcontrol.h"
 
@@ -40,10 +42,12 @@ extern bool gHiDPISupport;
 #endif
 
 static int LOW_PRIORITY_TEXTURE_SIZE_DEFAULT = 256;
+#if LL_DULLAHAN_AUDIO_CALLBACK
 static const size_t MEDIA_AUDIO_RING_CAPACITY_FRAMES = 48000 * 2;
 static const size_t MEDIA_AUDIO_SHARED_MEMORY_SIZE =
     sizeof(LLPluginAudioRingHeader) +
     (MEDIA_AUDIO_RING_CAPACITY_FRAMES * LL_PLUGIN_AUDIO_RING_MAX_CHANNELS * sizeof(float));
+#endif
 
 static int nextPowerOf2( int value )
 {
@@ -180,7 +184,9 @@ void LLPluginClassMedia::idle(void)
         mPlugin->idle();
     }
 
+#if LL_DULLAHAN_AUDIO_CALLBACK
     ensureAudioSharedMemory();
+#endif
 
     if((mMediaWidth == -1) || (!mTextureParamsReceived) || (mPlugin == NULL) || (mPlugin->isBlocked()) || (mOwner == NULL))
     {
@@ -319,14 +325,19 @@ unsigned char* LLPluginClassMedia::getBitsData()
 
 void* LLPluginClassMedia::getAudioData()
 {
+#if LL_DULLAHAN_AUDIO_CALLBACK
     void *result = NULL;
     if((mPlugin != NULL) && !mAudioSharedMemoryName.empty())
     {
         result = mPlugin->getSharedMemoryAddress(mAudioSharedMemoryName);
     }
     return result;
+#else
+    return NULL;
+#endif
 }
 
+#if LL_DULLAHAN_AUDIO_CALLBACK
 void LLPluginClassMedia::ensureAudioSharedMemory()
 {
     if(!mPlugin || !mPlugin->isRunning() || !mAudioSharedMemoryName.empty())
@@ -379,6 +390,7 @@ void LLPluginClassMedia::ensureAudioSharedMemory()
                        << " capacity_frames=" << MEDIA_AUDIO_RING_CAPACITY_FRAMES
                        << LL_ENDL;
 }
+#endif // LL_DULLAHAN_AUDIO_CALLBACK
 
 void LLPluginClassMedia::setSize(int width, int height)
 {

--- a/indra/llplugin/llpluginclassmedia.cpp
+++ b/indra/llplugin/llpluginclassmedia.cpp
@@ -30,6 +30,7 @@
 #include "indra_constants.h"
 
 #include "llpluginclassmedia.h"
+#include "llpluginaudio.h"
 #include "llpluginmessageclasses.h"
 #include "llcontrol.h"
 
@@ -39,6 +40,10 @@ extern bool gHiDPISupport;
 #endif
 
 static int LOW_PRIORITY_TEXTURE_SIZE_DEFAULT = 256;
+static const size_t MEDIA_AUDIO_RING_CAPACITY_FRAMES = 48000 * 2;
+static const size_t MEDIA_AUDIO_SHARED_MEMORY_SIZE =
+    sizeof(LLPluginAudioRingHeader) +
+    (MEDIA_AUDIO_RING_CAPACITY_FRAMES * LL_PLUGIN_AUDIO_RING_MAX_CHANNELS * sizeof(float));
 
 static int nextPowerOf2( int value )
 {
@@ -105,6 +110,8 @@ void LLPluginClassMedia::reset()
     mRequestedTextureCoordsOpenGL = false;
     mTextureSharedMemorySize = 0;
     mTextureSharedMemoryName.clear();
+    mAudioSharedMemorySize = 0;
+    mAudioSharedMemoryName.clear();
     mDefaultMediaWidth = 0;
     mDefaultMediaHeight = 0;
     mNaturalMediaWidth = 0;
@@ -172,6 +179,8 @@ void LLPluginClassMedia::idle(void)
     {
         mPlugin->idle();
     }
+
+    ensureAudioSharedMemory();
 
     if((mMediaWidth == -1) || (!mTextureParamsReceived) || (mPlugin == NULL) || (mPlugin->isBlocked()) || (mOwner == NULL))
     {
@@ -306,6 +315,69 @@ unsigned char* LLPluginClassMedia::getBitsData()
         result = (unsigned char*)mPlugin->getSharedMemoryAddress(mTextureSharedMemoryName);
     }
     return result;
+}
+
+void* LLPluginClassMedia::getAudioData()
+{
+    void *result = NULL;
+    if((mPlugin != NULL) && !mAudioSharedMemoryName.empty())
+    {
+        result = mPlugin->getSharedMemoryAddress(mAudioSharedMemoryName);
+    }
+    return result;
+}
+
+void LLPluginClassMedia::ensureAudioSharedMemory()
+{
+    if(!mPlugin || !mPlugin->isRunning() || !mAudioSharedMemoryName.empty())
+    {
+        return;
+    }
+
+    mAudioSharedMemorySize = MEDIA_AUDIO_SHARED_MEMORY_SIZE;
+    mAudioSharedMemoryName = mPlugin->addSharedMemory(mAudioSharedMemorySize);
+    if(mAudioSharedMemoryName.empty())
+    {
+        LL_WARNS("Plugin") << "Couldn't create media audio shared memory segment." << LL_ENDL;
+        mAudioSharedMemorySize = 0;
+        return;
+    }
+
+    void *addr = mPlugin->getSharedMemoryAddress(mAudioSharedMemoryName);
+    if(!addr)
+    {
+        LL_WARNS("Plugin") << "Failed to map media audio shared memory: "
+                            << mAudioSharedMemoryName << LL_ENDL;
+        return;
+    }
+
+    memset(addr, 0x00, mAudioSharedMemorySize);
+    LLPluginAudioRingHeader *header = reinterpret_cast<LLPluginAudioRingHeader*>(addr);
+    header->mMagic = LL_PLUGIN_AUDIO_RING_MAGIC;
+    header->mVersion = LL_PLUGIN_AUDIO_RING_VERSION;
+    header->mHeaderSize = sizeof(LLPluginAudioRingHeader);
+    header->mCapacityFrames = MEDIA_AUDIO_RING_CAPACITY_FRAMES;
+    header->mSampleRate = 0;
+    header->mChannels = 0;
+    header->mBytesPerSample = sizeof(float);
+    header->mReserved = 0;
+    header->mWriteFrame.store(0, std::memory_order_relaxed);
+    header->mReadFrame.store(0, std::memory_order_relaxed);
+    header->mTotalFramesWritten.store(0, std::memory_order_relaxed);
+    header->mTotalFramesDropped.store(0, std::memory_order_relaxed);
+
+    LLPluginMessage message(LLPLUGIN_MESSAGE_CLASS_MEDIA, "audio_shm_set");
+    message.setValue("name", mAudioSharedMemoryName);
+    message.setValueS32("size", (S32)mAudioSharedMemorySize);
+    message.setValueS32("capacity_frames", (S32)MEDIA_AUDIO_RING_CAPACITY_FRAMES);
+    message.setValueS32("max_channels", (S32)LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+    mPlugin->sendMessage(message);
+
+    LL_INFOS("Plugin") << "Created media audio shared memory: "
+                       << mAudioSharedMemoryName
+                       << " size=" << mAudioSharedMemorySize
+                       << " capacity_frames=" << MEDIA_AUDIO_RING_CAPACITY_FRAMES
+                       << LL_ENDL;
 }
 
 void LLPluginClassMedia::setSize(int width, int height)

--- a/indra/llplugin/llpluginclassmedia.h
+++ b/indra/llplugin/llpluginclassmedia.h
@@ -71,6 +71,8 @@ public:
 
     // This may return NULL.  Callers need to check for and handle this case.
     unsigned char* getBitsData();
+    void* getAudioData();
+    size_t getAudioDataSize() const { return mAudioSharedMemorySize; }
 
     // gets the format details of the texture data
     // These may return 0 if they haven't been set up yet.  The caller needs to detect this case.
@@ -361,6 +363,7 @@ protected:
     std::queue<LLPluginMessage> mSendQueue;     // Used to queue messages while the plugin initializes.
 
     void setSizeInternal(void);
+    void ensureAudioSharedMemory();
 
     bool        mTextureParamsReceived;     // the mRequestedTexture* fields are only valid when this is true
     S32         mRequestedTextureDepth;
@@ -372,6 +375,8 @@ protected:
 
     std::string mTextureSharedMemoryName;
     size_t      mTextureSharedMemorySize;
+    std::string mAudioSharedMemoryName;
+    size_t      mAudioSharedMemorySize;
 
     // True to scale requested media up to the full size of the texture (i.e. next power of two)
     bool        mAutoScaleMedia;

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -38,6 +38,8 @@ if (LINUX)
   set(CMAKE_SHARED_LINKER_FLAGS  "-Wl,--build-id -Wl,-rpath,'$ORIGIN:$ORIGIN/../../lib'")
   list(APPEND media_plugin_cef_LINK_LIBRARIES llwindow ${MEDIA_PLUGIN_BASE_LIBRARIES})
 elseif (DARWIN)
+  # The viewer-owned media volume path is FMOD. Keep the macOS VolumeCatcher
+  # active only so CEF's native output can be muted and not double-played.
   list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher.cpp)
   find_library(CORESERVICES_LIBRARY CoreServices)
   find_library(AUDIOUNIT_LIBRARY AudioUnit)

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -38,15 +38,22 @@ if (LINUX)
   set(CMAKE_SHARED_LINKER_FLAGS  "-Wl,--build-id -Wl,-rpath,'$ORIGIN:$ORIGIN/../../lib'")
   list(APPEND media_plugin_cef_LINK_LIBRARIES llwindow ${MEDIA_PLUGIN_BASE_LIBRARIES})
 elseif (DARWIN)
-  # The viewer-owned media volume path is FMOD. Keep the macOS VolumeCatcher
-  # active only so CEF's native output can be muted and not double-played.
-  list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher.cpp)
-  find_library(CORESERVICES_LIBRARY CoreServices)
-  find_library(AUDIOUNIT_LIBRARY AudioUnit)
-  set( media_plugin_cef_LINK_LIBRARIES
-       ${CORESERVICES_LIBRARY}     # for Component Manager calls
-       ${AUDIOUNIT_LIBRARY}        # for AudioUnit calls
-       )
+  # <AYAstorm> When Dullahan audio callback is ON, the viewer plays CEF/MOAP
+  # PCM through FMOD, so the macOS VolumeCatcher only needs to mute the
+  # plugin-side native output (to avoid double-play). When OFF, fall back to
+  # the upstream "null" VolumeCatcher path used before PR #69.
+  if (LL_DULLAHAN_AUDIO_CALLBACK)
+    list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher.cpp)
+    find_library(CORESERVICES_LIBRARY CoreServices)
+    find_library(AUDIOUNIT_LIBRARY AudioUnit)
+    set( media_plugin_cef_LINK_LIBRARIES
+         ${CORESERVICES_LIBRARY}     # for Component Manager calls
+         ${AUDIOUNIT_LIBRARY}        # for AudioUnit calls
+         )
+  else (LL_DULLAHAN_AUDIO_CALLBACK)
+    list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher_null.cpp)
+  endif (LL_DULLAHAN_AUDIO_CALLBACK)
+  # </AYAstorm>
 elseif (WINDOWS)
   list(APPEND media_plugin_cef_SOURCE_FILES windows_volume_catcher.cpp)
 endif (LINUX)

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -38,7 +38,7 @@ if (LINUX)
   set(CMAKE_SHARED_LINKER_FLAGS  "-Wl,--build-id -Wl,-rpath,'$ORIGIN:$ORIGIN/../../lib'")
   list(APPEND media_plugin_cef_LINK_LIBRARIES llwindow ${MEDIA_PLUGIN_BASE_LIBRARIES})
 elseif (DARWIN)
-  list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher_null.cpp)
+  list(APPEND media_plugin_cef_SOURCE_FILES mac_volume_catcher.cpp)
   find_library(CORESERVICES_LIBRARY CoreServices)
   find_library(AUDIOUNIT_LIBRARY AudioUnit)
   set( media_plugin_cef_LINK_LIBRARIES

--- a/indra/media_plugins/cef/mac_volume_catcher.cpp
+++ b/indra/media_plugins/cef/mac_volume_catcher.cpp
@@ -33,9 +33,10 @@
     kHALOutputParam_Volume parameter on all of them to adjust the output volume.
 **************************************************************************************************************/
 
+#include "linden_common.h"
 #include "volume_catcher.h"
 
-#include <QuickTime/QuickTime.h>
+#include <CoreServices/CoreServices.h>
 #include <AudioUnit/AudioUnit.h>
 #include <list>
 
@@ -239,7 +240,7 @@ void VolumeCatcherImpl::setInstanceVolume(VolumeCatcherStorage *instance)
 
     if(err)
     {
-//      std::cerr << "    AudioUnitSetParameter returned " << err << std::endl;
+        LL_WARNS("Media") << "VolumeCatcher AudioUnitSetParameter returned " << err << LL_ENDL;
     }
 }
 

--- a/indra/media_plugins/cef/media_plugin_cef.cpp
+++ b/indra/media_plugins/cef/media_plugin_cef.cpp
@@ -34,7 +34,9 @@
 #include "llplugininstance.h"
 #include "llpluginmessage.h"
 #include "llpluginmessageclasses.h"
+#if LL_DULLAHAN_AUDIO_CALLBACK
 #include "llpluginaudio.h"
+#endif
 #include "llstring.h"
 #if LL_VOLUME_CATCHER
 #include "volume_catcher.h"
@@ -83,11 +85,13 @@ private:
     const std::vector<std::string> onFileDialog(dullahan::EFileDialogType dialog_type, const std::string dialog_title, const std::string default_file, const std::string dialog_accept_filter, bool& use_default);
     bool onJSDialogCallback(const std::string origin_url, const std::string message_text, const std::string default_prompt_text);
     bool onJSBeforeUnloadCallback();
+#if LL_DULLAHAN_AUDIO_CALLBACK
     void onAudioStreamStartedCallback(const dullahan::dullahan_audio_stream_info& info);
     void onAudioStreamPacketCallback(const float** data, int frames, int64_t pts);
     void onAudioStreamStoppedCallback();
     void onAudioStreamErrorCallback(const std::string message);
     void writeAudioPacketToRing(const float** data, int frames);
+#endif
 
     void postDebugMessage(const std::string& msg);
     void authResponse(LLPluginMessage &message);
@@ -126,6 +130,7 @@ private:
     std::string mCefLogFile;
     bool mCefLogVerbose;
     std::vector<std::string> mPickedFiles;
+#if LL_DULLAHAN_AUDIO_CALLBACK
     bool mAudioStreamActive;
     int mAudioStreamSampleRate;
     int mAudioStreamChannels;
@@ -133,6 +138,7 @@ private:
     LLPluginAudioRingHeader* mAudioRing;
     size_t mAudioRingSize;
     int mAudioRingMaxChannels;
+#endif
 #if LL_VOLUME_CATCHER
     VolumeCatcher mVolumeCatcher;
 #endif
@@ -176,6 +182,7 @@ MediaPluginBase(host_send_func, host_user_data)
     mCefLogFile = "";
     mCefLogVerbose = false;
     mPickedFiles.clear();
+#if LL_DULLAHAN_AUDIO_CALLBACK
     mAudioStreamActive = false;
     mAudioStreamSampleRate = 0;
     mAudioStreamChannels = 0;
@@ -183,6 +190,7 @@ MediaPluginBase(host_send_func, host_user_data)
     mAudioRing = nullptr;
     mAudioRingSize = 0;
     mAudioRingMaxChannels = 0;
+#endif
     mCurVolume = 0.0;
 
     mCEFLib = new dullahan();
@@ -441,6 +449,7 @@ bool MediaPluginCEF::onJSBeforeUnloadCallback()
     return true;
 }
 
+#if LL_DULLAHAN_AUDIO_CALLBACK
 ////////////////////////////////////////////////////////////////////////////////
 //
 void MediaPluginCEF::onAudioStreamStartedCallback(const dullahan::dullahan_audio_stream_info& info)
@@ -560,6 +569,7 @@ void MediaPluginCEF::writeAudioPacketToRing(const float** data, int frames)
     mAudioRing->mWriteFrame.store(write, std::memory_order_release);
     mAudioRing->mTotalFramesWritten.fetch_add(written, std::memory_order_relaxed);
 }
+#endif // LL_DULLAHAN_AUDIO_CALLBACK
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -741,12 +751,14 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
                         mPixels = NULL;
                         mTextureSegmentName.clear();
                     }
+#if LL_DULLAHAN_AUDIO_CALLBACK
                     if (mAudioRing == iter->second.mAddress)
                     {
                         mAudioRing = nullptr;
                         mAudioRingSize = 0;
                         mAudioRingMaxChannels = 0;
                     }
+#endif
                     mSharedSegments.erase(iter);
                 }
                 else
@@ -763,6 +775,7 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
         }
         else if (message_class == LLPLUGIN_MESSAGE_CLASS_MEDIA)
         {
+#if LL_DULLAHAN_AUDIO_CALLBACK
             if (message_name == "audio_shm_set")
             {
                 std::string name = message_in.getValue("name");
@@ -779,6 +792,9 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
                 }
             }
             else if (message_name == "init")
+#else
+            if (message_name == "init")
+#endif
             {
                 // event callbacks from Dullahan
                 mCEFLib->setOnPageChangedCallback(std::bind(&MediaPluginCEF::onPageChangedCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
@@ -803,10 +819,12 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
                 mCEFLib->setOnRequestExitCallback(std::bind(&MediaPluginCEF::onRequestExitCallback, this));
                 mCEFLib->setOnJSDialogCallback(std::bind(&MediaPluginCEF::onJSDialogCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
                 mCEFLib->setOnJSBeforeUnloadCallback(std::bind(&MediaPluginCEF::onJSBeforeUnloadCallback, this));
+#if LL_DULLAHAN_AUDIO_CALLBACK
                 mCEFLib->setOnAudioStreamStartedCallback(std::bind(&MediaPluginCEF::onAudioStreamStartedCallback, this, std::placeholders::_1));
                 mCEFLib->setOnAudioStreamPacketCallback(std::bind(&MediaPluginCEF::onAudioStreamPacketCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
                 mCEFLib->setOnAudioStreamStoppedCallback(std::bind(&MediaPluginCEF::onAudioStreamStoppedCallback, this));
                 mCEFLib->setOnAudioStreamErrorCallback(std::bind(&MediaPluginCEF::onAudioStreamErrorCallback, this, std::placeholders::_1));
+#endif
 
                 dullahan::dullahan_settings settings;
 #if LL_WINDOWS
@@ -1401,9 +1419,15 @@ void MediaPluginCEF::checkEditState()
 void MediaPluginCEF::setVolume()
 {
 #if LL_VOLUME_CATCHER
-    // The viewer now plays CEF/MOAP PCM through FMOD. Keep the plugin-side
+#if LL_DULLAHAN_AUDIO_CALLBACK
+    // The viewer plays CEF/MOAP PCM through FMOD. Keep the plugin-side
     // native output silent so the same media audio is not heard twice.
     mVolumeCatcher.setVolume(0.0f);
+#else
+    // Fallback: no FMOD bridge, so let CEF's native audio output through the
+    // OS audio device, controlled by the viewer-side volume catcher.
+    mVolumeCatcher.setVolume(mCurVolume);
+#endif
 #endif
 }
 

--- a/indra/media_plugins/cef/media_plugin_cef.cpp
+++ b/indra/media_plugins/cef/media_plugin_cef.cpp
@@ -451,13 +451,14 @@ void MediaPluginCEF::onAudioStreamStartedCallback(const dullahan::dullahan_audio
     mAudioStreamFramesReceived = 0;
     if (mAudioRing)
     {
-        mAudioRing->mSampleRate = (std::uint32_t)llmax(0, info.sample_rate);
-        mAudioRing->mChannels = (std::uint32_t)llclamp(info.channels, 0, (int)LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
-        mAudioRing->mBytesPerSample = sizeof(float);
         mAudioRing->mWriteFrame.store(0, std::memory_order_release);
         mAudioRing->mReadFrame.store(0, std::memory_order_release);
         mAudioRing->mTotalFramesWritten.store(0, std::memory_order_release);
         mAudioRing->mTotalFramesDropped.store(0, std::memory_order_release);
+        mAudioRing->mSampleRate.store((std::uint32_t)llmax(0, info.sample_rate), std::memory_order_release);
+        mAudioRing->mChannels.store((std::uint32_t)llclamp(info.channels, 0, (int)LL_PLUGIN_AUDIO_RING_MAX_CHANNELS), std::memory_order_release);
+        mAudioRing->mBytesPerSample.store(sizeof(float), std::memory_order_release);
+        mAudioRing->mFormatSerial.fetch_add(1, std::memory_order_acq_rel);
     }
 
 }
@@ -485,6 +486,14 @@ void MediaPluginCEF::onAudioStreamStoppedCallback()
     mAudioStreamSampleRate = 0;
     mAudioStreamChannels = 0;
     mAudioStreamFramesReceived = 0;
+    if (mAudioRing)
+    {
+        mAudioRing->mSampleRate.store(0, std::memory_order_release);
+        mAudioRing->mChannels.store(0, std::memory_order_release);
+        mAudioRing->mWriteFrame.store(0, std::memory_order_release);
+        mAudioRing->mReadFrame.store(0, std::memory_order_release);
+        mAudioRing->mFormatSerial.fetch_add(1, std::memory_order_acq_rel);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -519,15 +528,19 @@ void MediaPluginCEF::writeAudioPacketToRing(const float** data, int frames)
     const std::uint32_t total = capacity + 1;
     std::uint32_t write = mAudioRing->mWriteFrame.load(std::memory_order_relaxed);
     std::uint32_t read = mAudioRing->mReadFrame.load(std::memory_order_acquire);
+    std::uint64_t written = 0;
 
     for (int frame = 0; frame < frames; ++frame)
     {
         const std::uint32_t next = (write + 1) % total;
         if (next == read)
         {
-            mAudioRing->mReadFrame.store((read + 1) % total, std::memory_order_release);
             read = mAudioRing->mReadFrame.load(std::memory_order_acquire);
-            mAudioRing->mTotalFramesDropped.fetch_add(1, std::memory_order_relaxed);
+            if (next == read)
+            {
+                mAudioRing->mTotalFramesDropped.fetch_add(1, std::memory_order_relaxed);
+                continue;
+            }
         }
 
         float* dst = samples + ((size_t)write * LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
@@ -541,10 +554,11 @@ void MediaPluginCEF::writeAudioPacketToRing(const float** data, int frames)
         }
 
         write = next;
+        ++written;
     }
 
     mAudioRing->mWriteFrame.store(write, std::memory_order_release);
-    mAudioRing->mTotalFramesWritten.fetch_add((std::uint64_t)frames, std::memory_order_relaxed);
+    mAudioRing->mTotalFramesWritten.fetch_add(written, std::memory_order_relaxed);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/indra/media_plugins/cef/media_plugin_cef.cpp
+++ b/indra/media_plugins/cef/media_plugin_cef.cpp
@@ -34,6 +34,7 @@
 #include "llplugininstance.h"
 #include "llpluginmessage.h"
 #include "llpluginmessageclasses.h"
+#include "llpluginaudio.h"
 #include "llstring.h"
 #if LL_VOLUME_CATCHER
 #include "volume_catcher.h"
@@ -82,6 +83,11 @@ private:
     const std::vector<std::string> onFileDialog(dullahan::EFileDialogType dialog_type, const std::string dialog_title, const std::string default_file, const std::string dialog_accept_filter, bool& use_default);
     bool onJSDialogCallback(const std::string origin_url, const std::string message_text, const std::string default_prompt_text);
     bool onJSBeforeUnloadCallback();
+    void onAudioStreamStartedCallback(const dullahan::dullahan_audio_stream_info& info);
+    void onAudioStreamPacketCallback(const float** data, int frames, int64_t pts);
+    void onAudioStreamStoppedCallback();
+    void onAudioStreamErrorCallback(const std::string message);
+    void writeAudioPacketToRing(const float** data, int frames);
 
     void postDebugMessage(const std::string& msg);
     void authResponse(LLPluginMessage &message);
@@ -120,6 +126,13 @@ private:
     std::string mCefLogFile;
     bool mCefLogVerbose;
     std::vector<std::string> mPickedFiles;
+    bool mAudioStreamActive;
+    int mAudioStreamSampleRate;
+    int mAudioStreamChannels;
+    U64 mAudioStreamFramesReceived;
+    LLPluginAudioRingHeader* mAudioRing;
+    size_t mAudioRingSize;
+    int mAudioRingMaxChannels;
 #if LL_VOLUME_CATCHER
     VolumeCatcher mVolumeCatcher;
 #endif
@@ -163,6 +176,13 @@ MediaPluginBase(host_send_func, host_user_data)
     mCefLogFile = "";
     mCefLogVerbose = false;
     mPickedFiles.clear();
+    mAudioStreamActive = false;
+    mAudioStreamSampleRate = 0;
+    mAudioStreamChannels = 0;
+    mAudioStreamFramesReceived = 0;
+    mAudioRing = nullptr;
+    mAudioRingSize = 0;
+    mAudioRingMaxChannels = 0;
     mCurVolume = 0.0;
 
     mCEFLib = new dullahan();
@@ -423,6 +443,112 @@ bool MediaPluginCEF::onJSBeforeUnloadCallback()
 
 ////////////////////////////////////////////////////////////////////////////////
 //
+void MediaPluginCEF::onAudioStreamStartedCallback(const dullahan::dullahan_audio_stream_info& info)
+{
+    mAudioStreamActive = true;
+    mAudioStreamSampleRate = info.sample_rate;
+    mAudioStreamChannels = info.channels;
+    mAudioStreamFramesReceived = 0;
+    if (mAudioRing)
+    {
+        mAudioRing->mSampleRate = (std::uint32_t)llmax(0, info.sample_rate);
+        mAudioRing->mChannels = (std::uint32_t)llclamp(info.channels, 0, (int)LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+        mAudioRing->mBytesPerSample = sizeof(float);
+        mAudioRing->mWriteFrame.store(0, std::memory_order_release);
+        mAudioRing->mReadFrame.store(0, std::memory_order_release);
+        mAudioRing->mTotalFramesWritten.store(0, std::memory_order_release);
+        mAudioRing->mTotalFramesDropped.store(0, std::memory_order_release);
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+void MediaPluginCEF::onAudioStreamPacketCallback(const float** data, int frames, int64_t pts)
+{
+    (void)pts;
+
+    if (!mAudioStreamActive || !data || frames <= 0)
+    {
+        return;
+    }
+
+    mAudioStreamFramesReceived += (U64)frames;
+    writeAudioPacketToRing(data, frames);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+void MediaPluginCEF::onAudioStreamStoppedCallback()
+{
+    mAudioStreamActive = false;
+    mAudioStreamSampleRate = 0;
+    mAudioStreamChannels = 0;
+    mAudioStreamFramesReceived = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+void MediaPluginCEF::onAudioStreamErrorCallback(const std::string message)
+{
+    LL_WARNS("AYAMediaAudio") << "CEF audio stream error: " << message << LL_ENDL;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+void MediaPluginCEF::writeAudioPacketToRing(const float** data, int frames)
+{
+    if (!mAudioRing ||
+        mAudioRing->mMagic != LL_PLUGIN_AUDIO_RING_MAGIC ||
+        mAudioRing->mVersion != LL_PLUGIN_AUDIO_RING_VERSION ||
+        mAudioStreamChannels <= 0 ||
+        frames <= 0)
+    {
+        return;
+    }
+
+    const std::uint32_t channels = (std::uint32_t)llclamp(mAudioStreamChannels, 1, mAudioRingMaxChannels);
+    const std::uint32_t capacity = mAudioRing->mCapacityFrames;
+    if (channels == 0 || capacity == 0)
+    {
+        return;
+    }
+
+    float* samples = reinterpret_cast<float*>(
+        reinterpret_cast<unsigned char*>(mAudioRing) + mAudioRing->mHeaderSize);
+    const std::uint32_t total = capacity + 1;
+    std::uint32_t write = mAudioRing->mWriteFrame.load(std::memory_order_relaxed);
+    std::uint32_t read = mAudioRing->mReadFrame.load(std::memory_order_acquire);
+
+    for (int frame = 0; frame < frames; ++frame)
+    {
+        const std::uint32_t next = (write + 1) % total;
+        if (next == read)
+        {
+            mAudioRing->mReadFrame.store((read + 1) % total, std::memory_order_release);
+            read = mAudioRing->mReadFrame.load(std::memory_order_acquire);
+            mAudioRing->mTotalFramesDropped.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        float* dst = samples + ((size_t)write * LL_PLUGIN_AUDIO_RING_MAX_CHANNELS);
+        for (std::uint32_t ch = 0; ch < channels; ++ch)
+        {
+            dst[ch] = data[ch] ? data[ch][frame] : 0.f;
+        }
+        for (std::uint32_t ch = channels; ch < LL_PLUGIN_AUDIO_RING_MAX_CHANNELS; ++ch)
+        {
+            dst[ch] = 0.f;
+        }
+
+        write = next;
+    }
+
+    mAudioRing->mWriteFrame.store(write, std::memory_order_release);
+    mAudioRing->mTotalFramesWritten.fetch_add((std::uint64_t)frames, std::memory_order_relaxed);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
 void MediaPluginCEF::onCursorChangedCallback(dullahan::ECursorType type)
 {
     std::string name = "";
@@ -601,6 +727,12 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
                         mPixels = NULL;
                         mTextureSegmentName.clear();
                     }
+                    if (mAudioRing == iter->second.mAddress)
+                    {
+                        mAudioRing = nullptr;
+                        mAudioRingSize = 0;
+                        mAudioRingMaxChannels = 0;
+                    }
                     mSharedSegments.erase(iter);
                 }
                 else
@@ -617,7 +749,22 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
         }
         else if (message_class == LLPLUGIN_MESSAGE_CLASS_MEDIA)
         {
-            if (message_name == "init")
+            if (message_name == "audio_shm_set")
+            {
+                std::string name = message_in.getValue("name");
+                SharedSegmentMap::iterator iter = mSharedSegments.find(name);
+                if (iter != mSharedSegments.end())
+                {
+                    mAudioRing = reinterpret_cast<LLPluginAudioRingHeader*>(iter->second.mAddress);
+                    mAudioRingSize = iter->second.mSize;
+                    mAudioRingMaxChannels = message_in.getValueS32("max_channels");
+                }
+                else
+                {
+                    LL_WARNS("AYAMediaAudio") << "CEF audio shared memory not found: " << name << LL_ENDL;
+                }
+            }
+            else if (message_name == "init")
             {
                 // event callbacks from Dullahan
                 mCEFLib->setOnPageChangedCallback(std::bind(&MediaPluginCEF::onPageChangedCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
@@ -642,6 +789,10 @@ void MediaPluginCEF::receiveMessage(const char* message_string)
                 mCEFLib->setOnRequestExitCallback(std::bind(&MediaPluginCEF::onRequestExitCallback, this));
                 mCEFLib->setOnJSDialogCallback(std::bind(&MediaPluginCEF::onJSDialogCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
                 mCEFLib->setOnJSBeforeUnloadCallback(std::bind(&MediaPluginCEF::onJSBeforeUnloadCallback, this));
+                mCEFLib->setOnAudioStreamStartedCallback(std::bind(&MediaPluginCEF::onAudioStreamStartedCallback, this, std::placeholders::_1));
+                mCEFLib->setOnAudioStreamPacketCallback(std::bind(&MediaPluginCEF::onAudioStreamPacketCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+                mCEFLib->setOnAudioStreamStoppedCallback(std::bind(&MediaPluginCEF::onAudioStreamStoppedCallback, this));
+                mCEFLib->setOnAudioStreamErrorCallback(std::bind(&MediaPluginCEF::onAudioStreamErrorCallback, this, std::placeholders::_1));
 
                 dullahan::dullahan_settings settings;
 #if LL_WINDOWS
@@ -1236,7 +1387,9 @@ void MediaPluginCEF::checkEditState()
 void MediaPluginCEF::setVolume()
 {
 #if LL_VOLUME_CATCHER
-    mVolumeCatcher.setVolume(mCurVolume);
+    // The viewer now plays CEF/MOAP PCM through FMOD. Keep the plugin-side
+    // native output silent so the same media audio is not heard twice.
+    mVolumeCatcher.setVolume(0.0f);
 #endif
 }
 

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -32,8 +32,10 @@
 #include "llagentcamera.h"
 #include "llappviewer.h"
 #include "llaudioengine.h"  // for gAudiop
+#if LL_DULLAHAN_AUDIO_CALLBACK
 #include "llmediaaudiostream.h"
 #include "llpluginaudio.h"
+#endif
 #include "llcallbacklist.h"
 #include "lldir.h"
 #include "lldiriterator.h"
@@ -1625,7 +1627,9 @@ LLViewerMediaImpl::LLViewerMediaImpl(     const LLUUID& texture_id,
                                           U8 media_loop)
 :
     mMediaSource( NULL ),
+#if LL_DULLAHAN_AUDIO_CALLBACK
     mMediaAudioStream(new LLMediaAudioStream()),
+#endif
     mMovieImageHasMips(false),
     mMediaWidth(media_width),
     mMediaHeight(media_height),
@@ -1647,7 +1651,9 @@ LLViewerMediaImpl::LLViewerMediaImpl(     const LLUUID& texture_id,
     mMediaSourceFailed(false),
     mRequestedVolume(1.0f),
     mPreviousVolume(1.0f),
+#if LL_DULLAHAN_AUDIO_CALLBACK
     mAppliedVolume(-1.0f),
+#endif
     mIsMuted(false),
     mNeedsMuteCheck(false),
     mPreviousMediaState(MEDIA_NONE),
@@ -1768,11 +1774,13 @@ void LLViewerMediaImpl::createMediaSource()
 void LLViewerMediaImpl::destroyMediaSource()
 {
     mNeedsNewTexture = true;
+#if LL_DULLAHAN_AUDIO_CALLBACK
     if (mMediaAudioStream)
     {
         mMediaAudioStream->stop();
         mMediaAudioStream->setRing(nullptr);
     }
+#endif
 
     // Tell the viewer media texture it's no longer active
     LLViewerMediaTexture* oldImage = LLViewerTextureManager::findMediaTexture( mTextureId );
@@ -1998,7 +2006,9 @@ bool LLViewerMediaImpl::initializePlugin(const std::string& media_type)
 
         mMediaSource.reset(media_source);
         mMediaSource->setDeleteOK(false) ;
+#if LL_DULLAHAN_AUDIO_CALLBACK
         mAppliedVolume = -1.0f;
+#endif
         updateVolume();
 
         return true;
@@ -2243,6 +2253,7 @@ void LLViewerMediaImpl::updateVolume()
 
         if (sOnlyAudibleTextureID == LLUUID::null || sOnlyAudibleTextureID == mTextureId)
         {
+#if LL_DULLAHAN_AUDIO_CALLBACK
             if (mAppliedVolume != volume)
             {
                 mMediaSource->setVolume(volume);
@@ -2252,9 +2263,13 @@ void LLViewerMediaImpl::updateVolume()
                 }
                 mAppliedVolume = volume;
             }
+#else
+            mMediaSource->setVolume(volume);
+#endif
         }
         else
         {
+#if LL_DULLAHAN_AUDIO_CALLBACK
             if (mAppliedVolume != 0.0f)
             {
                 mMediaSource->setVolume(0.0f);
@@ -2264,6 +2279,9 @@ void LLViewerMediaImpl::updateVolume()
                 }
                 mAppliedVolume = 0.0f;
             }
+#else
+            mMediaSource->setVolume(0.0f);
+#endif
         }
     }
 }
@@ -3022,11 +3040,13 @@ void LLViewerMediaImpl::update()
         return;
     }
 
+#if LL_DULLAHAN_AUDIO_CALLBACK
     if (mMediaAudioStream)
     {
         mMediaAudioStream->setRing(reinterpret_cast<LLPluginAudioRingHeader*>(mMediaSource->getAudioData()));
         mMediaAudioStream->update(gAudiop);
     }
+#endif
 
     if(!mMediaSource->textureValid())
     {

--- a/indra/newview/llviewermedia.cpp
+++ b/indra/newview/llviewermedia.cpp
@@ -32,6 +32,8 @@
 #include "llagentcamera.h"
 #include "llappviewer.h"
 #include "llaudioengine.h"  // for gAudiop
+#include "llmediaaudiostream.h"
+#include "llpluginaudio.h"
 #include "llcallbacklist.h"
 #include "lldir.h"
 #include "lldiriterator.h"
@@ -1623,6 +1625,7 @@ LLViewerMediaImpl::LLViewerMediaImpl(     const LLUUID& texture_id,
                                           U8 media_loop)
 :
     mMediaSource( NULL ),
+    mMediaAudioStream(new LLMediaAudioStream()),
     mMovieImageHasMips(false),
     mMediaWidth(media_width),
     mMediaHeight(media_height),
@@ -1644,6 +1647,7 @@ LLViewerMediaImpl::LLViewerMediaImpl(     const LLUUID& texture_id,
     mMediaSourceFailed(false),
     mRequestedVolume(1.0f),
     mPreviousVolume(1.0f),
+    mAppliedVolume(-1.0f),
     mIsMuted(false),
     mNeedsMuteCheck(false),
     mPreviousMediaState(MEDIA_NONE),
@@ -1764,6 +1768,11 @@ void LLViewerMediaImpl::createMediaSource()
 void LLViewerMediaImpl::destroyMediaSource()
 {
     mNeedsNewTexture = true;
+    if (mMediaAudioStream)
+    {
+        mMediaAudioStream->stop();
+        mMediaAudioStream->setRing(nullptr);
+    }
 
     // Tell the viewer media texture it's no longer active
     LLViewerMediaTexture* oldImage = LLViewerTextureManager::findMediaTexture( mTextureId );
@@ -1989,6 +1998,7 @@ bool LLViewerMediaImpl::initializePlugin(const std::string& media_type)
 
         mMediaSource.reset(media_source);
         mMediaSource->setDeleteOK(false) ;
+        mAppliedVolume = -1.0f;
         updateVolume();
 
         return true;
@@ -2233,11 +2243,27 @@ void LLViewerMediaImpl::updateVolume()
 
         if (sOnlyAudibleTextureID == LLUUID::null || sOnlyAudibleTextureID == mTextureId)
         {
-            mMediaSource->setVolume(volume);
+            if (mAppliedVolume != volume)
+            {
+                mMediaSource->setVolume(volume);
+                if (mMediaAudioStream)
+                {
+                    mMediaAudioStream->setVolume(volume);
+                }
+                mAppliedVolume = volume;
+            }
         }
         else
         {
-            mMediaSource->setVolume(0.0f);
+            if (mAppliedVolume != 0.0f)
+            {
+                mMediaSource->setVolume(0.0f);
+                if (mMediaAudioStream)
+                {
+                    mMediaAudioStream->setVolume(0.0f);
+                }
+                mAppliedVolume = 0.0f;
+            }
         }
     }
 }
@@ -2994,6 +3020,12 @@ void LLViewerMediaImpl::update()
         resetPreviousMediaState();
         destroyMediaSource();
         return;
+    }
+
+    if (mMediaAudioStream)
+    {
+        mMediaAudioStream->setRing(reinterpret_cast<LLPluginAudioRingHeader*>(mMediaSource->getAudioData()));
+        mMediaAudioStream->update(gAudiop);
     }
 
     if(!mMediaSource->textureValid())

--- a/indra/newview/llviewermedia.h
+++ b/indra/newview/llviewermedia.h
@@ -452,7 +452,9 @@ private:
 private:
     // a single media url with some data and an impl.
     std::shared_ptr<LLPluginClassMedia> mMediaSource;
+#if LL_DULLAHAN_AUDIO_CALLBACK
     std::unique_ptr<LLMediaAudioStream> mMediaAudioStream;
+#endif
     LLCoros::Mutex mLock;
     F64     mZoomFactor;
     LLUUID mTextureId;
@@ -486,7 +488,9 @@ private:
     bool mMediaSourceFailed;
     F32 mRequestedVolume;
     F32 mPreviousVolume;
+#if LL_DULLAHAN_AUDIO_CALLBACK
     F32 mAppliedVolume;
+#endif
     bool mIsMuted;
     bool mNeedsMuteCheck;
     int mPreviousMediaState;

--- a/indra/newview/llviewermedia.h
+++ b/indra/newview/llviewermedia.h
@@ -44,12 +44,15 @@
 #include "llcoros.h"
 #include "llcorehttputil.h"
 
+#include <memory>
+
 class LLViewerMediaImpl;
 class LLUUID;
 class LLViewerMediaTexture;
 class LLMediaEntry;
 class LLVOVolume;
 class LLMimeDiscoveryResponder;
+class LLMediaAudioStream;
 
 typedef LLPointer<LLViewerMediaImpl> viewer_media_t;
 ///////////////////////////////////////////////////////////////////////////////
@@ -449,6 +452,7 @@ private:
 private:
     // a single media url with some data and an impl.
     std::shared_ptr<LLPluginClassMedia> mMediaSource;
+    std::unique_ptr<LLMediaAudioStream> mMediaAudioStream;
     LLCoros::Mutex mLock;
     F64     mZoomFactor;
     LLUUID mTextureId;
@@ -482,6 +486,7 @@ private:
     bool mMediaSourceFailed;
     F32 mRequestedVolume;
     F32 mPreviousVolume;
+    F32 mAppliedVolume;
     bool mIsMuted;
     bool mNeedsMuteCheck;
     int mPreviousMediaState;


### PR DESCRIPTION
## 概要

この PR では、AYAstorm r24 として CEF/MOAP のメディア音声を Viewer 側の FMOD 2D media channel へ接続します。

主対象は MOAP / Web / HTML5 / YouTube 再生です。OS や CEF 側の native output volume に依存せず、Viewer の Media volume / mute で音量制御できるようにします。

旧 PR:

- #69
- mayatonton コメント: https://github.com/mayatonton/phoenix-firestorm/pull/69#issuecomment-4465019464

## #69 コメントへの対応

旧 PR #69 の mayatonton コメントで依頼された build-time fallback switch に対応済みです。

具体的には、`autobuild.xml` に upstream `dullahan` と fork `dullahan_aya_audio` を併記し、`-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=` で upstream / fork を切り替えられるようにしています。

- `FALSE`: upstream `secondlife/dullahan` を使い、audio callback 経路を compile out する。
- `TRUE`: `t-noami/dullahan` fork を使い、FMOD audio callback 経路を有効化する。

切替時の file 衝突は `indra/cmake/CEFPlugin.cmake` 側で uninstall と sentinel reset を行います。

## r24 / Dullahan audio callback

この PR は Viewer 側の変更だけでは完結しません。CEF 音声 PCM を取得するため、Dullahan 側に CEF audio stream callback を外へ渡す API を追加した package を使います。

参照先:

https://github.com/t-noami/dullahan/releases/tag/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3

対象 repo / tag:

- repo: `https://github.com/t-noami/dullahan`
- branch: `ayastorm-cef-audio-callback`
- tag: `v1.26.0-CEF_139.0.40-ayastorm-audio-callback.3`
- 実装 commit: `27d77e6 Add CEF audio stream callbacks`
- release workflow commit: `b59f464 Allow release workflow to publish artifacts`

追加した公開 API:

- `dullahan_audio_stream_info`
- `setOnAudioStreamStartedCallback(...)`
- `setOnAudioStreamPacketCallback(...)`
- `setOnAudioStreamStoppedCallback(...)`
- `setOnAudioStreamErrorCallback(...)`

## Fallback build switch

mayatonton コメントを反映し、t-noami/dullahan fork が利用不可になった場合でも upstream `secondlife/dullahan` で build できる fallback を入れています。

`autobuild.xml` には 2 つの installable を併記します。

- `dullahan`: upstream `secondlife/dullahan`
- `dullahan_aya_audio`: `t-noami/dullahan` fork

切替は CMake フラグで行います。

```bash
-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=FALSE
```

`FALSE` は upstream `secondlife/dullahan` を使い、audio callback 経路を compile out します。

```bash
-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
```

`TRUE` は `t-noami/dullahan` fork を使い、FMOD audio callback 経路を有効化します。

`indra/cmake/CEFPlugin.cmake` が installable の切替と sentinel reset を行うため、フラグを変えて configure し直すだけで切替できます。

## 変更内容

- media plugin と Viewer 間に audio 用 shared memory ring を追加。
- `LLMediaAudioStream` を追加し、media plugin から受け取った PCM を FMOD 2D `OPENUSER` stream へ渡すように変更。
- `media_plugin_cef` で Dullahan / CEF audio callback の PCM を受け取り、shared audio ring へ書き込む処理を追加。
- Viewer の Media volume / mute を FMOD media stream に反映。
- `autobuild.xml` に upstream `dullahan` と fork `dullahan_aya_audio` を併記。
- build-time switch `LL_DULLAHAN_AUDIO_CALLBACK` を追加。
- 実装内容と検証範囲を `docs/ayastorm-r24-moap-audio-to-fmod-2d.md` に整理。
- macOS build 手順を `doc/building_ayastorm_macos.md` に整理。

## 対象範囲

対象:

- MOAP
- Shared Media
- Web page media
- HTML5 audio / video
- YouTube など、CEF / Dullahan を通るメディア
- Viewer の Media volume / mute による音量制御
- FMOD 2D channel への接続

この PR には含めません。

- libVLC direct media の FMOD 接続
- `.mp3` / `.mp4` など direct media の再生修正
- Linux GStreamer direct media の FMOD 接続
- MOAP 音声の 3D Stream / プリムスピーカー接続
- Parcel Music / Streaming Music の動作変更

## 検証

macOS で確認済み:

- Viewer build 完了。
- `-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE` で MOAP / YouTube 音声が FMOD 2D media path 経由で再生される。
- Viewer の Media volume / mute が MOAP / YouTube 音声に反映される。
- フェーダーを動かしていない間、volume update が出続けない。
- 実装途中に発生していたプチプチノイズは、FMOD buffer 長の調整で解消。
- 確認した再生範囲では `ring_dropped` / `frames_silenced` が継続増加していない。
- `-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=FALSE` の macOS build / DMG 作成 / codesign verify 済み。

#69 コメントで確認済み:

- Linux で 3D stream 動作確認済み。
- Linux で `-DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=FALSE` / `TRUE` の両モード build 確認済み。
- fallback switch による upstream `dullahan` と `dullahan_aya_audio` の切替確認済み。

未確認:

- Windows build / runtime 確認。
- Linux での MOAP / YouTube audio callback runtime 確認。
- 長時間再生での audio ring 安定性確認。

## レビュー時に見てほしい点

- Dullahan package 参照先が妥当か。
- Dullahan 側の CEF audio callback API 追加が package として妥当か。
- shared memory audio ring の構造が plugin process / Viewer process 間の受け渡しとして問題ないか。
- FMOD 2D stream の buffer 長と underrun 対策が妥当か。
- CEF native output と FMOD output の二重再生が発生しない構成になっているか。
- Windows build / runtime で Dullahan audio callback API 追加による破綻がないか。
