### PR TITLE
r30 Cinematic ゴッドレイ: SUN_SHADOW permutation 修正 + live cvar 化 + Cinematic default ON

### DIFF
--- a/docs/specs/ayastorm-r30-cinematic-godrays-handoff.md
+++ b/docs/specs/ayastorm-r30-cinematic-godrays-handoff.md
@@ -1,0 +1,161 @@
+# r30 Cinematic Godrays 引き継ぎ資料 (2026-05-24)
+
+context clear 直前の作業状態 snapshot。次セッションはこの doc を最初に読んで、
+working tree の uncommitted 変更と AYA さん検証待ちの内容を pick up すること。
+
+## branch / 親
+
+- 作業 branch: `fix/r30-cinematic-godrays-sun-shadow-permutation`
+- 親: `ayastorm-release`
+- **commit 0 件** (全変更が uncommitted、working tree のみ)
+- AYA さん指示があるまで commit しない (`feedback_no_auto_commit`)
+
+## このセッションの本題
+
+Cinematic mode (`AYAVisualRealismEnabled==2`) で **r15 godrays** を
+ちゃんと魅せるための live cvar 整備と default 調整。
+
+経緯のキーポイント:
+
+1. **SUN_SHADOW permutation 抜け**: BD-port `gVolumetricLightProgram` に
+   `SUN_SHADOW` permutation を立て忘れていて、`shadowUtil.glsl` の
+   `nonpcfShadowAtPos` が一様 `1.0` fallback を返し godray が「光のシャフト」
+   ではなく scene 全体への一様 sunlight 加算になっていた → fix 済。
+2. **godrays の cvar 化**: 旧 `const float strength = 0.10` / `pow(cos, 8.0)`
+   を live cvar (`AYAR15GodraysStrength` / `AYAR15GodraysPhaseExponent`) に置換。
+3. **白飛び対策**: 当初 Reinhard soft-clip (`AYAR15GodraysSoftClip`) を入れたが、
+   「白飛びを抑えると結局 beam 強度も落ちるだけ」と AYA さんが指摘し、
+   **物理的に等価 (Reinhard は最も明るい sun center を最も削るため強度低下と等価)** と
+   判明 → 全削除。
+4. ~~MAX blend 案~~ → AYA さん検証で「あまりよくなかった」と却下、全削除済
+   (`AYAR15GodraysUseMaxBlend` cvar / pipeline.cpp glBlendEquation / xui checkbox 全消)。
+5. **default チューニング** (AYA 体感確定):
+   - `AYAR15GodraysPhaseExponent`: 16.0 → **30.0** (集中ビーム)
+   - `AYAR15GodraysStrength`: 0.15 → **0.10** (控えめ)
+6. **mesh blow-out (sun-facing 面の白濁)**: godrays が原因ではなく
+   mesh material × tonemap/exposure が支配的、と AYA さん診断。**Task #12 で
+   parking lot に保留** (godrays 整備完了後に別 phase で着手)。
+7. **Cinematic 新 default 3 件追加** (overlay + parityTable 同期):
+   - `RenderShadowResolutionScale = 3.0` (sunset 影の cascade 解像度確保)
+   - `RenderFarClip = 400.0` (遠景描画)
+   - `RenderVolumetricLightingMultiplier = 4.0` (BD-port renderVolumetric 強度、
+     50 → 4.0 に大幅 down。AYA さん「4.0 でも OK」と承認済)
+8. **Godrays Cinematic default flip migration**: `AYAR15GodraysInCinematicEnabled`
+   default `false` → `true` に切替。既存ユーザーの persisted false を一度だけ
+   強制 true 上書きする one-shot migration (`AYAR15GodraysCinematicMigrationVersion`
+   sentinel) を追加。
+9. **UI label 統一**: floater section / checkbox / tooltip 全部
+   "AYAstorm r15 ゴッドレイ" → "ゴッドレイ" (en は "Godrays") に簡略化。
+   Cinematic 有効化 checkbox label は "ゴッドレイ有効化" / "Enable Godrays"。
+10. **floater 右余白縮小** (AYA 指摘): floater 600→500、tab 590→490、
+    panel 588→488、header text 572→472、checkbox label 506→406 で 100px 削減。
+    Glow & Volumetric panel height は MAX blend 行削除分 457→433 (-24)。
+
+## working tree 変更ファイル (14 件)
+
+| ファイル | 役割 |
+| --- | --- |
+| `indra/newview/llviewershadermgr.cpp` | `gVolumetricLightProgram` に `SUN_SHADOW=1` permutation 追加 (godrays shaftify fix の本丸) |
+| `indra/newview/app_settings/settings.xml` | godrays cvar 4 件追加/更新 (`InCinematicEnabled` default→1, `PhaseExponent` default 30.0, `Strength` default 0.10, `CinematicMigrationVersion`)。MAX blend cvar は削除 |
+| `indra/newview/app_settings/settings_cinematic_bd.xml` | Cinematic overlay に `RenderShadowResolutionScale=3.0` / `RenderFarClip=400.0` / `RenderVolumetricLightingMultiplier=4.0` を追加 |
+| `indra/newview/llviewermenu.cpp` | `AYAResetCinematic::parityTable` に上記 3 件を同期 (D ボタン reset 値) |
+| `indra/newview/llappviewer.cpp` | `LLCinematicOverlay::applyR15GodraysCinematicMigrationIfNeeded()` 呼出追加 |
+| `indra/newview/llcinematicoverlay.cpp` / `.h` | 同 migration 関数の実装/宣言 |
+| `indra/newview/llsettingsvo.cpp` | godrays 用 `phase_exponent` / `strength` uniform binding (LLCachedControl + uniform1f) |
+| `indra/llrender/llshadermgr.h` | `AYA_R15_GODRAYS_PHASE_EXPONENT` / `AYA_R15_GODRAYS_STRENGTH` enum 追加 |
+| `indra/llrender/llshadermgr.cpp` | 同 uniform name の `mReservedUniforms.push_back` |
+| `indra/newview/app_settings/shaders/class1/deferred/godraysF.glsl` | 旧 const を `uniform float aya_r15_godrays_phase_exponent` / `aya_r15_godrays_strength` 化 |
+| `indra/newview/pipeline.cpp::doGodrays` | mode==1 早期 return 削除 (唯一の caller 側に gate 集約済)。MAX blend opt-in は削除 |
+| `indra/newview/skins/default/xui/en/floater_aya_cinematic.xml` | floater 490 / tab_container 461 / `tab_glow_godrays` panel 433、`PhaseExp` slider min 4→1、section/checkbox label を "Godrays" に統一、Cinematic 有効化 checkbox label を "Enable Godrays"。floater 右余白 100px 削減 (各 width -100)。MAX blend 行 / SoftClip 行は完全削除 |
+| `indra/newview/skins/default/xui/ja/floater_aya_cinematic.xml` | 同 ja 翻訳追加。section "ゴッドレイ"、Cinematic 有効化 checkbox label "ゴッドレイ有効化"。MAX blend / SoftClip 行削除 |
+
+> SoftClip 関連 + MAX blend 関連は **全 6 ファイルから完全 revert 済**
+> (`AYAR15GodraysSoftClip` / `aya_r15_godrays_soft_clip` / `AYA_R15_GODRAYS_SOFT_CLIP` /
+> `AYAR15GodraysUseMaxBlend` / `aya_r15_max_blend` / `MAX_BLEND` 全文字列 grep して
+> 残存 0 を確認済)。
+
+## 新規 cvar 一覧
+
+| cvar | Type | default (settings.xml) | Cinematic overlay | parityTable (D 値) | 役割 |
+| --- | --- | --- | --- | --- | --- |
+| `AYAR15GodraysInCinematicEnabled` | Boolean | **1** (flip 済) | — | — | godrays の Cinematic mode opt-in。default ON 化 |
+| `AYAR15GodraysCinematicMigrationVersion` | S32 | 0 | — | — | flip migration の sentinel (0=未適用 → 起動時に強制 true 上書き、1=適用済) |
+| `AYAR15GodraysPhaseExponent` | F32 | **30.0** | — | LL default (30.0) | Mie phase exponent。1=全画面 halo / 8=wide / 16=moderate / 30=tight beam / 32=thin shaft |
+| `AYAR15GodraysStrength` | F32 | **0.10** | — | LL default (0.10) | 加算強度 |
+| `RenderShadowResolutionScale` | F32 | 1.0 | **3.0** | 3.0 | Cinematic で sunset の cascade 影確保 |
+| `RenderFarClip` | F32 | 256.0 | **400.0** | 400.0 | Cinematic 遠景 |
+| `RenderVolumetricLightingMultiplier` | F32 | 50.0 | **4.0** | 4.0 | BD-port renderVolumetric 強度 (godrays とは別 path) |
+
+## build / install 状態
+
+- **build**: 完了 (autobuild ReleaseFS_open + fmodstudio + opensim + LL_DULLAHAN_AUDIO_CALLBACK=ON)
+- **install**: `~/ayastorm/` に deploy 済 (rm -rf → cp -r build-linux-x86_64/newview/packaged/.)
+- **shader cache clear**: `~/.ayastorm_x64/cache/shader_cache/` 削除済
+- AYA さん起動して live 検証待ち
+
+## AYA さんに依頼中の検証
+
+```
+1. Cinematic mode で起動 (mode 0/1 → 2 切替は再起動必要)
+2. AYAstorm Controls → "Glow & Volumetric" tab → "ゴッドレイ (太陽方向ビーム)" section
+   - "ゴッドレイ有効化" checkbox が default ON
+   - "ビーム集中度" default 30.0、"ビーム強度" default 0.10
+3. 新 3 default が初起動時に焼かれているか確認:
+   - RenderShadowResolutionScale = 3.00
+   - RenderFarClip = 400
+   - RenderVolumetricLightingMultiplier = 4.0
+4. PhaseExp slider min が 1 まで下がるか (旧 4 制限の撤廃)
+5. floater 右余白が縮小 (幅 500px) され、コンパクトに収まっているか
+```
+
+**sentinel 既適用ユーザーの注意点**:
+
+すでに mode 2 で起動済みなら `AYACinematicOverlayApplied=1` が立っていて
+新 default は再焼きされない。次のいずれかが必要:
+
+- (a) Debug Settings から `AYACinematicOverlayApplied=0` に手動 reset → 再起動
+- (b) mode 0/1 → 2 に切り替え (sentinel auto reset される)→ 再起動
+
+## 検証後の debug settings 戻し案内 (release note 用)
+
+`feedback_restore_debug_settings` 準拠。検証で持ち上げた値があれば下記表で戻す:
+
+| cvar | 検証で持ち上げる可能性 | 戻す値 |
+| --- | --- | --- |
+| `AYAR15GodraysPhaseExponent` | スライダーで A/B 比較 | 30.0 (default) |
+| `AYAR15GodraysStrength` | スライダーで A/B 比較 | 0.10 (default) |
+| `AYACinematicOverlayApplied` | 0 に reset した場合 | 1 (再焼き完了後に勝手に戻る) |
+| `AYAR15GodraysCinematicMigrationVersion` | デバッグで 0 に戻す可能性 | 1 (migration 完了後) |
+
+## 残タスク
+
+| # | 状態 | 内容 |
+| --- | --- | --- |
+| #11 | pending | SSS controls を Preferences → AYAstorm Controls に full move (godrays 受入後着手) |
+| #12 | pending (parking lot) | sun-facing mesh blow-out (tonemap/exposure 軸) 調査。godrays とは独立、別 phase |
+| #14 | completed | Cinematic 3 defaults 追加 (本セッション分) |
+| #15 | completed | build + install (本セッション分) |
+
+## 次に何をすべきか (Resume チェックリスト)
+
+1. AYA さんから検証結果を聞く (MAX blend の見た目、新 3 default の有効化確認、min 1 動作)。
+2. 検証 OK なら **commit してよいか AYA さんに確認** (`feedback_no_auto_commit`)。
+   commit する場合の単位推奨:
+   - C1: SUN_SHADOW permutation fix (llviewershadermgr.cpp) — 単独 bug fix として独立
+   - C2: godrays cvar 化 + UI label 統一 + 右余白縮小 (settings.xml + llshadermgr.h/cpp + llsettingsvo.cpp + godraysF.glsl + pipeline.cpp + xui en/ja)
+   - C3: Cinematic default flip migration (settings.xml の `InCinematicEnabled=1` + `CinematicMigrationVersion` + llappviewer.cpp + llcinematicoverlay.cpp/h)
+   - C4: Cinematic 3 defaults (settings_cinematic_bd.xml + llviewermenu.cpp)
+3. push / PR は AYA さん側 (`feedback_release_flow`)。
+4. Task #11 (SSS migration) に着手するか AYA さんに確認 (godrays 確定後)。
+5. Task #12 (mesh blow-out) は別 phase。今 phase では触らない。
+
+## 注意点
+
+- 「壊さない」原則: BD-port `renderVolumetric` (50→4 default 変更) と r15 `doGodrays` は
+  **完全に別 path**。両者を混同して片方の挙動で他方を診断しない。
+- `RenderVolumetricLightingMultiplier=4.0` は **Cinematic overlay でのみ 4.0**、
+  Firestorm View / AYAstorm View では LL default 50 のまま (BD改善 phase 思想:
+  Cinematic default は変えるが他 mode は触らない)。
+- `AYAR15GodraysInCinematicEnabled` の default flip は **flag のみ反転**、
+  migration は既存ユーザー救済用の sentinel one-shot。逆戻ししたいユーザーは
+  Debug Settings から false に再設定可能。

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1372,6 +1372,8 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("aya_r14_volumetric_atmosphere_enabled");  // <FS:AYAstorm r30 BD改善>
     mReservedUniforms.push_back("aya_r14_strength");  // <FS:AYAstorm r30 BD改善>
     mReservedUniforms.push_back("aya_r15_godrays_enabled");  // <FS:AYAstorm r30 BD改善>
