### PR TITLE
r26.1: media-5.1 callback routing fix

### DIFF
--- a/autobuild.xml
+++ b/autobuild.xml
@@ -794,11 +794,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>17ba90bd9af76c15e97f69c9ea629987cdcedcf6</string>
+              <string>591356284bc72efcf108d8eb54390c32b6d8171c</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170826_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605201414_139.0.40_g465474a_chromium-139.0.7258.139-linux64-26168239569.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -808,11 +808,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>0e8cd6fba9c2d184743e95e36ad08e40bc686efd</string>
+              <string>d77d2b871524b3a542554719b65dd8dff7b09df1</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170827_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605201415_139.0.40_g465474a_chromium-139.0.7258.139-windows64-26168239569.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>

--- a/autobuild.xml
+++ b/autobuild.xml
@@ -780,11 +780,11 @@
             <key>archive</key>
             <map>
               <key>hash</key>
-              <string>2a043c69549411e934ecccf31f789528268ba46c</string>
+              <string>ee6efac6ec83b2a2b1b79c9188622924b13bddf7</string>
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-261370827.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-darwin64-261370827.tar.zst</string>
             </map>
             <key>name</key>
             <string>darwin64</string>
@@ -798,7 +798,7 @@
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605170826_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170826_139.0.40_g465474a_chromium-139.0.7258.139-linux64-25985807911.tar.zst</string>
             </map>
             <key>name</key>
             <string>linux64</string>
@@ -812,7 +812,7 @@
               <key>hash_algorithm</key>
               <string>sha1</string>
               <key>url</key>
-              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.4/dullahan-1.26.0.202605170827_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25985807911.tar.zst</string>
+              <string>https://github.com/t-noami/dullahan/releases/download/v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5/dullahan-1.26.0.202605170827_139.0.40_g465474a_chromium-139.0.7258.139-windows64-25985807911.tar.zst</string>
             </map>
             <key>name</key>
             <string>windows64</string>
@@ -825,7 +825,7 @@
         <key>copyright</key>
         <string>Copyright (c) 2017, Linden Research, Inc.</string>
         <key>version</key>
-        <string>1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.4</string>
+        <string>1.26.0.202605171727_139.0.40_g465474a_chromium-139.0.7258.139-ayastorm-audio-callback.5</string>
         <key>name</key>
         <string>dullahan_aya_audio</string>
         <key>description</key>

--- a/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md
+++ b/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md
@@ -68,6 +68,8 @@ PR 前の macOS 実機確認では、root prim tag + child prim media、5.1ch so
 
 この追加修正は viewer 側だけで完結する。Dullahan/CEF package へ追加 API を入れず、3D Stream の media source reader が「実 callback bus channel 数」と「3D Stream source として扱う論理 channel 数」を分離する。URL source は従来通り FMOD の URL decode path を使うため、この修正の影響を受けない。
 
+2026-05-21 の追加確認で、`{source:media-5-1}` は callback bus が 8ch でも logical 6ch の `FL / FR / C / LFE / SL / SR` を bus index `0..5` から読む必要があることを確認した。full 7.1 source では CEF 7.1 layout の `BL/BR` と `SL/SR` の並べ替えが必要だが、WebAudio `ChannelMerger` 経由の media-5-1 に同じ並べ替えを適用すると、SL / SR を誤って bus index `6/7` から読んでしまう。詳細は `docs/specs/ayastorm-r26-media-5-1-callback-routing-fix.md` を参照する。
+
 残る主な確認は Windows / Linux での二重再生有無と、callback が使えない build での fallback 挙動である。7.1ch / BL/BR speaker routing は今回の 3D Stream 実装対象ではない。
 
 ## 詳細な実装・検証ログ

