### PR TITLE
r30 #13 雲消失 fix: cloudsF.glsl HAS_EMISSIVE 経路の alpha を alpha1 に戻す

### DIFF
--- a/indra/newview/app_settings/shaders/class1/deferred/cloudsF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/cloudsF.glsl
@@ -157,11 +157,11 @@ void main()
 #if defined(HAS_EMISSIVE)
     frag_data[0] = vec4(0);
     // <FS:AYA r30 Phase 3.8 Cinematic mount strategy C> r20 SSS skin
-    // mask in gbuffer3.a; clouds are never skin.
-    // <FS:AYAstorm r30 BD改善> Cinematic でも SSS dispatch が走るため、
-    //   alpha=cloud_alpha leak で雲経由で skin_mask 誤発火。両 mode で 0。
-    frag_data[3] = vec4(color.rgb, 0.0);
-    // </FS:AYAstorm>
+    // mask in gbuffer3.a; clouds are never skin. しかし HAS_EMISSIVE 経路で
+    // frag_data[3].a=0 にすると softenLightF SKIP_ATMOS 分岐合成で雲自体が
+    // 消えるため alpha1 を維持する。skin_mask 誤発火は skinSSSF 側で
+    // GBUFFER_FLAG_SKIP_ATMOS を見て gate する方向で別途対応。
+    frag_data[3] = vec4(color.rgb, alpha1);
     // </FS:AYA>
 #else
     frag_data[0] = vec4(color.rgb, alpha1);


### PR DESCRIPTION
fb7b270569 で sky/clouds/moon/stars/sunDisc 全 sky 系の HAS_EMISSIVE 経路の frag_data[3].a を 0.0 に統一して r20 SSS skin_mask 誤発火 (sky 真っ赤 / SIM rez 真っ赤) を防いだが、雲だけは softenLightF SKIP_ATMOS 分岐合成で雲そのものが 消える副作用があった (frag_data[0]=vec4(0) で alpha も 0、色は frag_data[3].rgb のみ → alpha=0 で存在判定が落ちる)。

雲のみ alpha1 を復元して #13 雲消失を解消。sky/moon/stars/sunDisc は 0.0 維持。 skin_mask 誤発火対策は skinSSSF 側で GBUFFER_FLAG_SKIP_ATMOS による gate を 別途検討する方向で残し、当面この patch で雲を取り戻す。

検証 (AYA 確認済):
- 雲が出る
- SSS が顔に効く
- sky / SIM rez が真っ赤にならない

## Firestorm Pull Request Checklist
Thank you for contributing to the Phoenix Firestorm Project.
We will endeavour to review you changes and accept/reject/request changes as soon as possible. 
Please read and follow the [Firestorm Pull Request Guidelines](https://github.com/firestormviewer/phoenix-firestorm/blob/master/FS_PR_GUIDELINES.md) to reduce the likelihood that we need to ask for "Bureaucratic" changes to make the code comply with our workflows.