+    mReservedUniforms.push_back("aya_r15_godrays_phase_exponent");  // <FS:AYAstorm r30 BD改善>
+    mReservedUniforms.push_back("aya_r15_godrays_strength");  // <FS:AYAstorm r30 BD改善>
     mReservedUniforms.push_back("aya_r16_aerial_perspective_enabled");  // <FS:AYA r16>
     mReservedUniforms.push_back("aya_r16_strength");  // <FS:AYAstorm r30 BD改善>
     mReservedUniforms.push_back("aya_r18_cloud_volumetric_enabled");  // <FS:AYA r18>

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -128,6 +128,8 @@ public:
         AYA_R14_VOLUMETRIC_ATMOSPHERE_ENABLED, // "aya_r14_volumetric_atmosphere_enabled" <FS:AYAstorm r30 BD改善>
         AYA_R14_STRENGTH,                   //  "aya_r14_strength" <FS:AYAstorm r30 BD改善>
         AYA_R15_GODRAYS_ENABLED,            //  "aya_r15_godrays_enabled" <FS:AYAstorm r30 BD改善>
+        AYA_R15_GODRAYS_PHASE_EXPONENT,     //  "aya_r15_godrays_phase_exponent" <FS:AYAstorm r30 BD改善>
+        AYA_R15_GODRAYS_STRENGTH,           //  "aya_r15_godrays_strength" <FS:AYAstorm r30 BD改善>
         AYA_R16_AERIAL_PERSPECTIVE_ENABLED, //  "aya_r16_aerial_perspective_enabled" <FS:AYA r16>
         AYA_R16_STRENGTH,                   //  "aya_r16_strength" <FS:AYAstorm r30 BD改善>
         AYA_R18_CLOUD_VOLUMETRIC_ENABLED,   //  "aya_r18_cloud_volumetric_enabled" <FS:AYA r18>

--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10222,11 +10222,44 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>AYAR15GodraysInCinematicEnabled</key>
     <map>
       <key>Comment</key>
-      <string>r15 Godrays (godraysF post-process pass) を Cinematic mode で有効化。default OFF、live cvar。AYAVisualRealismEnabled==2 のとき有効。AYAstorm View (mode 1) では従来通り常時 ON</string>
+      <string>r15 Godrays (godraysF post-process pass) を Cinematic mode で有効化。default ON (BD改善 phase 確定)。AYAVisualRealismEnabled==2 のとき有効。既存ユーザーは AYAR15GodraysCinematicMigrationVersion 経由で一度だけ強制 true 化される</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>
       <string>Boolean</string>
+      <key>Value</key>
+      <integer>1</integer>
+    </map>
+    <key>AYAR15GodraysPhaseExponent</key>
+    <map>
+      <key>Comment</key>
+      <string>r15 Godrays Mie phase 関数の forward-peak exponent (pow(cos_theta, e))。1.0 = 余弦そのまま (最大ハロー、ほぼ全画面に薄く拡散) / 4 = 全画面 halo / 8 = wide halo / 16 = moderate beam / 30 = tight beam (default) / 32 = thin shaft (太陽 ~5° 内のみ)。値が大きいほど太陽方向に光が集中しビーム感が強い。shader 側で max(value, 1.0) でクランプ</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>30.0</real>
+    </map>
+    <key>AYAR15GodraysStrength</key>
+    <map>
+      <key>Comment</key>
+      <string>r15 Godrays の加算強度 (light_color * accum * phase * strength)。0.05 = うっすら / 0.10 = 控えめ (default) / 0.15-0.20 = ビーム / 0.50 = 強烈。HDR 加算なので 0.30 以上で空が白飛びする可能性</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>F32</string>
+      <key>Value</key>
+      <real>0.10</real>
+    </map>
+    <key>AYAR15GodraysCinematicMigrationVersion</key>
+    <map>
+      <key>Comment</key>
+      <string>AYAR15GodraysInCinematicEnabled default flip (OFF -> ON) one-shot migration の version sentinel。0=未適用 (起動時に強制 true 上書き)、1=適用済 (no-op)。手動で 0 に戻すと再 migration が走る</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>S32</string>
       <key>Value</key>
       <integer>0</integer>
     </map>

--- a/indra/newview/app_settings/settings_cinematic_bd.xml
+++ b/indra/newview/app_settings/settings_cinematic_bd.xml
@@ -192,5 +192,19 @@
 
     <key>AYAR18CloudVolumetricStrength</key>
     <real>0.7</real>
+
+    <!-- r30 Cinematic shadow / clip / volumetric defaults (2026-05-24 編入)。
+         AYA hands-on verify で「Cinematic で beam が薄く影が立たない」「奥が
+         見えない」「godray が控えめすぎる」を解消するための初起動焼き。
+         Reset D ボタン (parityTable) と値同期必須。 -->
+
+    <key>RenderShadowResolutionScale</key>
+    <real>3.0</real>
+
+    <key>RenderFarClip</key>
+    <real>400.0</real>
+
+    <key>RenderVolumetricLightingMultiplier</key>
+    <real>4.0</real>
   </map>
 </llsd>

--- a/indra/newview/app_settings/shaders/class1/deferred/godraysF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/godraysF.glsl
@@ -51,6 +51,12 @@ uniform vec4 shadow_clip;
 // <FS:AYAstorm r30 BD改善> master ではなく r15 個別 uniform を見る (Cinematic で master OFF のまま r15 だけ ON 可能)
 uniform int aya_r15_godrays_enabled;
 
