### PR TITLE
r27: macOSのFirestorm表記をAYAstormに変更

### DIFF
--- a/indra/newview/English.lproj/InfoPlist.strings
+++ b/indra/newview/English.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
 /* Localized versions of Info.plist keys */
 
-CFBundleName = "Firestorm";
+CFBundleName = "AYAstorm";
 
-CFBundleShortVersionString = "Firestorm version %%VERSION%%";
-CFBundleGetInfoString = "Firestorm version %%VERSION%%, Copyright 2010-2026 The Phoenix Firestorm Project, Inc.";
+CFBundleShortVersionString = "AYAstorm version %%VERSION%% (based on Firestorm)";
+CFBundleGetInfoString = "AYAstorm version %%VERSION%% (based on Firestorm), Copyright 2010-2026 The Phoenix Firestorm Project, Inc.";

--- a/indra/newview/Firestorm.xib
+++ b/indra/newview/Firestorm.xib
@@ -14,11 +14,11 @@
         <customObject id="-3" userLabel="Application"/>
         <menu title="Main Menu" systemMenu="main" id="29" userLabel="Main Menu">
             <items>
-                <menuItem title="Firestorm" id="56">
+                <menuItem title="AYAstorm" id="56">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="Firestorm" systemMenu="apple" id="57">
+                    <menu key="submenu" title="AYAstorm" systemMenu="apple" id="57">
                         <items>
-                            <menuItem title="About Firestorm" id="58">
+                            <menuItem title="About AYAstorm" id="58">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="orderFrontStandardAboutPanel:" target="-2" id="142"/>
@@ -32,7 +32,7 @@
                                 <menu key="submenu" title="Services" systemMenu="services" id="130"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="144"/>
-                            <menuItem title="Hide Firestorm" keyEquivalent="h" id="134">
+                            <menuItem title="Hide AYAstorm" keyEquivalent="h" id="134">
                                 <connections>
                                     <action selector="hide:" target="-1" id="369"/>
                                 </connections>
@@ -50,7 +50,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="149"/>
-                            <menuItem title="Quit Firestorm" keyEquivalent="q" id="136">
+                            <menuItem title="Quit AYAstorm" keyEquivalent="q" id="136">
                                 <connections>
                                     <action selector="terminate:" target="-3" id="823"/>
                                 </connections>
@@ -135,7 +135,7 @@
                 <outlet property="window" destination="828" id="850"/>
             </connections>
         </customObject>
-        <window title="Firestorm" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" showsToolbarButton="NO" frameAutosaveName="Firestorm" animationBehavior="default" id="828" customClass="LLNSWindow">
+        <window title="AYAstorm" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" showsToolbarButton="NO" frameAutosaveName="AYAstorm" animationBehavior="default" id="828" customClass="LLNSWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <rect key="contentRect" x="196" y="240" width="1024" height="600"/>


### PR DESCRIPTION
## 概要

macOS 版で、アプリメニュー、ウィンドウタイトル、標準 About 表示に残っていた `Firestorm` 表記を `AYAstorm` に変更します。

## 変更内容

- macOS の上部アプリメニューを `AYAstorm` 表記に変更
- 初期ウィンドウタイトルを `AYAstorm` に変更
- 標準 About 表示のアプリ名を `AYAstorm` に変更
- 派生元が Firestorm であることは、About のバージョン表記に `(based on Firestorm)` として残す

## 検証

- `plutil -lint indra/newview/English.lproj/InfoPlist.strings`
- `xmllint --noout indra/newview/Firestorm.xib`
