### PR TITLE
r30 GLSL Apple Silicon Metal 安全化: NaN/Inf/無限ループの境界条件 guard

### DIFF
--- a/indra/newview/app_settings/shaders/cinematic_bd/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/cinematic_bd/class3/deferred/screenSpaceReflUtil.glsl
@@ -230,7 +230,7 @@ float tapScreenSpaceReflection(
             float u1 = random(tc * screen_res + noiseSine + float(s) * 0.123);
             float u2 = random(tc * screen_res * 1.7 + noiseSine + float(s) * 0.456 + 0.5);
 
-            float theta = atan(alpha * sqrt(u1) / sqrt(1.0 - u1));
+            float theta = atan(alpha * sqrt(clamp(u1, 0.0, 0.9999)) / sqrt(max(1.0 - u1, 1e-6)));
             float phi = 2.0 * 3.14159265 * u2;
 
             vec3 up = abs(reflectDir.y) < 0.999 ? vec3(0, 1, 0) : vec3(1, 0, 0);
@@ -275,7 +275,7 @@ float tapScreenSpaceReflection(
         float zFade = 1.0 - smoothstep(zFadeStart, maxZDepth, hitDepth);
 
         float rayLength = length(hitCoord - transformedJitteredPos);
-        float maxMipLevels = floor(log2(max(screen_res.x, screen_res.y)));
+        float maxMipLevels = floor(log2(max(1.0, max(screen_res.x, screen_res.y))));
         float distanceFactor = clamp(rayLength / maxZDepth, 0.0, 1.0);
         float effectiveRoughness = clamp(roughness + distanceFactor * roughness, 0.0, 1.0);
         float mipLevel = maxMipLevels * effectiveRoughness;

--- a/indra/newview/app_settings/shaders/class1/deferred/aoUtil.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/aoUtil.glsl
@@ -114,7 +114,7 @@ float calcHBAmbientOcclusion(vec4 pos, vec3 normal, vec2 pos_screen)
         for (int j = 1; j <= NUM_STEPS; ++j)
         {
             float step_scale = pow((float(j) + 0.5) / float(NUM_STEPS), 2.0);
-            float view_scale = 1.0 / abs(pos.z);
+            float view_scale = 1.0 / max(abs(pos.z), 1e-4);
             vec3 viewDir = normalize(-pos.xyz);
             vec2 offset = dir * radius * view_scale * step_scale;
 
@@ -180,7 +180,7 @@ float calcHBAmbientOcclusion(vec4 pos, vec3 normal, vec2 pos_screen)
         weight_sum += weight;
     }
 
-    return result / weight_sum;
+    return weight_sum > 1e-6 ? (result / weight_sum) : 1.0;
 }
 
 //calculate decreases in ambient lighting when crowded out (SSAO)

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredHQDoFF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredHQDoFF.glsl
@@ -109,7 +109,9 @@ void main()
 #if FRONT_BLUR
 		if (sc > 0.5)
 		{
-			while (sc > 0.5)
+			// Apple Silicon Metal safety: bound the loop in case sc becomes NaN
+			// (NaN > 0.5 is always false on conformant GL but undefined under Metal emulation).
+			for (int safety = 0; safety < 32 && sc > 0.5; ++safety)
 			{
 				int its = int(max(1.0,(sc*3.7)));
 				for (int i=0; i<its; ++i)
@@ -129,7 +131,8 @@ void main()
 #endif
 		{
 			sc = abs(sc);
-			while (sc > 0.5)
+			// Apple Silicon Metal safety: bounded loop (see comment above).
+			for (int safety = 0; safety < 32 && sc > 0.5; ++safety)
 			{
 				int its = int(max(1.0,(sc*3.7)));
 				for (int i=0; i<its; ++i)

--- a/indra/newview/app_settings/shaders/class3/deferred/volumetricLightF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/volumetricLightF.glsl
@@ -123,7 +123,7 @@ void main()
     shaftify /= godray_res;
     shadamount *= clamp(depth, 0.0 , 0.5);
 
-    float fade = max(falloff_multiplier / depth, 1.0);
+    float fade = max(falloff_multiplier / max(depth, 1e-4), 1.0);
     shaftify = (shaftify / fade) * godray_multiplier;
 #if GODRAYS_FADE
     fade = 0.0;
@@ -180,7 +180,7 @@ void main()
     shaftify /= godray_res;
     shadamount *= clamp(depth, 0.0 , 0.5);
 
-    float fade = max(falloff_multiplier / depth, 1.0);
+    float fade = max(falloff_multiplier / max(depth, 1e-4), 1.0);
     shaftify = (shaftify / fade) * godray_multiplier;
 #if GODRAYS_FADE
     fade = 0.0;


### PR DESCRIPTION
Apple Silicon Mac (M4 等) では OpenGL→Metal emulation のため、 conformant GL では undefined だった NaN/Inf 値の伝播や保護なし
while ループが GPU timeout で viewer ごと kill される事象が
報告されたため、r25 以降に追加/改変した GLSL に対して網羅的に
境界条件 guard を入れる。通常描画では一切発火しないため見た目
への影響なし。

対象 4 ファイル / 6 箇所:

- aoUtil.glsl L117: view_scale = 1.0 / abs(pos.z) に対して pos.z=0 (near plane) で Inf になる経路を max(.., 1e-4) で蓋
- aoUtil.glsl L183: result / weight_sum で全 sample が exp flush-to-zero で NaN を返す経路に guard を入れ、退避値 1.0 (occlusion 無し) を返す
- screenSpaceReflUtil.glsl L233: atan(.. / sqrt(1.0 - u1)) で u1=1.0 のとき sqrt(0) で 0 除算になる経路を clamp + max guard
- screenSpaceReflUtil.glsl L278: log2(max(res.x, res.y)) で screen_res < 1 のとき log2(0)=-Inf になる経路を max(1.0, ..) guard
- postDeferredHQDoFF.glsl L112/L132: while (sc > 0.5) の sc が NaN になった場合 Apple Silicon Metal 上で無限ループ → GPU timeout → process kill になるため for safety<32 で頭打ち
- volumetricLightF.glsl L126/L183 (Cinematic / AY 両 main): falloff_multiplier / depth で depth=0 (sky) のとき Inf になる 経路を max(depth, 1e-4) で蓋

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