+// <FS:AYAstorm r30 BD改善> r15 ビーム感 live cvar tuning
+//   phase_exponent: Mie 前方ピーク (pow(cos_theta, e))。大きいほど太陽方向に集中、ビーム感増
+//   strength: 加算強度。HDR 加算なので大きすぎると空白飛び。
+uniform float aya_r15_godrays_phase_exponent;
+uniform float aya_r15_godrays_strength;
+
 // helpers provided by deferred/deferredUtil.glsl + deferred/shadowUtil.glsl
 float getDepth(vec2 pos_screen);
 vec4  getPositionWithDepth(vec2 pos_screen, float depth);
@@ -144,15 +150,12 @@ void main()
 
     // Mie-style forward peak. Exponent controls how tightly the contribution
     // hugs the sun direction. 8 = visibly wide halo, 16 = moderate, 32 = thin
-    // shaft only when looking ~5° from the sun.
+    // shaft only when looking ~5° from the sun. Live cvar AYAR15GodraysPhaseExponent。
     float cos_theta = clamp(dot(view_dir, light_dir), 0.0, 1.0);
-    float phase     = pow(cos_theta, 8.0);
+    float phase     = pow(cos_theta, max(aya_r15_godrays_phase_exponent, 1.0));
 
-    // r15 MVP intensity. AYA 体感調整: 0.5 = loud, 0.2 = ちょっと強い、
-    // 0.15 もまだ少し強い、0.10 で「うっすら空気の主張」を狙う。
-    const float strength = 0.10;
-
-    vec3 godrays = light_color * accum * phase * strength;
+    // 加算強度。live cvar AYAR15GodraysStrength。
+    vec3 godrays = light_color * accum * phase * aya_r15_godrays_strength;
 
     // Alpha は必ず 0。scene buffer の alpha は doAtmospherics / sky 合成が
     // mask として使うので、blendFunc ONE/ONE のもとで alpha=1.0 を書くと

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3282,6 +3282,12 @@ bool LLAppViewer::initConfiguration()
     LLCinematicOverlay::applyR20SSSMigrationIfNeeded();
     // </FS:AYAstorm>
 
+    // <FS:AYAstorm> r30 BD改善: r15 Godrays Cinematic opt-in default flip migration.
+    // One-shot; safe in every startup path (no-op once
+    // AYAR15GodraysCinematicMigrationVersion >= 1).
+    LLCinematicOverlay::applyR15GodraysCinematicMigrationIfNeeded();
+    // </FS:AYAstorm>
+
     // <FS:Ansariel> Debug setting to disable log throttle
     nd::logging::setThrottleEnabled(gSavedSettings.getBOOL("FSEnableLogThrottle"));
 

--- a/indra/newview/llcinematicoverlay.cpp
+++ b/indra/newview/llcinematicoverlay.cpp
@@ -178,3 +178,33 @@ void LLCinematicOverlay::applyAYAViewModeMigrationIfNeeded()
     gSavedSettings.setS32(VERSION_CONTROL, 1);
 }
 // </FS:AYAstorm>
+
+// <FS:AYAstorm> r30 BD改善: r15 Godrays Cinematic opt-in default flip migration.
+// Pre-flip (live A/B 期間):
+//   AYAR15GodraysInCinematicEnabled default false → 既存ユーザーは false 持ち
+// Post-flip (BD改善 phase 確定):
+//   default true → 新規ユーザーは godrays 体験
+// 既存ユーザーは Persist=1 で false が残るため新 default の恩恵を受けない。
+// 本 migration で version 0 → 1 のとき強制 true 上書き。明示的に false に設定
+// していたユーザーも一度上書きされるが、godrays 撮影体験を guarantee する方を優先。
+// 再度 OFF にしたい場合は Debug Settings から手動で false に戻せる。
+void LLCinematicOverlay::applyR15GodraysCinematicMigrationIfNeeded()
+{
+    static const char VERSION_CONTROL[] = "AYAR15GodraysCinematicMigrationVersion";
+    static const char ENABLED_CONTROL[] = "AYAR15GodraysInCinematicEnabled";
+
+    const S32 ver = gSavedSettings.getS32(VERSION_CONTROL);
+    if (ver >= 1)
+    {
+        return;
+    }
+
+    const bool old_value = gSavedSettings.getBOOL(ENABLED_CONTROL);
+    gSavedSettings.setBOOL(ENABLED_CONTROL, true);
+    gSavedSettings.setS32(VERSION_CONTROL, 1);
+
+    LL_INFOS("CinematicOverlay")
+        << "r15 godrays Cinematic migration v0->v1: "
+        << ENABLED_CONTROL << " " << (old_value ? "true" : "false") << " -> true" << LL_ENDL;
+}
+// </FS:AYAstorm>

--- a/indra/newview/llcinematicoverlay.h
+++ b/indra/newview/llcinematicoverlay.h
@@ -52,6 +52,15 @@ namespace LLCinematicOverlay
     // AYAViewModeMigrationVersion.
     void applyAYAViewModeMigrationIfNeeded();
     // </FS:AYAstorm>
+
+    // <FS:AYAstorm> r30 BD改善: r15 Godrays Cinematic opt-in default flip.
+    // Pre: AYAR15GodraysInCinematicEnabled default OFF (live A/B 期間)
+    // Post: default ON (BD改善 phase で「Cinematic でも godrays 標準」と確定)
+    // Runs once: when AYAR15GodraysCinematicMigrationVersion < 1, forces the
+    // cvar to true regardless of persisted value, then bumps the version.
+    // 既存ユーザーが live A/B 期間中 false 持ちで放置していたケースを救済する。
+    void applyR15GodraysCinematicMigrationIfNeeded();
+    // </FS:AYAstorm>
 }
 
 #endif // LL_CINEMATIC_OVERLAY_H

--- a/indra/newview/llsettingsvo.cpp
+++ b/indra/newview/llsettingsvo.cpp
@@ -998,6 +998,11 @@ void LLSettingsVOSky::applySpecial(void *ptarget, bool force)
         static LLCachedControl<bool> aya_r15_in_cinematic(gSavedSettings, "AYAR15GodraysInCinematicEnabled", false);
         bool r15_on = aya_view || (aya_visual_realism() == 2 && aya_r15_in_cinematic);
         shader->uniform1i(LLShaderMgr::AYA_R15_GODRAYS_ENABLED, r15_on ? 1 : 0);
+
+        static LLCachedControl<F32> aya_r15_phase_exp(gSavedSettings, "AYAR15GodraysPhaseExponent", 16.0f);
+        static LLCachedControl<F32> aya_r15_strength(gSavedSettings, "AYAR15GodraysStrength", 0.15f);
+        shader->uniform1f(LLShaderMgr::AYA_R15_GODRAYS_PHASE_EXPONENT, (F32)aya_r15_phase_exp);
+        shader->uniform1f(LLShaderMgr::AYA_R15_GODRAYS_STRENGTH, (F32)aya_r15_strength);
     }
     // </FS:AYAstorm>
 

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -10179,6 +10179,11 @@ class AYAResetCinematic : public view_listener_t
             {"AYAR17Strength",                               LLSD(0.5)},
             {"AYAR18CloudVolumetricInCinematicEnabled",      LLSD(true)},
             {"AYAR18CloudVolumetricStrength",                LLSD(0.7)},
+            // r30 Cinematic shadow / clip / volumetric defaults (2026-05-24)。
+            // settings_cinematic_bd.xml overlay と値同期必須。
+            {"RenderShadowResolutionScale",                  LLSD(3.0)},
+            {"RenderFarClip",                                LLSD(400.0)},
+            {"RenderVolumetricLightingMultiplier",           LLSD(4.0)},
         };
         return table;
     }

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -3439,6 +3439,13 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         if (use_sun_shadow)
         {
             gVolumetricLightProgram.addPermutation("HAS_SUN_SHADOW", "1");
+            // <FS:AYAstorm r30 godrays fix> cinematic_bd/class1/deferred/shadowUtil.glsl の
+            // nonpcfShadowAtPos は #if defined(SUN_SHADOW) 外で return 1.0 (一様 fallback) を
+            // 返す。SUN_SHADOW permutation を立てないと Cinematic main() で
+            // shaftify が depth に依らず const となり、godray が「光のシャフト」
+            // でなく scene 全体への一様 sunlight 加算になる。BD 元実装に合わせて立てる。
+            gVolumetricLightProgram.addPermutation("SUN_SHADOW", "1");
+            // </FS:AYAstorm>
         }
 
         static LLCachedControl<bool> volumetric_directional(gSavedSettings, "RenderVolumetricLightingDirectional", true);

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -11625,14 +11625,10 @@ void LLPipeline::doGodrays()
         return;
     }
 
-    // <FS:AYAstorm r30 BD full port Phase 3.1> AYAVisualRealismEnabled (U32, 0=Firestorm View / 1=AYAstorm View / 2=Cinematic)。
-    // r15 godrays は AYAstorm View r14+ stack の一部、Cinematic は純 BD パスのため OFF。
-    // D1 確定 (docs/specs/ayastorm-r30-bd-full-port-phase2-spec.md §1)。
-    static LLCachedControl<U32> realism_enabled(gSavedSettings, "AYAVisualRealismEnabled", 1);
-    if (realism_enabled() != 1)
-    {
-        return;
-    }
+    // <FS:AYAstorm r30 BD改善> mode gate は唯一の caller (line ~5184) 側に集約済。
+    // BD改善 Phase で Cinematic mode==2 + AYAR15GodraysInCinematicEnabled で opt-in dispatch
+    // できるようになったため、本体側の mode==1 early return は dispatch 条件を裏切る。
+    // 二重 gate を撤去し、callee は呼ばれたら走るだけにする。
     // </FS:AYAstorm>
 
     if (!gDeferredGodraysProgram.isComplete())

