### PR TITLE
macOS の Dullahan helper app パッケージング修正と audio callback package .5 への更新

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -780,11 +780,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>2a043c69549411e934ecccf31f789528268ba46c</string>
+              <string>ee6efac6ec83b2a2b1b79c9188622924b13bddf7</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-261370827.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-261370827.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -798,7 +798,7 @@
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605170826_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170826_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25985807911.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -812,7 +812,7 @@
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605170827_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170827_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25985807911.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -825,7 +825,7 @@
         <key>copyright</key>
         <string>Copyright (c) 2017, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.4</string>
+        <string>1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.5</string>
         <key>name</key>
         <string>dullahan_aya_audio</string>
         <key>description</key>

--- a/indra/newview/viewer_manifest.py
+++ b/indra/newview/viewer_manifest.py
@@ -1807,10 +1807,17 @@ class Darwin_x86_64_Manifest(ViewerManifest):
                     with self.prefix(src=os.path.join(pkgdir, 'lib', 'release')):
                         self.path("Chromium Embedded Framework.framework")
                         self.path("DullahanHelper.app")
-                        self.path("DullahanHelper (Alerts).app")
-                        self.path("DullahanHelper (GPU).app")
-                        self.path("DullahanHelper (Renderer).app")
-                        self.path("DullahanHelper (Plugin).app")
+                        dullahan_helper_apps = [
+                            "DullahanHelper (Alerts).app",
+                            "DullahanHelper (GPU).app",
+                            "DullahanHelper (Renderer).app",
+                            "DullahanHelper (Plugin).app",
+                        ]
+                        for helper_app in dullahan_helper_apps:
+                            self.path(helper_app)
+                            nested_helper_app = self.dst_path_of(os.path.join(helper_app, helper_app))
+                            if os.path.isdir(nested_helper_app):
+                                shutil.rmtree(nested_helper_app)
 
                         # Copy libvlc
                         self.path( "libvlc*.dylib*" )


### PR DESCRIPTION
## 概要

AYAstorm 用 Dullahan audio callback package を `.5` に更新し、macOS の Dullahan helper app に対するパッケージング保護処理を追加します。

`.5` の Dullahan release では、macOS で `DullahanHelper*.app` が同名 `.app` を内側に含んでしまう問題を修正しています。

例:

```text
DullahanHelper (Renderer).app/DullahanHelper (Renderer).app
```

Dullahan release:
https://github.com/t-noami/dullahan/releases/tag/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5

## 変更内容

- `autobuild.xml` の Dullahan audio callback package を `.5` release に更新
- Darwin/macOS 用 Dullahan package の hash を `.5` の `darwin64` asset に更新
- linux64/windows64 も `.5` release asset を参照するように更新
- 影響のある package が再度混入した場合に備え、`viewer_manifest.py` 側でも nested Dullahan helper app を除去する防御処理を追加

## 確認内容

- `LL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE` で configure
- `AYAstorm.app` の Xcode build 成功
- final app 内に nested Dullahan helper app が存在しないことを確認
- installed Dullahan package が `.5` release 由来であることを確認
- `media_plugin_cef.dylib` に audio callback parameter override が残っていることを確認
- final app の codesign verify 成功

```text
codesign --verify --deep --strict --verbose=2 AYAstorm.app
```

## 補足

Dullahan `.5` release の asset は現在、各 platform 1つずつです。

- `darwin64`
- `linux64`
- `windows64`
