### PR TITLE
r30 build: AppleClang で -Wno-inconsistent-missing-override を追加

### DIFF
--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -241,6 +241,10 @@ if (LINUX OR DARWIN)
     add_compile_options(-Wno-unused-local-typedef)
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    add_compile_options(-Wno-inconsistent-missing-override)
+  endif()
+
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-stringop-truncation -Wno-parentheses -Wno-maybe-uninitialized)
   endif()


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作) のうち、macOS AppleClang のビルド warning 抑制のみを切り出したもの (`fix/r30-pr89-mac-glsl-guards` のうち 1 commit を cherry-pick)。

AppleClang は GCC / Clang と override 判定が異なり、`-Winconsistent-missing-override` が大量発火する。CMake 側で AppleClang 限定で当該 warning を抑制する。

## 修正内容

`indra/cmake/00-Common.cmake`:

```cmake
if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
  add_compile_options(-Wno-inconsistent-missing-override)
endif()
```

## 副作用範囲

- AppleClang (macOS) ビルドにのみ影響
- Linux GCC / Windows MSVC には無影響
- warning 抑制のみで挙動は変わらない

## 検証状況

- Linux ビルド影響なし
- macOS 実機ビルドは AYA 側で確認お願いします