--- a/docs/specs/ayastorm-r26-media-5-1-callback-routing-fix.md
+++ b/docs/specs/ayastorm-r26-media-5-1-callback-routing-fix.md
@@ -1,0 +1,128 @@
+# AYAstorm r26 media-5-1 callback routing fix
+
+作成日: 2026-05-21
+
+対象:
+
+- 3D Stream media source
+- `{source:media-5-1}`
+- Dullahan / CEF audio callback が 8ch bus を返す macOS build
+
+## 背景
+
+Dullahan audio callback package `.5` 適用後、CEF audio callback は viewer log 上で次のように見える。
+
+```text
+CEF audio stream started: 48000 Hz x 8 ch (ring max 8 ch)
+Media multi source ready: ... 48000 Hz x 6 logical ch (callback bus=8 ch), layout=FL/FR/C/LFE/SL/SR
+```
+
+この状態で `[3dstream-stereo:{source:media-5-1}]` を使うと、FL / FR は鳴るが、SL / SR が speaker prim に出ない症状が出た。
+
+C / LFE については、今回確認した `https://mp3-proxy.onrender.com/http%3A%2F%2Fgo%2Dstream%2Dlive%2Ecom%3A8030%2Fstream` の約 12 秒サンプルでは source 側の channel 3 / 4 が完全な無音だった。そのため、この症状とは別問題として扱う。
+
+## 原因
+
+`LLPositionalStreamMulti::pumpMediaRingSource()` が、callback bus が 8ch の場合に media-5-1 の SL / SR を CEF 7.1 layout の index 6 / 7 から読んでいた。
+
+修正前の考え方:
+
+```text
+CEF 7.1 callback layout: FL / FR / C / LFE / BL / BR / SL / SR
+3D Stream internal 8ch: FL / FR / C / LFE / SL / SR / BL / BR
+media-5-1 SL/SR <- callback index 6/7
+```
+
+これは full 7.1 source では必要な並べ替えだが、今回の WebAudio media-5-1 経路には合わない。
+
+`vj_051726_A.html` / `vj_051726_B.html` は `ChannelSplitter` から `ChannelMerger` へ channel 0..N をそのまま接続する。`source:media-5-1` では viewer 側の logical source channel 数を 6ch として扱うため、callback bus が 8ch でも、3D Stream が読むべき 5.1 logical channel は 0..5 である。
+
+つまり、この構成では次のように扱う。
+
+```text
+media-5-1 on 8ch callback bus: FL / FR / C / LFE / SL / SR / unused / unused
+```
+
+修正前は SL / SR を `6/7` から読んでいたため、WebAudio が `4/5` に出した SL / SR を取り逃がしていた。
+
+## 修正
+
+`indra/llaudio/llpositionalstreammulti.cpp` の media ring copy で、6ch logical media source は callback bus channel 0..5 をそのまま読むようにした。
+
+8ch logical source の場合だけ、CEF 7.1 layout から 3D Stream internal 8ch layout へ並べ替える。
+
+修正後の rule:
+
+| 条件 | 読み方 |
+| --- | --- |
+| `mSourceChannels == 1` | ch0 を全 track へ複製 |
+| `mSourceChannels == 2` | ch0 / ch1 をそのまま読む |
+| `mSourceChannels == 6` | ch0..ch5 を `FL/FR/C/LFE/SL/SR` としてそのまま読む |
+| `mSourceChannels == 8` かつ callback bus 8ch | CEF 7.1 `FL/FR/C/LFE/BL/BR/SL/SR` を internal `FL/FR/C/LFE/SL/SR/BL/BR` へ並べ替える |
+
+実装上の要点:
+
+```text
+media-5-1:
+  src_channel = c
+
+media-7-1 / full 8ch:
+  src_channel = { 0, 1, 2, 3, 6, 7, 4, 5 }[c]
+```
+
+URL source path は FMOD decode path のままであり、この修正の影響を受けない。
+
+## 検証
+
+確認済み:
+
+- 対象 branch: `fix/dullahan-audio-callback-5-macos-helper`
+- Dullahan package: `v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5`
+- `LL_DULLAHAN_AUDIO_CALLBACK=TRUE`
+- macOS arm64 viewer build 成功
+
+実行した検証:
+
+```text
+xcodebuild -project build-darwin-universal/Firestorm.xcodeproj \
+  -configuration Release \
+  -target viewer \
+  ARCHS=arm64 \
+  ONLY_ACTIVE_ARCH=YES \
+  build
+```
+
+生成 app:
+
+```text
+build-darwin-universal/newview/Release/AYAstorm.app
+```
+
+補足確認:
+
+- `ffprobe` では対象 stream が Opus 6ch / 48 kHz として認識される。
+- `ffmpeg astats` では取得サンプルの channel 3 / 4 が無音、channel 5 / 6 には信号あり。
+- そのため C / LFE の無音は source 側の内容に由来する。
+- SL / SR の無音は viewer 側の media-5-1 callback bus mapping が原因。
+
+## 注意点
+
+root prim の media 5.1 source 指定:
+
+```text
+[3dstream-stereo:{source:media-5-1}{...}]
+```
+
+child speaker prim の channel 指定:
+
+```text
+[3dstream-stereo:{ch:SL}{range:80}{volume:1.0}]
+[3dstream-stereo:{ch:SR}{range:80}{volume:1.0}]
+```
+
+`[3dstream:{ch:SR}...]` ではなく、distributed 3D Stream の child prim description は `[3dstream-stereo:...]` を使う。
+
+## 今後の確認
+
+- C / LFE に実信号が入った 5.1 test source で、FL / FR / C / LFE / SL / SR の全 speaker prim を個別確認する。
+- `media-7-1` / full 8ch source を使う場合は、CEF 7.1 layout の `BL/BR` と `SL/SR` の並べ替えが必要なため、今回の 6ch rule と混同しない。