--- a/indra/newview/skins/default/xui/en/floater_aya_cinematic.xml
+++ b/indra/newview/skins/default/xui/en/floater_aya_cinematic.xml
@@ -25,7 +25,7 @@
  can_resize="false"
  can_close="true"
  can_minimize="true"
- height="484"
+ height="490"
  help_topic="aya_cinematic_floater"
  layout="topleft"
  name="aya_cinematic"
@@ -34,55 +34,55 @@
  save_dock_state="false"
  single_instance="true"
  title="AYAstorm Controls"
- width="600">
+ width="500">
 
     <tab_container
      follows="left|top"
      halign="center"
-     height="455"
+     height="461"
      layout="topleft"
      left="5"
      name="aya_cinematic_tabs"
      tab_height="22"
      tab_position="top"
      top="22"
-     width="590">
+     width="490">
 
         <!-- =================== Tab 1: General =================== -->
-        <panel border="false" follows="left|top" label="General" layout="topleft" left="1" name="tab_general" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_GeneralMaster" top="8"   left="8"  width="572" height="18" font="SansSerif">Master switches (AYAstorm preset defaults)</text>
+        <panel border="false" follows="left|top" label="General" layout="topleft" left="1" name="tab_general" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_GeneralMaster" top="8"   left="8"  width="472" height="18" font="SansSerif">Master switches (AYAstorm preset defaults)</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DeferredSSAO"        control_name="RenderDeferredSSAO"       top="32"  left="36" width="506" height="20" label="Screen Space Ambient Occlusion (SSAO)" tool_tip="Approximate contact shadows / ambient darkening."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DeferredSSAO"        control_name="RenderDeferredSSAO"       top="32"  left="36" width="406" height="20" label="Screen Space Ambient Occlusion (SSAO)" tool_tip="Approximate contact shadows / ambient darkening."/>
             <button    follows="left|top" layout="topleft" name="d_DeferredSSAO"         top="32"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDeferredSSAO"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_Glow"                control_name="RenderGlow"               top="56"  left="36" width="506" height="20" label="Glow / Bloom" tool_tip="HDR bloom pass on bright pixels."/>
+            <check_box follows="left|top" layout="topleft" name="cb_Glow"                control_name="RenderGlow"               top="56"  left="36" width="406" height="20" label="Glow / Bloom" tool_tip="HDR bloom pass on bright pixels."/>
             <button    follows="left|top" layout="topleft" name="d_Glow"                 top="56"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderGlow"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_AttachedParticles"   control_name="RenderAttachedParticles"  top="80"  left="36" width="506" height="20" label="Render Attached Particles" tool_tip="Particles emitted from attachments on avatars."/>
+            <check_box follows="left|top" layout="topleft" name="cb_AttachedParticles"   control_name="RenderAttachedParticles"  top="80"  left="36" width="406" height="20" label="Render Attached Particles" tool_tip="Particles emitted from attachments on avatars."/>
             <button    follows="left|top" layout="topleft" name="d_AttachedParticles"    top="80"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderAttachedParticles"/></button>
 
-            <text       follows="left|top" layout="topleft" name="T_GeneralReflection"   top="116" left="8"   width="572" height="18" font="SansSerif">Reflection detail</text>
+            <text       follows="left|top" layout="topleft" name="T_GeneralReflection"   top="116" left="8"   width="472" height="18" font="SansSerif">Reflection detail</text>
 
             <text       follows="left|top" layout="topleft" name="T_ReflectionDetail"    top="140" left="12"  width="160" height="20">Reflection probe quality</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_ReflectionDetail"   top="142" left="176" width="195" height="16" control_name="RenderReflectionProbeLevel" min_val="0" max_val="3" increment="1"/>
             <spinner    follows="left|top" layout="topleft" name="s_ReflectionDetail"    top="140" left="376" width="65"  height="20" control_name="RenderReflectionProbeLevel" min_val="0" max_val="3" increment="1" decimal_digits="0" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_ReflectionDetail"    top="140" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderReflectionProbeLevel"/></button>
 
-            <text       follows="left|top|right" layout="topleft" name="T_GeneralNote"   top="186" left="8"   width="572" height="40" font="SansSerifSmall" word_wrap="true" text_color="White_50">
+            <text       follows="left|top|right" layout="topleft" name="T_GeneralNote"   top="186" left="8"   width="472" height="40" font="SansSerifSmall" word_wrap="true" text_color="White_50">
                 Tip: change View Mode in Preferences → Graphics. Restart the viewer after switching to apply.
             </text>
         </panel>
 
         <!-- =================== Tab 2: Shadows =================== -->
-        <panel border="false" follows="left|top" label="Shadows" layout="topleft" left="1" name="tab_shadows" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_ShadowsLevel" top="8" left="8" width="572" height="18" font="SansSerif">Shadow level &amp; distance</text>
+        <panel border="false" follows="left|top" label="Shadows" layout="topleft" left="1" name="tab_shadows" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_ShadowsLevel" top="8" left="8" width="472" height="18" font="SansSerif">Shadow level &amp; distance</text>
 
             <text       follows="left|top" layout="topleft" name="T_ShadowDetail"        top="32"  left="12"  width="160" height="20">Shadow Detail (0-2)</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_ShadowDetail"       top="34"  left="176" width="195" height="16" control_name="RenderShadowDetail" min_val="0" max_val="2" increment="1" tool_tip="0=off, 1=sun only, 2=sun+spot+projector (LL/BD have no level 3 path)"/>
             <spinner    follows="left|top" layout="topleft" name="s_ShadowDetail"        top="32"  left="376" width="65"  height="20" control_name="RenderShadowDetail" min_val="0" max_val="2" increment="1" decimal_digits="0" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_ShadowDetail"        top="32"  left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderShadowDetail"/></button>
 
-            <check_box  follows="left|top" layout="topleft" name="cb_ShadowAutoDistance" control_name="RenderShadowAutomaticDistance" top="60" left="36" width="506" height="20" label="Automatic shadow distance" tool_tip="When on, viewer chooses cascade distances; manual sliders below are ignored."/>
+            <check_box  follows="left|top" layout="topleft" name="cb_ShadowAutoDistance" control_name="RenderShadowAutomaticDistance" top="60" left="36" width="406" height="20" label="Automatic shadow distance" tool_tip="When on, viewer chooses cascade distances; manual sliders below are ignored."/>
             <button     follows="left|top" layout="topleft" name="d_ShadowAutoDistance"  top="60"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderShadowAutomaticDistance"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_ShadowBlurSize"      top="88"  left="12"  width="160" height="20">Shadow blur size</text>
@@ -90,14 +90,14 @@
             <spinner    follows="left|top" layout="topleft" name="s_ShadowBlurSize"      top="88"  left="376" width="65"  height="20" enabled_control="AYACinematicModeActive" control_name="RenderShadowBlurSize" min_val="0" max_val="4" increment="0.1" decimal_digits="2" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_ShadowBlurSize"      top="88"  left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderShadowBlurSize"/></button>
 
-            <text       follows="left|top" layout="topleft" name="T_ShadowsRes"          top="124" left="8"   width="572" height="18" font="SansSerif">Shadow resolution</text>
+            <text       follows="left|top" layout="topleft" name="T_ShadowsRes"          top="124" left="8"   width="472" height="18" font="SansSerif">Shadow resolution</text>
 
             <text       follows="left|top" layout="topleft" name="T_ShadowResX"          top="148" left="12"  width="160" height="20">Resolution scale (x base)</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_ShadowResX"         top="150" left="176" width="195" height="16" control_name="RenderShadowResolutionScale" min_val="0.5" max_val="3.0" increment="0.05"/>
             <spinner    follows="left|top" layout="topleft" name="s_ShadowResX"          top="148" left="376" width="65"  height="20" control_name="RenderShadowResolutionScale" min_val="0.5" max_val="3.0" increment="0.05" decimal_digits="2" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_ShadowResX"          top="148" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderShadowResolutionScale"/></button>
 
-            <text       follows="left|top" layout="topleft" name="T_ShadowsExtras"       top="184" left="8"   width="572" height="18" font="SansSerif">Extras</text>
+            <text       follows="left|top" layout="topleft" name="T_ShadowsExtras"       top="184" left="8"   width="472" height="18" font="SansSerif">Extras</text>
 
             <text       follows="left|top" layout="topleft" name="T_ShadowFarClip"       top="208" left="12"  width="160" height="20">Shadow far clip</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_ShadowFarClip"      top="210" left="176" width="195" height="16" enabled_control="AYACinematicModeActive" control_name="RenderShadowFarClip" min_val="32" max_val="512" increment="1" tool_tip="Shadow draw distance in meters. Effective range is capped by RenderFarClip (view distance)."/>
@@ -106,16 +106,16 @@
         </panel>
 
         <!-- =================== Tab 3: SSAO =================== -->
