### PR TITLE
r30 P5 透過 DoF C 案: LMB-on-HUD / LMB-up 間の alpha BLEND 描画差異を修正

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/ayaAlphaPlateCompositeF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/ayaAlphaPlateCompositeF.glsl
@@ -1,0 +1,49 @@
+/**
+ * @file ayaAlphaPlateCompositeF.glsl
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Second Life Viewer Source Code
+ * Copyright (C) 2026, Linden Research, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+// <AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+// Composite mAYAAlphaColor (premultiplied linear alpha BLEND plate) onto
+// mRT->screen BEFORE generateLuminance / tonemap. This makes alpha BLEND
+// surfaces participate in HDR exposure auto-calibration the same way the
+// SL/LMB-on-HUD path does (where alpha was written directly to mRT->screen).
+// Trivial passthrough: blend func is set on the C++ side to
+//   glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA)
+// so the fixed-function blender does the premultiplied over-blend:
+//   dst.rgb = plate.rgb + dst.rgb * (1 - plate.a)
+//   dst.a   = plate.a   + dst.a   * (1 - plate.a)
+// </AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+
+out vec4 frag_color;
+
+uniform sampler2D diffuseRect;
+
+in vec2 vary_fragcoord;
+
+void main()
+{
+    frag_color = texture(diffuseRect, vary_fragcoord);
+}

--- a/indra/newview/app_settings/shaders/class1/deferred/dofCombineF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/dofCombineF.glsl
@@ -38,16 +38,6 @@ uniform float res_scale;
 uniform float dof_width;
 uniform float dof_height;
 
-// <AYAstorm r30 P5 transparent-DoF C-(a)>
-// Alpha BLEND plate (gPipeline.mAYAAlphaColor) — premultiplied color/coverage
-// from forward alpha pass redirected away from mRT->screen so the opaque-only
-// scene goes through cofF/HQDoFF unobstructed. Composited back as sharp "over"
-// on top of the DoF result here. Guarded by aya_alpha_plate_enabled so the
-// shader is a no-op when C-(a) is not allocated (aux / probe paths).
-uniform sampler2D aya_alpha_plate;
-uniform bool      aya_alpha_plate_enabled;
-// </AYAstorm r30 P5 transparent-DoF C-(a)>
-
 in vec2 vary_fragcoord;
 
 vec4 dofSample(sampler2D tex, vec2 tc)
@@ -82,55 +72,4 @@ void main()
     }
 
     frag_color = mix(diff, dof, a);
-
-    // <AYAstorm r30 P5 transparent-DoF C-(a)> Over-blend the alpha plate
-    // with DoF CoC applied so 装着物 (髪 / 服) と sim Rez Object の alpha BLEND
-    // surfaces respond to camera params (F値 / 焦点距離 / 最大散乱円).
-    //
-    // mAYAAlphaColor was filled with forward alpha BLEND using factor
-    // (SRC_ALPHA, 1-SRC_ALPHA) for color + (ONE, 1-SRC_ALPHA) for alpha into a
-    // clear-to-(0,0,0,0) target, which produces premultiplied output:
-    //   plate.rgb = src.rgb * src.a (accumulated)
-    //   plate.a   = src.a           (accumulated as coverage)
-    // Standard "over" composite is:
-    //   out.rgb = plate.rgb + scene.rgb * (1 - plate.a)
-    //
-    // CoC source: cofF was bound to mAYAAlphaDepth (L2-β: opaque depth + alpha
-    // BLEND re-injection at cutoff 0.5). diff.a (lightMap.a) thus carries
-    // alpha-aware CoC for alpha ≥ 0.5 pixels and bg-depth CoC otherwise. All
-    // three camera params (CameraFNumber / CameraFocalLength / CameraMaxCoF)
-    // feed into this CoC through cofF's calc_cof + max_cof clamp.
-    //
-    // Gather pattern: 12-tap disc, radius scaled by CoC pixels (matches HQDoFF
-    // *4 magnitude). Premultiplied color/coverage averages correctly under
-    // uniform-weight box gather, so the over-blend formula remains valid.
-    // Collapses to single-tap when CoC < 0.75 px (in-focus surfaces stay sharp).
-    //
-    // Preserve frag_color.a (= scene glow signal) untouched — the alpha plate
-    // has no glow contribution and downstream combineGlow reads .a from this RT.
-    if (aya_alpha_plate_enabled)
-    {
-        float coc_px = abs(diff.a * 2.0 - 1.0) * max_cof * 4.0;
-
-        vec4 plate;
-        if (coc_px < 0.75)
-        {
-            plate = texture(aya_alpha_plate, vary_fragcoord.xy);
-        }
-        else
-        {
-            const int N = 12;
-            const float TWO_PI = 6.2831853;
-            vec4 acc = vec4(0.0);
-            for (int i = 0; i < N; ++i)
-            {
-                float ang = float(i) * TWO_PI / float(N);
-                vec2 off = vec2(cos(ang), sin(ang)) * coc_px / screen_res;
-                acc += texture(aya_alpha_plate, vary_fragcoord.xy + off);
-            }
-            plate = acc / float(N);
-        }
-        frag_color.rgb = plate.rgb + frag_color.rgb * (1.0 - plate.a);
-    }
-    // </AYAstorm r30 P5 transparent-DoF C-(a)>
 }

--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -226,6 +226,29 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
         gPipeline.mRT == &gPipeline.mMainRT &&
         gPipeline.mAYAAlphaColor.isComplete();
 
+    // <AYAstorm r30 P5 plate-clear unconditional 2026-05-23>
+    // Clear mAYAAlphaColor every frame regardless of use_alpha_rt. When
+    // inBuildMode() (= LMB on HUD) flips use_alpha_rt=false, this branch used
+    // to skip the clear → previous frame's plate contents leaked into the
+    // next frame's composite. The pre-tonemap composite step (renderFinalize)
+    // reads mAYAAlphaColor unconditionally, so it must start clean every
+    // frame.
+    if (!LLPipeline::sImpostorRender && !LLPipeline::sRenderingHUDs &&
+        !gCubeSnapshot && getType() == LLDrawPool::POOL_ALPHA_POST_WATER &&
+        gPipeline.mRT == &gPipeline.mMainRT &&
+        gPipeline.mAYAAlphaColor.isComplete())
+    {
+        LL_PROFILE_GPU_ZONE("aya alpha color clear");
+        gPipeline.mAYAAlphaColor.bindTarget();
+        {
+            LLGLDepthTest depth_off(GL_FALSE, GL_FALSE);
+            glClearColor(0.f, 0.f, 0.f, 0.f);
+            glClear(GL_COLOR_BUFFER_BIT);
+        }
+        gPipeline.mAYAAlphaColor.flush();
+    }
+    // </AYAstorm r30 P5 plate-clear unconditional>
+
     if (use_alpha_rt)
     {
         LL_PROFILE_GPU_ZONE("aya alpha color redirect");
@@ -234,13 +257,6 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
         // to it automatically — no manual screen.flush()/bindTarget() needed
         // (doing so trips the !isBoundInStack assertion on re-push).
         gPipeline.mAYAAlphaColor.bindTarget();
-        // Clear color only — depth attachment is shared with mRT->screen and
-        // holds opaque z that alpha BLEND must depth-test against.
-        {
-            LLGLDepthTest depth_off(GL_FALSE, GL_FALSE);
-            glClearColor(0.f, 0.f, 0.f, 0.f);
-            glClear(GL_COLOR_BUFFER_BIT);
-        }
         mForwardToAlphaRT = true;
     }
     // </AYAstorm r30 P5 transparent-DoF C-(a)>
@@ -1023,6 +1039,30 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
             {
                 gPipeline.enableLightsDynamic();
 
+                // <AYAstorm r30 P5 fix glow-lost-in-plate 2026-05-23>
+                // Emissive pass uses (BF_ZERO, BF_ONE) for color (no-op) and
+                // (BF_ONE, BF_ONE) for alpha (additive glow). When the BLEND
+                // pass above was redirected to mAYAAlphaColor (plate), the
+                // currently-bound FBO is the plate — leaving it bound here
+                // makes emissive ADD glow into plate.a, which is the plate's
+                // coverage channel used by dofCombineF's over-composite. That
+                // both corrupts coverage AND prevents glow from ever reaching
+                // mRT->screen.a (the scene glow channel combineGlow reads).
+                // Net effect: alpha BLEND material loses its glow entirely.
+                //
+                // Fix: temporarily pop the plate so the emissive pass targets
+                // mRT->screen, where glow accumulation belongs. flush() pops
+                // the plate off LLRenderTarget's FBO stack, leaving the
+                // pre-pushed screen on top; bindTarget() re-pushes the plate
+                // after the emissive pass so subsequent BLEND in the second
+                // forwardRender() call continues to write to the plate.
+                const bool emissive_to_screen = mForwardToAlphaRT;
+                if (emissive_to_screen)
+                {
+                    gPipeline.mAYAAlphaColor.flush();
+                }
+                // </AYAstorm r30 P5 fix glow-lost-in-plate>
+
                 // install glow-accumulating blend mode
                 // don't touch color, add to alpha (glow)
                 gGL.blendFunc(LLRender::BF_ZERO, LLRender::BF_ONE, LLRender::BF_ONE, LLRender::BF_ONE);
@@ -1064,6 +1104,15 @@ void LLDrawPoolAlpha::renderAlpha(U32 mask, bool depth_only, bool rigged)
                 {
                     lastShader->bind();
                 }
+
+                // <AYAstorm r30 P5 fix glow-lost-in-plate 2026-05-23>
+                // Re-push plate so subsequent BLEND (second forwardRender call
+                // or other consumers) continues writing into the plate.
+                if (emissive_to_screen)
+                {
+                    gPipeline.mAYAAlphaColor.bindTarget();
+                }
+                // </AYAstorm r30 P5 fix glow-lost-in-plate>
             }
         }
     }

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -207,6 +207,9 @@ LLGLSLShader            gDeferredPostTonemapGammaCorrectProgram;
 LLGLSLShader            gNoPostTonemapGammaCorrectProgram;
 LLGLSLShader            gDeferredPostTonemapLegacyGammaCorrectProgram;
 LLGLSLShader            gNoPostTonemapLegacyGammaCorrectProgram;
+// <AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+LLGLSLShader            gAYAAlphaPlateCompositeProgram;
+// </AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
 LLGLSLShader            gDeferredPostGammaCorrectProgram;
 LLGLSLShader            gLegacyPostGammaCorrectProgram;
 LLGLSLShader            gExposureProgram;
@@ -2668,6 +2671,26 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         success = gLegacyPostGammaCorrectProgram.createShader();
         llassert(success);
     }
+
+    // <AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+    // Simple fullscreen passthrough that, with blend func set to
+    // (ONE, 1-SRC_ALPHA), overlays mAYAAlphaColor (premult linear plate) onto
+    // mRT->screen before generateLuminance / tonemap runs. Puts alpha BLEND
+    // into the auto-exposure / tonemap input the same way the LMB-on-HUD path
+    // does (where forward alpha was written directly to mRT->screen).
+    if (success)
+    {
+        gAYAAlphaPlateCompositeProgram.mName = "AYAstorm Alpha Plate Composite";
+        gAYAAlphaPlateCompositeProgram.mFeatures.isDeferred = true;
+        gAYAAlphaPlateCompositeProgram.mShaderFiles.clear();
+        gAYAAlphaPlateCompositeProgram.clearPermutations();
+        gAYAAlphaPlateCompositeProgram.mShaderFiles.push_back(make_pair("deferred/postDeferredNoTCV.glsl", GL_VERTEX_SHADER));
+        gAYAAlphaPlateCompositeProgram.mShaderFiles.push_back(make_pair("deferred/ayaAlphaPlateCompositeF.glsl", GL_FRAGMENT_SHADER));
+        gAYAAlphaPlateCompositeProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        success = gAYAAlphaPlateCompositeProgram.createShader();
+        llassert(success);
+    }
+    // </AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
 
     if (success)
     {

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -276,6 +276,9 @@ extern LLGLSLShader         gDeferredPostTonemapGammaCorrectProgram;
 extern LLGLSLShader         gNoPostTonemapGammaCorrectProgram;
 extern LLGLSLShader         gDeferredPostTonemapLegacyGammaCorrectProgram;
 extern LLGLSLShader         gNoPostTonemapLegacyGammaCorrectProgram;
+// <AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+extern LLGLSLShader         gAYAAlphaPlateCompositeProgram;
+// </AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
 extern LLGLSLShader         gExposureProgram;
 extern LLGLSLShader         gExposureProgramNoFade;
 extern LLGLSLShader         gLuminanceProgram;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -9900,22 +9900,6 @@ void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
                 gDeferredDoFCombineProgram.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, src, LLTexUnit::TFO_POINT);
                 gDeferredDoFCombineProgram.bindTexture(LLShaderMgr::DEFERRED_LIGHT, &mRT->deferredLight, LLTexUnit::TFO_POINT);
 
-                // <AYAstorm r30 P5 transparent-DoF C-(a)> Bind the alpha BLEND
-                // plate so dofCombineF can "over" it on top of the DoF'd
-                // opaque scene. When mAYAAlphaColor is not allocated (aux /
-                // probe paths) the gate uniform stays false and the shader
-                // skips the composite entirely — no fallback bind needed.
-                {
-                    S32 ap_chan = gDeferredDoFCombineProgram.getTextureChannel(LLShaderMgr::AYA_ALPHA_PLATE);
-                    const bool ap_on = mAYAAlphaColor.isComplete() && ap_chan >= 0;
-                    if (ap_on)
-                    {
-                        gDeferredDoFCombineProgram.bindTexture(LLShaderMgr::AYA_ALPHA_PLATE, &mAYAAlphaColor, false, LLTexUnit::TFO_POINT);
-                    }
-                    gDeferredDoFCombineProgram.uniform1i(LLShaderMgr::AYA_ALPHA_PLATE_ENABLED, ap_on ? 1 : 0);
-                }
-                // </AYAstorm r30 P5 transparent-DoF C-(a)>
-
                 gDeferredDoFCombineProgram.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES, (GLfloat)dst->getWidth(), (GLfloat)dst->getHeight());
                 // <FS:Beq> FIRE-13989 DOF should be equivalent in all resolutions of the same rendered image
                 // gDeferredDoFCombineProgram.uniform1f(LLShaderMgr::DOF_MAX_COF, CameraMaxCoF);
@@ -9960,6 +9944,62 @@ void LLPipeline::renderFinalize()
 
     gGL.setColorMask(true, true);
     glClearColor(0, 0, 0, 0);
+
+    // <AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
+    // Over-blend the linear premultiplied alpha plate (mAYAAlphaColor) onto
+    // mRT->screen BEFORE generateLuminance / tonemap. Without this step the
+    // HDR auto-exposure path (generateLuminance → generateExposure → tonemap)
+    // sees only opaque scene contents on LMB-up (use_alpha_rt=true) — alpha
+    // BLEND brightness is invisible to exposure calibration, so the later
+    // post-tonemap composite produces an exposure mismatch versus the
+    // LMB-on-HUD (use_alpha_rt=false) path where alpha was written into
+    // mRT->screen directly. By compositing here both paths feed exposure
+    // calibration the same merged scene, and the plate is no longer
+    // composited inside dofCombineF (post-tonemap) where it would be in a
+    // different color space. mAYAAlphaColor is cleared unconditionally at
+    // the start of the forward alpha pass (lldrawpoolalpha.cpp) so when
+    // use_alpha_rt=false the texture is all-zeros and this pass is a no-op.
+    if (mAYAAlphaColor.isComplete() && gAYAAlphaPlateCompositeProgram.isComplete())
+    {
+        LL_PROFILE_GPU_ZONE("aya plate pre-tonemap composite");
+        mRT->screen.bindTarget();
+
+        LLGLEnable blend_on(GL_BLEND);
+        // RGB: premultiplied "over" composite onto opaque scene.
+        //   dst.rgb = plate.rgb + screen.rgb * (1 - plate.a)
+        // Alpha: attenuate dst.a by (1 - plate.a) to mimic the LMB-on-HUD
+        // path's "glow suppression" blend (BF_ZERO, BF_ONE_MINUS_SOURCE_ALPHA)
+        // which attenuates screen.a (scene glow channel consumed by
+        // combineGlow) under alpha-covered pixels. Without attenuation
+        // LMB-up shows opaque-light glow halos bleeding through hair /
+        // clothing while LMB-on-HUD does not — visible path divergence.
+        // This is an approximation: LMB-on-HUD attenuates per-draw with
+        // emissive added between, whereas here we attenuate accumulated
+        // screen.a (opaque_glow + sum(alpha_emissive)) once by accumulated
+        // plate.a. For emissive-zero alpha BLEND (hair/clothing/glass, the
+        // vast majority) the approximation matches LMB-on-HUD; for emissive
+        // alpha BLEND (lanterns) we over-attenuate slightly. Acceptable.
+        //   dst.a = screen.a * (1 - plate.a)
+        glBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+
+        gAYAAlphaPlateCompositeProgram.bind();
+        gAYAAlphaPlateCompositeProgram.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, &mAYAAlphaColor, false, LLTexUnit::TFO_POINT);
+
+        {
+            LLGLDepthTest depth_test(GL_FALSE, GL_FALSE);
+            mScreenTriangleVB->setBuffer();
+            mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+        }
+
+        gAYAAlphaPlateCompositeProgram.unbind();
+
+        // Restore default blend func so subsequent passes (tonemap etc.)
+        // aren't surprised.
+        glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
+
+        mRT->screen.flush();
+    }
+    // </AYAstorm r30 P5 transparent-DoF C-(a) pre-tonemap composite>
 
     static LLCachedControl<bool> has_hdr(gSavedSettings, "RenderHDREnabled", true);
     bool hdr = gGLManager.mGLVersion > 4.05f && has_hdr();
@@ -10033,9 +10073,12 @@ void LLPipeline::renderFinalize()
     gGLViewport[3] = gViewerWindow->getWorldViewRectRaw().getHeight();
     glViewport(gGLViewport[0], gGLViewport[1], gGLViewport[2], gGLViewport[3]);
 
-    if((RenderDepthOfFieldInEditMode || !LLToolMgr::getInstance()->inBuildMode()) &&
+    const bool dof_gate_pass =
+        (RenderDepthOfFieldInEditMode || !LLToolMgr::getInstance()->inBuildMode()) &&
         RenderDepthOfField &&
-        !gCubeSnapshot)
+        !gCubeSnapshot;
+
+    if (dof_gate_pass)
     {
         renderDoF(sourceBuffer, targetBuffer);
         std::swap(sourceBuffer, targetBuffer);


### PR DESCRIPTION
forward alpha BLEND の描画先 RT が LMB 状態で分岐する設計に対し、
path 補正が 2 系統で抜けていた。

1. composite が dofCombineF (tonemap 後) で行われていたため generateLuminance (HDR auto-exposure) が alpha BLEND を見ておらず、 LMB-on-HUD path (alpha は screen 直書き) と exposure 不整合。 → pre-tonemap composite (新 shader ayaAlphaPlateCompositeF) に移動

2. LMB-on-HUD path の forward alpha blend func 4 引数目 (ZERO, 1-Sa) は screen.a (= scene glow channel) を src.a で 減衰させる glow suppression を兼ねていたが、plate path では この減衰が無く alpha 被覆部から opaque-light の glow halo が 透けて見えていた。 → composite blend func の alpha factor を (ZERO, 1-Sa) にして dst.a = screen.a * (1 - plate.a) を実現。emissive-zero の 大半 (hair/glass/服) で LMB-on-HUD と math 上 identical。

emissive 入り (lanterns 等) では emissive-between-BLEND 順序の 違いでわずかに over-attenuate するが許容範囲 (pipeline.cpp:10032-10037 にコメント記載)。

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
