### PR TITLE
r24 version bump: login brand + shader cache tag (r20→r24)

### DIFF
--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -568,7 +568,7 @@ void LLViewerShaderMgr::setShaders()
             // r19 → r20 would silently hit stale compiled shaders on all
             // three OS. Bump this string at every AYAstorm release — grep
             // "AYASTORM_SHADER_CACHE_TAG" to find every site that needs it.
-            const char* const AYASTORM_SHADER_CACHE_TAG = "AYAstorm r20";
+            const char* const AYASTORM_SHADER_CACHE_TAG = "AYAstorm r24";
             hash_obj.update(AYASTORM_SHADER_CACHE_TAG);
             // </FS:AYA>
             current_cache_version = hash_obj.digest();

--- a/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
@@ -66,7 +66,7 @@
     halign="center"
     text_color="EmphasisColor"
     name="aya_brand_line1">
-AYAstorm r20
+AYAstorm r24
   </text>
   <text
     left="0"


### PR DESCRIPTION
## Summary
- `skins/default/xui/en/panel_fs_nui_login.xml:69` を `AYAstorm r20` → `AYAstorm r24`
- `llviewershadermgr.cpp:571` (`AYASTORM_SHADER_CACHE_TAG`) を `"AYAstorm r20"` → `"AYAstorm r24"`
- r21 / r22 / r23 を通して bump 漏れしていた 2 箇所をまとめて r24 化

## Why
- ログイン画面のブランド表示が r20 のまま 3 リリース凍結していた
- shader cache 識別子が r20 のままだと、r21 以降に入った GLSL 変更で stale compiled shader を踏むリスク (cache key で強制再コンパイルさせる責務を果たしていなかった)

## Scope (確認済)
- 他ロケール (`az/de/fr/it/ja/pl/ru/zh`) と `starlight / starlightcui` の `panel_fs_nui_login.xml` は brand 行を override していないので default/en から継承される。grep `aya_brand|AYAstorm r2[0-4]` で bump 対象が 1 箇所だけなのを裏取り済
- `settings.xml` 等の `AYAstorm r12.1:` / `AYAstorm r11:` 等のコメントは「いつそのコードが入ったか」の provenance タグ。FS upstream の `<FS:CR>` change marker と同じ位置づけで bump 対象ではない (凍結が正)

## Test plan
- [ ] viewer 起動、ログイン画面ブランドが `AYAstorm r24` 表示
- [ ] 初回起動時 shader cache (`~/.ayastorm_x64/cache/shader_cache/`) が r24 タグで再構築される