-        <panel border="false" follows="left|top" label="SSAO" layout="topleft" left="1" name="tab_ssao" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_SSAOMaster" top="8" left="8" width="572" height="18" font="SansSerif">SSAO master</text>
+        <panel border="false" follows="left|top" label="SSAO" layout="topleft" left="1" name="tab_ssao" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_SSAOMaster" top="8" left="8" width="472" height="18" font="SansSerif">SSAO master</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DeferredSSAO_ssao_tab"  control_name="RenderDeferredSSAO" top="32" left="36" width="506" height="20" label="SSAO master (same toggle as General tab)"/>
+            <check_box follows="left|top" layout="topleft" name="cb_DeferredSSAO_ssao_tab"  control_name="RenderDeferredSSAO" top="32" left="36" width="406" height="20" label="SSAO master (same toggle as General tab)"/>
             <button    follows="left|top" layout="topleft" name="d_DeferredSSAO_ssao_tab"    top="32"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDeferredSSAO"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DeferredBlurLight"       control_name="RenderDeferredBlurLight" top="56" left="36" width="506" height="20" label="Blur deferred lights" tool_tip="Soften the per-light contributions in the deferred pass."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DeferredBlurLight"       control_name="RenderDeferredBlurLight" top="56" left="36" width="406" height="20" label="Blur deferred lights" tool_tip="Soften the per-light contributions in the deferred pass."/>
             <button    follows="left|top" layout="topleft" name="d_DeferredBlurLight"        top="56"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDeferredBlurLight"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_SSAOTuning" top="92" left="8" width="572" height="18" font="SansSerif">Tuning</text>
+            <text follows="left|top" layout="topleft" name="T_SSAOTuning" top="92" left="8" width="472" height="18" font="SansSerif">Tuning</text>
 
             <text       follows="left|top" layout="topleft" name="T_SSAOFactor"   top="116" left="12"  width="160" height="20">Factor</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_SSAOFactor"  top="118" left="176" width="195" height="16" enabled_control="AYACinematicModeActive" control_name="RenderSSAOFactor" min_val="0" max_val="2" increment="0.01"/>
@@ -134,25 +134,25 @@
         </panel>
 
         <!-- =================== Tab 4: DoF & Camera =================== -->
-        <panel border="false" follows="left|top" label="DoF &amp; Camera" layout="topleft" left="1" name="tab_dof_camera" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_DoFMaster" top="8" left="8" width="572" height="18" font="SansSerif">DoF master switches</text>
+        <panel border="false" follows="left|top" label="DoF &amp; Camera" layout="topleft" left="1" name="tab_dof_camera" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_DoFMaster" top="8" left="8" width="472" height="18" font="SansSerif">DoF master switches</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DepthOfField"   control_name="RenderDepthOfField"            top="32"  left="36" width="506" height="20" label="Enable Depth of Field" tool_tip="AYAstorm preset default ON; LL default OFF."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DepthOfField"   control_name="RenderDepthOfField"            top="32"  left="36" width="406" height="20" label="Enable Depth of Field" tool_tip="AYAstorm preset default ON; LL default OFF."/>
             <button    follows="left|top" layout="topleft" name="d_DepthOfField"    top="32"  left="12" width="20"  height="20" label="D" tool_tip="Reset to AYAstorm preset (ON)"><button.commit_callback function="AYAResetCinematic" parameter="RenderDepthOfField"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DoFHighQuality" control_name="RenderDepthOfFieldHighQuality" top="56"  left="36" width="506" height="20" label="High-quality DoF (4× CoF, depth-gated)" tool_tip="Higher GPU cost; AYAstorm preset default ON."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DoFHighQuality" control_name="RenderDepthOfFieldHighQuality" top="56"  left="36" width="406" height="20" label="High-quality DoF (4× CoF, depth-gated)" tool_tip="Higher GPU cost; AYAstorm preset default ON."/>
             <button    follows="left|top" layout="topleft" name="d_DoFHighQuality"  top="56"  left="12" width="20"  height="20" label="D" tool_tip="Reset to AYAstorm preset (ON)"><button.commit_callback function="AYAResetCinematic" parameter="RenderDepthOfFieldHighQuality"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DoFFront"       control_name="RenderDepthOfFieldFront"       top="80"  left="36" width="506" height="20" label="Front-of-focus blur" tool_tip="Allow objects in front of the focus plane to blur, not just behind."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DoFFront"       control_name="RenderDepthOfFieldFront"       top="80"  left="36" width="406" height="20" label="Front-of-focus blur" tool_tip="Allow objects in front of the focus plane to blur, not just behind."/>
             <button    follows="left|top" layout="topleft" name="d_DoFFront"        top="80"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDepthOfFieldFront"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DoFChroma"      control_name="RenderDepthOfFieldChroma"      top="104" left="36" width="506" height="20" label="Couple chromatic aberration to DoF" tool_tip="On: R/G/B offset scales with DoF blur. Off: radial vignette at screen edges only."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DoFChroma"      control_name="RenderDepthOfFieldChroma"      top="104" left="36" width="406" height="20" label="Couple chromatic aberration to DoF" tool_tip="On: R/G/B offset scales with DoF blur. Off: radial vignette at screen edges only."/>
             <button    follows="left|top" layout="topleft" name="d_DoFChroma"       top="104" left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDepthOfFieldChroma"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DoFAlphas"      enabled_control="AYACinematicModeActive" control_name="RenderDepthOfFieldAlphas" top="128" left="36" width="506" height="20" label="Include alpha-blended surfaces in DoF depth" tool_tip="On: alpha surfaces (cutoff 0.7) contribute to DoF. Off: excluded (cutoff 1.0)."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DoFAlphas"      enabled_control="AYACinematicModeActive" control_name="RenderDepthOfFieldAlphas" top="128" left="36" width="406" height="20" label="Include alpha-blended surfaces in DoF depth" tool_tip="On: alpha surfaces (cutoff 0.7) contribute to DoF. Off: excluded (cutoff 1.0)."/>
             <button    follows="left|top" layout="topleft" name="d_DoFAlphas"       top="128" left="12" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDepthOfFieldAlphas"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_CameraValues" top="160" left="8" width="572" height="18" font="SansSerif">Camera (AYAstorm preset values)</text>
+            <text follows="left|top" layout="topleft" name="T_CameraValues" top="160" left="8" width="472" height="18" font="SansSerif">Camera (AYAstorm preset values)</text>
 
             <text       follows="left|top" layout="topleft" name="T_FieldOfView"          top="184" left="12"  width="160" height="20">DoF focal FOV (°)</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_FieldOfView"         top="186" left="176" width="195" height="16" control_name="CameraFieldOfView"   min_val="10" max_val="120" increment="1" tool_tip="DoF blur formula input only. Does not change the viewport field of view (controlled by the world FOV settings)."/>
@@ -184,7 +184,7 @@
             <spinner    follows="left|top" layout="topleft" name="s_DoFResScale"          top="304" left="376" width="65"  height="20" control_name="CameraDoFResScale" min_val="0.1" max_val="1" increment="0.05" decimal_digits="2" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_DoFResScale"          top="304" left="445" width="20"  height="20" label="D" tool_tip="Reset to AYAstorm preset (0.5)"><button.commit_callback function="AYAResetCinematic" parameter="CameraDoFResScale"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_ChromaSec" top="336" left="8" width="572" height="18" font="SansSerif">Chromatic aberration strength</text>
+            <text follows="left|top" layout="topleft" name="T_ChromaSec" top="336" left="8" width="472" height="18" font="SansSerif">Chromatic aberration strength</text>
 
             <text       follows="left|top" layout="topleft" name="T_ChromaStrength" top="360" left="12"  width="160" height="20">Strength</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_ChromaStrength" top="362" left="176" width="195" height="16" control_name="RenderChromaStrength" min_val="0" max_val="100" increment="0.1"/>
@@ -193,13 +193,13 @@
         </panel>
 
         <!-- =================== Tab 5: SSR =================== -->
-        <panel border="false" follows="left|top" label="SSR" layout="topleft" left="1" name="tab_ssr" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_SSRMaster" top="8" left="8" width="572" height="18" font="SansSerif">Screen Space Reflections</text>
+        <panel border="false" follows="left|top" label="SSR" layout="topleft" left="1" name="tab_ssr" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_SSRMaster" top="8" left="8" width="472" height="18" font="SansSerif">Screen Space Reflections</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_SSR" control_name="RenderScreenSpaceReflections" top="32" left="36" width="506" height="20" label="Enable Screen Space Reflections" tool_tip="AYAstorm preset default ON; LL default OFF."/>
+            <check_box follows="left|top" layout="topleft" name="cb_SSR" control_name="RenderScreenSpaceReflections" top="32" left="36" width="406" height="20" label="Enable Screen Space Reflections" tool_tip="AYAstorm preset default ON; LL default OFF."/>
             <button    follows="left|top" layout="topleft" name="d_SSR"  top="32" left="12" width="20" height="20" label="D" tool_tip="Reset to AYAstorm preset (ON)"><button.commit_callback function="AYAResetCinematic" parameter="RenderScreenSpaceReflections"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_SSRTuning" top="68" left="8" width="572" height="18" font="SansSerif">Quality tuning</text>
+            <text follows="left|top" layout="topleft" name="T_SSRTuning" top="68" left="8" width="472" height="18" font="SansSerif">Quality tuning</text>
 
             <text       follows="left|top" layout="topleft" name="T_SSRRayStep"     top="92"  left="12"  width="160" height="20">Ray step</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_SSRRayStep"    top="94"  left="176" width="195" height="16" control_name="RenderScreenSpaceReflectionRayStep" min_val="0.01" max_val="10" increment="0.1" tool_tip="Step size per iteration. Practical reflection reach is RayStep × Iterations; keep the product around ~50m or less."/>
@@ -233,10 +233,10 @@
         </panel>
 
         <!-- =================== Tab 6: Motion Blur =================== -->