--- a/docs/specs/ayastorm-r26-media-5-1-callback-routing-fix.md
+++ b/docs/specs/ayastorm-r26-media-5-1-callback-routing-fix.md
@@ -76,7 +76,7 @@ URL source path は FMOD decode path のままであり、この修正の影響�
 
 確認済み:
 
-- 対象 branch: `fix/dullahan-audio-callback-5-macos-helper`
+- 対象 branch: `fix/r26-1-media-5-1-callback-routing`
 - Dullahan package: `v1.26.0-CEF_139.0.40-ayastorm-audio-callback.5`
 - `LL_DULLAHAN_AUDIO_CALLBACK=TRUE`
 - macOS arm64 viewer build 成功

--- a/indra/llaudio/llpositionalstreammulti.cpp
+++ b/indra/llaudio/llpositionalstreammulti.cpp
@@ -1651,13 +1651,11 @@ size_t LLPositionalStreamMulti::pumpMediaRingSource()
                     if (mMediaRingChannels == 8)
                     {
                         // CEF 7.1 callback order is FL/FR/C/LFE/BL/BR/SL/SR.
-                        // The 3D stream internals use FL/FR/C/LFE/SL/SR/BL/BR,
-                        // so normalize while copying out of the media ring.
-                        if (mSourceChannels == 6 && c >= 4)
-                        {
-                            src_channel = c + 2; // SL/SR <- CEF indices 6/7
-                        }
-                        else if (mSourceChannels == 8)
+                        // The 3D stream internals use FL/FR/C/LFE/SL/SR/BL/BR.
+                        // media-5-1 is produced by WebAudio's ChannelMerger as
+                        // logical channels 0..5 on the 8ch callback bus, so only
+                        // full 7.1 media needs reordering here.
+                        if (mSourceChannels == 8)
                         {
                             static constexpr int kCef71ToStream8[8] =
                                 { 0, 1, 2, 3, 6, 7, 4, 5 };


### PR DESCRIPTION
## 概要

r26.1 向けの 3D Stream / MOAP media 5.1 修正です。

- Dullahan audio callback package を .5 に更新
- macOS helper app の staging 入れ子問題を修正
- source:media-5-1 で callback bus が 8ch の場合も、logical 6ch は bus index 0..5 をそのまま読むよう修正
- full 7.1 source の場合だけ CEF 7.1 layout FL/FR/C/LFE/BL/BR/SL/SR を internal FL/FR/C/LFE/SL/SR/BL/BR へ並べ替える
- media-5.1 callback routing の調査・修正内容を docs に追加

## 背景

Dullahan .5 適用後、CEF callback は 48000 Hz x 8 ch として届きます。一方、WebAudio ChannelMerger 経由の source:media-5-1 は logical 6ch を 0..5 に出すため、viewer 側で SL/SR を 7.1 前提の 6/7 から読むと side channel が無音になります。

この PR では media-5.1 は FL/FR/C/LFE/SL/SR を 0..5 から読み、8ch logical source のみ 7.1 並べ替えを行います。

## 確認

- git diff --check
- macOS arm64 viewer build 成功
  - xcodebuild -project build-darwin-universal/Firestorm.xcodeproj -configuration Release -target viewer ARCHS=arm64 ONLY_ACTIVE_ARCH=YES build
- 生成 app: build-darwin-universal/newview/Release/AYAstorm.app

## 注意

今回確認した外部 6ch stream では C/LFE 相当の source channel が無音でした。これは source 側の内容であり、本修正の対象は SL/SR の callback bus mapping です。
