### PR TITLE
r30 fix: Glow OFF 時 postprocess glow target を明示 zero-clear (Linux UI 白化対策)

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -8981,7 +8981,8 @@ void LLPipeline::generateGlow(LLRenderTarget* src)
     else // !sRenderGlow, skip the glow ping-pong and just clear the result target
     {
         mGlow[1].bindTarget();
-        mGlow[1].clear();
+        glClearColor(0.f, 0.f, 0.f, 0.f);
+        mGlow[1].clear(GL_COLOR_BUFFER_BIT);
         mGlow[1].flush();
     }
 }


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作)。

`RenderGlow=OFF` 経路で `mGlow[1]` を `LLRenderTarget::clear()` で消去していたが、`LLRenderTarget::clear()` は `glClear(mask)` を呼ぶだけで `glClearColor` を設定しないため、直前の GL state に依存していた。`mGlow[1]` は `combineGlow()` で常時 `DEFERRED_EMISSIVE` として bind されるため、Glow OFF 時に未初期化 / 残骸の色が emissive として乗ってしまう (Linux Mesa で UI 文字縁の白化として観測)。

`glClearColor(0,0,0,0)` を明示してから `clear(GL_COLOR_BUFFER_BIT)` を呼ぶことで、Glow OFF 時の `mGlow[1]` を確実に透明黒に揃える。

## 修正内容

`indra/newview/pipeline.cpp::generateGlow` の Glow OFF 経路 3 行:

```cpp
// before
mGlow[1].bindTarget();
mGlow[1].clear();
mGlow[1].flush();

// after
mGlow[1].bindTarget();
glClearColor(0.f, 0.f, 0.f, 0.f);
mGlow[1].clear(GL_COLOR_BUFFER_BIT);
mGlow[1].flush();
```

## 副作用範囲

- 影響は Glow OFF 経路のみ (Glow ON では ping-pong 描画で自然に上書き)
- mayatonton 側に同等の修正なし、本 PR で初出

## 検証状況

- Linux で受け容れ判定済 (AYA OK 出し)
- macOS / Windows は未検証 (3 OS 揃えは別途)