-        <panel border="false" follows="left|top" label="Motion Blur" layout="topleft" left="1" name="tab_motion_blur" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_MBMaster" top="8" left="8" width="572" height="18" font="SansSerif">Motion Blur</text>
+        <panel border="false" follows="left|top" label="Motion Blur" layout="topleft" left="1" name="tab_motion_blur" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_MBMaster" top="8" left="8" width="472" height="18" font="SansSerif">Motion Blur</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_MotionBlur" control_name="RenderMotionBlur" top="32" left="36" width="506" height="20" label="Enable Motion Blur" tool_tip="AYAstorm preset default ON; LL default OFF."/>
+            <check_box follows="left|top" layout="topleft" name="cb_MotionBlur" control_name="RenderMotionBlur" top="32" left="36" width="406" height="20" label="Enable Motion Blur" tool_tip="AYAstorm preset default ON; LL default OFF."/>
             <button    follows="left|top" layout="topleft" name="d_MotionBlur"  top="32" left="12" width="20"  height="20" label="D" tool_tip="Reset to AYAstorm preset (ON)"><button.commit_callback function="AYAResetCinematic" parameter="RenderMotionBlur"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_MBStrength" top="60" left="12" width="160" height="20">Strength (px)</text>
@@ -244,13 +244,13 @@
             <spinner    follows="left|top" layout="topleft" name="s_MBStrength"  top="60" left="376" width="65"  height="20" control_name="RenderMotionBlurStrength" min_val="0" max_val="128" increment="1" decimal_digits="0" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_MBStrength"  top="60" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderMotionBlurStrength"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_MBSelf"     control_name="RenderMotionBlurSelfAvatar"   top="88"  left="36" width="506" height="20" label="Blur self avatar" tool_tip="Include self avatar in velocity buffer."/>
+            <check_box follows="left|top" layout="topleft" name="cb_MBSelf"     control_name="RenderMotionBlurSelfAvatar"   top="88"  left="36" width="406" height="20" label="Blur self avatar" tool_tip="Include self avatar in velocity buffer."/>
             <button    follows="left|top" layout="topleft" name="d_MBSelf"      top="88"  left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderMotionBlurSelfAvatar"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_MBOthers"   control_name="RenderMotionBlurOtherAvatars" top="112" left="36" width="506" height="20" label="Blur other avatars" tool_tip="Include other avatars in velocity buffer. Disable to keep them crisp in portrait/group shots."/>
+            <check_box follows="left|top" layout="topleft" name="cb_MBOthers"   control_name="RenderMotionBlurOtherAvatars" top="112" left="36" width="406" height="20" label="Blur other avatars" tool_tip="Include other avatars in velocity buffer. Disable to keep them crisp in portrait/group shots."/>
             <button    follows="left|top" layout="topleft" name="d_MBOthers"    top="112" left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderMotionBlurOtherAvatars"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_AA" top="148" left="8" width="572" height="18" font="SansSerif">Antialiasing</text>
+            <text follows="left|top" layout="topleft" name="T_AA" top="148" left="8" width="472" height="18" font="SansSerif">Antialiasing</text>
 
             <text       follows="left|top" layout="topleft" name="T_FSAAType"   top="172" left="12"  width="160" height="20">AA type (0/1/2/3)</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_FSAAType"  top="174" left="176" width="195" height="16" control_name="RenderFSAAType" min_val="0" max_val="3" increment="1" tool_tip="0=Off, 1=FXAA, 2=SMAA (AYAstorm preset), 3=SMAA + T2x temporal resolve (may ghost on motion)"/>
@@ -259,8 +259,8 @@
         </panel>
 
         <!-- =================== Tab 7: Glow & Volumetric =================== -->
-        <panel border="false" follows="left|top" label="Glow &amp; Volumetric" layout="topleft" left="1" name="tab_glow_godrays" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_GlowTuning" top="8" left="8" width="572" height="18" font="SansSerif">Glow / Bloom tuning</text>
+        <panel border="false" follows="left|top" label="Glow &amp; Volumetric" layout="topleft" left="1" name="tab_glow_godrays" top="0" height="433" width="488">
+            <text follows="left|top" layout="topleft" name="T_GlowTuning" top="8" left="8" width="472" height="18" font="SansSerif">Glow / Bloom tuning</text>
 
             <text       follows="left|top" layout="topleft" name="T_GlowStrength"          top="32"  left="12"  width="160" height="20">Strength</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_GlowStrength"         top="34"  left="176" width="195" height="16" enabled_control="AYACinematicModeActive" control_name="RenderGlowStrength" min_val="0" max_val="2" increment="0.005"/>
@@ -292,9 +292,9 @@
             <spinner    follows="left|top" layout="topleft" name="s_GlowWidth"             top="152" left="376" width="65"  height="20" enabled_control="AYACinematicModeActive" control_name="RenderGlowWidth" min_val="0.1" max_val="5" increment="0.05" decimal_digits="2" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_GlowWidth"             top="152" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderGlowWidth"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_VolLighting" top="184" left="8" width="572" height="18" font="SansSerif">Volumetric Lighting (AYA godrays)</text>
+            <text follows="left|top" layout="topleft" name="T_VolLighting" top="184" left="8" width="472" height="18" font="SansSerif">Volumetric Lighting (AYA godrays)</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_VolEnable" control_name="RenderVolumetricLighting" top="208" left="36" width="506" height="20" label="Enable volumetric lighting (godrays)" tool_tip="Master switch for the AYA godrays composite."/>
+            <check_box follows="left|top" layout="topleft" name="cb_VolEnable" control_name="RenderVolumetricLighting" top="208" left="36" width="406" height="20" label="Enable volumetric lighting (godrays)" tool_tip="Master switch for the AYA godrays composite."/>
             <button    follows="left|top" layout="topleft" name="d_VolEnable"  top="208" left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderVolumetricLighting"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_VolRes"  top="236" left="12"  width="160" height="20">Resolution</text>
@@ -312,25 +312,40 @@
             <spinner    follows="left|top" layout="topleft" name="s_VolFall"  top="284" left="376" width="65"  height="20" control_name="RenderVolumetricLightingFalloffMultiplier" min_val="0" max_val="10" increment="0.1" decimal_digits="2" label_width="0" tool_tip="Attenuates near-field godrays only; does not affect far-field rays."/>
             <button     follows="left|top" layout="topleft" name="d_VolFall"  top="284" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderVolumetricLightingFalloffMultiplier"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_VolDir" control_name="RenderVolumetricLightingDirectional" top="312" left="36" width="506" height="20" label="Directional fade (sun-below-horizon)" tool_tip="Adds GODRAYS_FADE permutation. Toggling rebuilds shaders live (1-2s)."/>
+            <check_box follows="left|top" layout="topleft" name="cb_VolDir" control_name="RenderVolumetricLightingDirectional" top="312" left="36" width="406" height="20" label="Directional fade (sun-below-horizon)" tool_tip="Adds GODRAYS_FADE permutation. Toggling rebuilds shaders live (1-2s)."/>
             <button    follows="left|top" layout="topleft" name="d_VolDir"  top="312" left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderVolumetricLightingDirectional"/></button>
+
+            <text follows="left|top" layout="topleft" name="T_R15Godrays" top="340" left="8" width="472" height="18" font="SansSerif">Godrays (sun-facing beam)</text>
+
+            <check_box follows="left|top" layout="topleft" name="cb_R15GodraysCinematic" control_name="AYAR15GodraysInCinematicEnabled" top="362" left="36" width="406" height="20" label="Enable Godrays" tool_tip="Cinematic モードで Godrays を有効化 (AYAstorm View では常時 ON)。"/>
+            <button    follows="left|top" layout="topleft" name="d_R15GodraysCinematic"  top="362" left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="AYAR15GodraysInCinematicEnabled"/></button>
+
+            <text       follows="left|top" layout="topleft" name="T_R15PhaseExp"  top="386" left="12"  width="160" height="20">Beam tightness</text>
+            <slider_bar follows="left|top" layout="topleft" name="sb_R15PhaseExp" top="388" left="176" width="195" height="16" control_name="AYAR15GodraysPhaseExponent" min_val="1" max_val="64" increment="1" tool_tip="Mie 前方ピーク exponent。1 = 最大ハロー (ほぼ全画面) / 4 = 全画面 halo / 8 = wide / 16 = moderate beam / 30 = tight beam (default) / 32 = thin shaft only near sun."/>
+            <spinner    follows="left|top" layout="topleft" name="s_R15PhaseExp"  top="386" left="376" width="65"  height="20" control_name="AYAR15GodraysPhaseExponent" min_val="1" max_val="64" increment="1" decimal_digits="1" label_width="0" tool_tip="Mie 前方ピーク exponent。1 = 最大ハロー (ほぼ全画面) / 4 = 全画面 halo / 8 = wide / 16 = moderate beam / 30 = tight beam (default) / 32 = thin shaft only near sun."/>
+            <button     follows="left|top" layout="topleft" name="d_R15PhaseExp"  top="386" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="AYAR15GodraysPhaseExponent"/></button>
+
+            <text       follows="left|top" layout="topleft" name="T_R15Strength"  top="410" left="12"  width="160" height="20">Beam strength</text>
+            <slider_bar follows="left|top" layout="topleft" name="sb_R15Strength" top="412" left="176" width="195" height="16" control_name="AYAR15GodraysStrength" min_val="0" max_val="0.5" increment="0.01" tool_tip="加算強度。0.10 = 控えめ (default) / 0.15-0.20 = ビーム / 0.30 以上で空が白飛び。"/>
+            <spinner    follows="left|top" layout="topleft" name="s_R15Strength"  top="410" left="376" width="65"  height="20" control_name="AYAR15GodraysStrength" min_val="0" max_val="0.5" increment="0.01" decimal_digits="2" label_width="0" tool_tip="加算強度。0.10 = 控えめ (default) / 0.15-0.20 = ビーム / 0.30 以上で空が白飛び。"/>
+            <button     follows="left|top" layout="topleft" name="d_R15Strength"  top="410" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="AYAR15GodraysStrength"/></button>
 
         </panel>
 
         <!-- =================== Tab 8: Lighting =================== -->
-        <panel border="false" follows="left|top" label="Lighting" layout="topleft" left="1" name="tab_lighting" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_LightingNote" top="8" left="8" width="572" height="18" font="SansSerif">Lighting controls</text>
+        <panel border="false" follows="left|top" label="Lighting" layout="topleft" left="1" name="tab_lighting" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_LightingNote" top="8" left="8" width="472" height="18" font="SansSerif">Lighting controls</text>
 
-            <check_box follows="left|top" layout="topleft" name="cb_EnableFullbright"   enabled_control="AYACinematicModeActive" control_name="RenderEnableFullbright"   top="32"  left="36" width="506" height="20" label="Enable fullbright textures (global)" tool_tip="If off, fullbright textures render as regular shaded surfaces (applies to all modes)."/>
+            <check_box follows="left|top" layout="topleft" name="cb_EnableFullbright"   enabled_control="AYACinematicModeActive" control_name="RenderEnableFullbright"   top="32"  left="36" width="406" height="20" label="Enable fullbright textures (global)" tool_tip="If off, fullbright textures render as regular shaded surfaces (applies to all modes)."/>
             <button    follows="left|top" layout="topleft" name="d_EnableFullbright"    top="32"  left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderEnableFullbright"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_DeferredLights"     enabled_control="AYACinematicModeActive" control_name="RenderDeferredLights"     top="56"  left="36" width="506" height="20" label="Render in-world point/spot lights" tool_tip="If off, non-attached point/spot lights are suppressed."/>
+            <check_box follows="left|top" layout="topleft" name="cb_DeferredLights"     enabled_control="AYACinematicModeActive" control_name="RenderDeferredLights"     top="56"  left="36" width="406" height="20" label="Render in-world point/spot lights" tool_tip="If off, non-attached point/spot lights are suppressed."/>
             <button    follows="left|top" layout="topleft" name="d_DeferredLights"      top="56"  left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderDeferredLights"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_OwnAttachedLights"  enabled_control="AYACinematicModeActive" control_name="RenderOwnAttachedLights"  top="80"  left="36" width="506" height="20" label="Render own attached lights" tool_tip="If off, lights attached to your own avatar are suppressed."/>
+            <check_box follows="left|top" layout="topleft" name="cb_OwnAttachedLights"  enabled_control="AYACinematicModeActive" control_name="RenderOwnAttachedLights"  top="80"  left="36" width="406" height="20" label="Render own attached lights" tool_tip="If off, lights attached to your own avatar are suppressed."/>
             <button    follows="left|top" layout="topleft" name="d_OwnAttachedLights"   top="80"  left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderOwnAttachedLights"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_OtherAttachedLights" enabled_control="AYACinematicModeActive" control_name="RenderOtherAttachedLights" top="104" left="36" width="506" height="20" label="Render others' attached lights" tool_tip="If off, lights attached to other avatars are suppressed."/>
+            <check_box follows="left|top" layout="topleft" name="cb_OtherAttachedLights" enabled_control="AYACinematicModeActive" control_name="RenderOtherAttachedLights" top="104" left="36" width="406" height="20" label="Render others' attached lights" tool_tip="If off, lights attached to other avatars are suppressed."/>
             <button    follows="left|top" layout="topleft" name="d_OtherAttachedLights" top="104" left="12" width="20" height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderOtherAttachedLights"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_GlobalLightStrength" top="128" left="12" width="160" height="20">Global light strength</text>
@@ -340,15 +355,15 @@
         </panel>
 
         <!-- =================== Tab 9: Post-process =================== -->
-        <panel border="false" follows="left|top" label="Post-process" layout="topleft" left="1" name="tab_postprocess" top="0" height="427" width="588">
-            <text follows="left|top" layout="topleft" name="T_PostCAS" top="8" left="8" width="572" height="18" font="SansSerif">Contrast Adaptive Sharpening (CAS)</text>
+        <panel border="false" follows="left|top" label="Post-process" layout="topleft" left="1" name="tab_postprocess" top="0" height="427" width="488">
+            <text follows="left|top" layout="topleft" name="T_PostCAS" top="8" left="8" width="472" height="18" font="SansSerif">Contrast Adaptive Sharpening (CAS)</text>
 
             <text       follows="left|top" layout="topleft" name="T_CASSharpness"  top="32" left="12"  width="160" height="20">CAS sharpness</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_CASSharpness" top="34" left="176" width="195" height="16" control_name="RenderCASSharpness" min_val="0" max_val="1" increment="0.01"/>
             <spinner    follows="left|top" layout="topleft" name="s_CASSharpness"  top="32" left="376" width="65"  height="20" control_name="RenderCASSharpness" min_val="0" max_val="1" increment="0.01" decimal_digits="2" label_width="0"/>
             <button     follows="left|top" layout="topleft" name="d_CASSharpness"  top="32" left="445" width="20"  height="20" label="D" tool_tip="Reset to default"><button.commit_callback function="AYAResetCinematic" parameter="RenderCASSharpness"/></button>
 
-            <text follows="left|top" layout="topleft" name="T_PostFX" top="64" left="8" width="572" height="18" font="SansSerif">Post FX</text>
+            <text follows="left|top" layout="topleft" name="T_PostFX" top="64" left="8" width="472" height="18" font="SansSerif">Post FX</text>
 
             <text       follows="left|top" layout="topleft" name="T_GreyscaleStrength"    top="88"  left="12" width="160" height="20">Greyscale strength</text>
             <slider_bar follows="left|top" layout="topleft" name="sb_GreyscaleStrength"   top="90"  left="176" width="195" height="16" enabled_control="AYACinematicModeActive" control_name="RenderPostGreyscaleStrength" min_val="0" max_val="1" increment="0.01" tool_tip="Applied before Sepia in the post pipeline. With both Greyscale and Sepia at 1.0 the result is a light brown tint."/>
@@ -370,8 +385,8 @@
         <!-- <FS:AYAstorm r30 BD改善> AYAstorm View 由来の追加効果を Cinematic mode に個別 opt-in。
              default OFF (= 純 BD パスのまま) で、AYA さんが live A/B しながら 1 件ずつ on/off 判断する想定。
              各 cvar は AYAR##InCinematicEnabled (Bool, default 0, Persist=1, live)。 -->
-        <panel border="false" follows="left|top" label="Atmosphere &amp; sky" layout="topleft" left="1" name="tab_aya_view_fx" top="0" height="427" width="588">
-            <check_box follows="left|top" layout="topleft" name="cb_R14VolAtm" enabled_control="AYACinematicModeActive" control_name="AYAR14VolumetricAtmosphereInCinematicEnabled" top="32"  left="36" width="506" height="20" label="Sky depth &amp; sun glare" tool_tip="高度に応じた空気密度勾配 + scene-referred linear 積分 (空の物理的混色)。空全体の色相/明度が変わる。"/>
+        <panel border="false" follows="left|top" label="Atmosphere &amp; sky" layout="topleft" left="1" name="tab_aya_view_fx" top="0" height="427" width="488">
+            <check_box follows="left|top" layout="topleft" name="cb_R14VolAtm" enabled_control="AYACinematicModeActive" control_name="AYAR14VolumetricAtmosphereInCinematicEnabled" top="32"  left="36" width="406" height="20" label="Sky depth &amp; sun glare" tool_tip="高度に応じた空気密度勾配 + scene-referred linear 積分 (空の物理的混色)。空全体の色相/明度が変わる。"/>
             <button    follows="left|top" layout="topleft" name="d_R14VolAtm"  enabled_control="AYACinematicModeActive" top="32"  left="12" width="20"  height="20" label="D" tool_tip="Reset to default (ON)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR14VolumetricAtmosphereInCinematicEnabled"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_R14Str"  enabled_control="AYACinematicModeActive" top="60" left="56"  width="116" height="20">Strength</text>
@@ -379,7 +394,7 @@
             <spinner    follows="left|top" layout="topleft" name="s_R14Str"  enabled_control="AYACinematicModeActive" top="60" left="376" width="65"  height="20" control_name="AYAR14Strength" min_val="0" max_val="1" increment="0.05" decimal_digits="2" label_width="0" tool_tip="r14 効果の強度 (0=OFF / 1=ON)。"/>
             <button     follows="left|top" layout="topleft" name="d_R14Str"  enabled_control="AYACinematicModeActive" top="60" left="445" width="20"  height="20" label="D" tool_tip="Reset to default (0.2)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR14Strength"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_R16Aerial" enabled_control="AYACinematicModeActive" control_name="AYAR16AerialPerspectiveInCinematicEnabled" top="84" left="36" width="506" height="20" label="Distant blue haze" tool_tip="遠景の青ヘイズ重み付け。遠距離オブジェクトに青みがかかる。"/>
+            <check_box follows="left|top" layout="topleft" name="cb_R16Aerial" enabled_control="AYACinematicModeActive" control_name="AYAR16AerialPerspectiveInCinematicEnabled" top="84" left="36" width="406" height="20" label="Distant blue haze" tool_tip="遠景の青ヘイズ重み付け。遠距離オブジェクトに青みがかかる。"/>
             <button    follows="left|top" layout="topleft" name="d_R16Aerial"  enabled_control="AYACinematicModeActive" top="84" left="12" width="20"  height="20" label="D" tool_tip="Reset to default (ON)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR16AerialPerspectiveInCinematicEnabled"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_R16Str"  enabled_control="AYACinematicModeActive" top="108" left="56"  width="116" height="20">Strength</text>
@@ -387,7 +402,7 @@
             <spinner    follows="left|top" layout="topleft" name="s_R16Str"  enabled_control="AYACinematicModeActive" top="108" left="376" width="65"  height="20" control_name="AYAR16AerialPerspectiveStrength" min_val="0" max_val="1" increment="0.05" decimal_digits="2" label_width="0" tool_tip="r16 効果の強度 (0=OFF / 1=ON)。"/>
             <button     follows="left|top" layout="topleft" name="d_R16Str"  enabled_control="AYACinematicModeActive" top="108" left="445" width="20"  height="20" label="D" tool_tip="Reset to default (0.5)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR16AerialPerspectiveStrength"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_R17Kelvin" enabled_control="AYACinematicModeActive" control_name="AYAR17ColorTemperatureInCinematicEnabled" top="132" left="36" width="506" height="20" label="Morning blue / evening warm tint" tool_tip="太陽 elevation から派生する Kelvin (2200K horizon ～ 6500K noon) を preset 色に乗算で modulate。朝青/夕橙の物理的整合を sky + scene + cloud で同期。"/>
+            <check_box follows="left|top" layout="topleft" name="cb_R17Kelvin" enabled_control="AYACinematicModeActive" control_name="AYAR17ColorTemperatureInCinematicEnabled" top="132" left="36" width="406" height="20" label="Morning blue / evening warm tint" tool_tip="太陽 elevation から派生する Kelvin (2200K horizon ～ 6500K noon) を preset 色に乗算で modulate。朝青/夕橙の物理的整合を sky + scene + cloud で同期。"/>
             <button    follows="left|top" layout="topleft" name="d_R17Kelvin"  enabled_control="AYACinematicModeActive" top="132" left="12" width="20"  height="20" label="D" tool_tip="Reset to default (OFF)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR17ColorTemperatureInCinematicEnabled"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_R17Str"  enabled_control="AYACinematicModeActive" top="156" left="56"  width="116" height="20">Strength</text>
@@ -395,7 +410,7 @@
             <spinner    follows="left|top" layout="topleft" name="s_R17Str"  enabled_control="AYACinematicModeActive" top="156" left="376" width="65"  height="20" control_name="AYAR17Strength" min_val="0" max_val="1" increment="0.05" decimal_digits="2" label_width="0" tool_tip="r17 効果の強度 (0=OFF / 1=ON)。"/>
             <button     follows="left|top" layout="topleft" name="d_R17Str"  enabled_control="AYACinematicModeActive" top="156" left="445" width="20"  height="20" label="D" tool_tip="Reset to default (0.5)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR17Strength"/></button>
 
-            <check_box follows="left|top" layout="topleft" name="cb_R18Cloud"  enabled_control="AYACinematicModeActive" control_name="AYAR18CloudVolumetricInCinematicEnabled" top="180" left="36" width="506" height="20" label="3D cloud depth" tool_tip="雲を平面ではなく厚みのある体積として raymarch。立体感が出るが GPU 負荷あり。"/>
+            <check_box follows="left|top" layout="topleft" name="cb_R18Cloud"  enabled_control="AYACinematicModeActive" control_name="AYAR18CloudVolumetricInCinematicEnabled" top="180" left="36" width="406" height="20" label="3D cloud depth" tool_tip="雲を平面ではなく厚みのある体積として raymarch。立体感が出るが GPU 負荷あり。"/>
             <button    follows="left|top" layout="topleft" name="d_R18Cloud"   enabled_control="AYACinematicModeActive" top="180" left="12" width="20"  height="20" label="D" tool_tip="Reset to default (ON)"><button.commit_callback function="AYAResetCinematic" parameter="AYAR18CloudVolumetricInCinematicEnabled"/></button>
 
             <text       follows="left|top" layout="topleft" name="T_R18Str"  enabled_control="AYACinematicModeActive" top="204" left="56"  width="116" height="20">Strength</text>

--- a/indra/newview/skins/default/xui/ja/floater_aya_cinematic.xml
+++ b/indra/newview/skins/default/xui/ja/floater_aya_cinematic.xml
@@ -243,6 +243,22 @@
                        tool_tip="GODRAYS_FADE permutation を追加します。切替時にシェーダーが即時再構築 (1-2秒) されます。"/>
             <button name="d_VolDir" tool_tip="デフォルトに戻す"/>
 
+            <text name="T_R15Godrays">ゴッドレイ (太陽方向ビーム)</text>
+
+            <check_box name="cb_R15GodraysCinematic" label="ゴッドレイ有効化"
+                       tool_tip="Cinematic モードでゴッドレイを有効化します (AYAstorm View では常時 ON)。"/>
+            <button name="d_R15GodraysCinematic" tool_tip="デフォルトに戻す"/>
+
+            <text name="T_R15PhaseExp">ビーム集中度</text>
+            <slider_bar name="sb_R15PhaseExp" tool_tip="Mie 前方ピーク指数。1 = 最大ハロー (ほぼ全画面) / 4 = 全画面ハロー / 8 = 広い / 16 = 中程度ビーム / 30 = 集中ビーム (デフォルト) / 32 = 太陽近傍のみの細いシャフト。"/>
+            <spinner    name="s_R15PhaseExp"  tool_tip="Mie 前方ピーク指数。1 = 最大ハロー (ほぼ全画面) / 4 = 全画面ハロー / 8 = 広い / 16 = 中程度ビーム / 30 = 集中ビーム (デフォルト) / 32 = 太陽近傍のみの細いシャフト。"/>
+            <button name="d_R15PhaseExp" tool_tip="デフォルトに戻す"/>
+
+            <text name="T_R15Strength">ビーム強度</text>
+            <slider_bar name="sb_R15Strength" tool_tip="加算強度。0.10 = 控えめ (デフォルト) / 0.15-0.20 = ビーム / 0.30 以上で空が白飛びします。"/>
+            <spinner    name="s_R15Strength"  tool_tip="加算強度。0.10 = 控えめ (デフォルト) / 0.15-0.20 = ビーム / 0.30 以上で空が白飛びします。"/>
+            <button name="d_R15Strength" tool_tip="デフォルトに戻す"/>
+
         </panel>
 
         <!-- ============ Tab 8: Lighting ============ -->


### PR DESCRIPTION
## 概要

r30 Cinematic mode の godrays (太陽方向ビーム) 周りを 3 commit でまとめて修正・調整します。

- SUN_SHADOW permutation 未指定で shaftify が一様 sunlight 加算になっていた致命を修正
- ビーム集中度 / 強度を live cvar 化 (記憶される設定)
- Cinematic default ON 化 (既存ユーザーは migration sentinel で 1 度だけ強制 true)
- floater UI の余白 100px 削減 + label を「ゴッドレイ / Godrays」に統一

経緯と検証手順は `docs/specs/ayastorm-r30-cinematic-godrays-handoff.md` に集約しています。

## 修正内容

### 1. `r30 godrays fix: gVolumetricLightProgram に SUN_SHADOW permutation 追加` (612c2d88a0)

`cinematic_bd/class1/deferred/shadowUtil.glsl::nonpcfShadowAtPos` は `#if defined(SUN_SHADOW)` 外で `return 1.0` (一様 fallback) を返すため、permutation を立てないと Cinematic main() の shaftify が depth に依らず一様 1.0 になり、godray が「光のシャフト」ではなく scene 全体への一様 sunlight 加算になっていました。BD 元実装に合わせて permutation を立てます。

### 2. `r30 godrays cvar 化 + UI 整理` (75968ccbae)

- `godraysF.glsl` の旧 const (`strength=0.10` / `pow(cos,8.0)`) を live uniform (`aya_r15_godrays_phase_exponent` / `aya_r15_godrays_strength`) に置換
- `settings.xml` に `AYAR15GodraysPhaseExponent` (default 30.0) / `AYAR15GodraysStrength` (default 0.10) を追加 (`Persist=1`)
- `AYAR15GodraysInCinematicEnabled` default false → true。既存ユーザーは `AYAR15GodraysCinematicMigrationVersion` 0→1 起動時に 1 度だけ強制 true 上書き
- `pipeline.cpp::doGodrays` の mode==1 早期 return を削除 (caller 側で Cinematic+opt-in / AYAstorm View 両 dispatch 済)
- `floater_aya_cinematic.xml` (en/ja): section/checkbox label を「ゴッドレイ / Godrays」/「ゴッドレイ有効化 / Enable Godrays」に統一、PhaseExp slider min 4→1
- floater 右余白を 100px 削減 (600→500, tab 590→490, panel 488)、Glow & Volumetric panel height 457→433 (MAX blend 行廃止分)
- 試作した MAX blend (`AYAR15GodraysUseMaxBlend`) と Reinhard SoftClip (`AYAR15GodraysSoftClip`) は AYA 体感判定で不採用、全 cvar/uniform/UI を削除

### 3. `r30 Cinematic defaults 追加: shadow 解像度 / 遠景 clip / volumetric 強度` (1dd92c5ee5)

`settings_cinematic_bd.xml` の Cinematic overlay (mode 2 起動時 1 度焼き) に下記 3 件を追加。Reset D ボタン (`AYAResetCinematic::parityTable`) と値同期:

- `RenderShadowResolutionScale = 3.0` (sunset cascade 影確保)
- `RenderFarClip = 400.0` (遠景描画)
- `RenderVolumetricLightingMultiplier = 4.0` (BD-port renderVolumetric 強度、LL default 50 から大幅 down)

既存ユーザーは `AYACinematicOverlayApplied=1` のため再焼きされず、新規 mode 2 起動時のみ自動適用。

## 検証状況

- Linux で全 3 commit 込みのビルドで動作確認済
  - Cinematic mode 起動 → godrays が「太陽方向のビーム」として可視
  - 既存 user 起動 → migration で Cinematic Godrays 強制 ON
  - floater の右余白が詰まり、label が「ゴッドレイ」表記
  - PhaseExp / Strength slider が live で反映
- macOS / Windows は未検証 (3 OS 揃えは別途お願いします)

## 参考

- `docs/specs/ayastorm-r30-cinematic-godrays-handoff.md`