### PR TITLE
r30 fix: Cinematic SSR uniform 配線修正 (vec3→float + maxZDepth/maxRoughness bind)

### DIFF
--- a/indra/newview/app_settings/shaders/cinematic_bd/class3/deferred/screenSpaceReflUtil.glsl
+++ b/indra/newview/app_settings/shaders/cinematic_bd/class3/deferred/screenSpaceReflUtil.glsl
@@ -34,12 +34,11 @@ uniform mat4 inv_proj;
 uniform mat4 modelview_delta;
 uniform mat4 inv_modelview_delta;
 
-// Declared to keep pipeline uniform setup happy
-uniform vec3 iterationCount;
-uniform vec3 rayStep;
-uniform vec3 distanceBias;
-uniform vec3 depthRejectBias;
-uniform vec3 adaptiveStepMultiplier;
+uniform float iterationCount;
+uniform float rayStep;
+uniform float distanceBias;
+uniform float depthRejectBias;
+uniform float adaptiveStepMultiplier;
 uniform vec3 splitParamsStart;
 uniform vec3 splitParamsEnd;
 uniform float glossySampleCount;
@@ -47,17 +46,14 @@ uniform float noiseSine;
 uniform float maxZDepth;
 uniform float maxRoughness;
 
-// Ray march parameters wired to uniforms (.x component of each)
-//   rayStep.x              = step size (default 0.5)
-//   iterationCount.x       = max steps (default 96)
-//   adaptiveStepMultiplier.x = step growth rate (default 1.03)
-//   distanceBias.x         = max step size cap (default 5.0)
-//   depthRejectBias.x      = max thickness for hit validation (default 1.0)
-#define STEP_SIZE       rayStep.x
-#define STEP_GROWTH     adaptiveStepMultiplier.x
-#define MAX_STEP_SIZE   distanceBias.x
-#define MAX_THICKNESS   depthRejectBias.x
-#define DEPTH_BIAS      depthRejectBias.y
+// Ray march parameters wired to AYA scalar controls.
+// distanceBias is used as hit thickness; max step is derived from max depth
+// and iteration count so rayStep/Iterations still control reach.
+#define STEP_SIZE       rayStep
+#define STEP_GROWTH     adaptiveStepMultiplier
+#define MAX_STEP_SIZE   max(STEP_SIZE, maxZDepth / max(iterationCount, 1.0))
+#define MAX_THICKNESS   max(distanceBias, STEP_SIZE * 0.5)
+#define DEPTH_BIAS      depthRejectBias
 const int   BINARY_STEPS    = 8;
 
 vec4 getPositionWithDepth(vec2 pos_screen, float depth);
@@ -115,7 +111,7 @@ vec3 rayMarch(vec3 dir, inout vec3 hitCoord, out float dDepth, float startDepth)
 {
     dir *= STEP_SIZE;
 
-    for (int i = 0; i < int(iterationCount.x); i++)
+    for (int i = 0; i < int(iterationCount); i++)
     {
         hitCoord += dir;
 

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -340,6 +340,8 @@ static LLStaticHashedString sDelta("delta");
 static LLStaticHashedString sDistFactor("dist_factor");
 static LLStaticHashedString sKern("kern");
 static LLStaticHashedString sKernScale("kern_scale");
+static LLStaticHashedString sSSRMaxDepth("maxZDepth");
+static LLStaticHashedString sSSRMaxRoughness("maxRoughness");
 static LLStaticHashedString sSmaaRTMetrics("SMAA_RT_METRICS");
 
 //----------------------------------------
@@ -12201,6 +12203,11 @@ void LLPipeline::bindReflectionProbes(LLGLSLShader& shader)
 
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_NOISE_SINE, (GLfloat)mPoissonOffset);
     shader.uniform1f(LLShaderMgr::DEFERRED_SSR_ADAPTIVE_STEP_MULT, RenderScreenSpaceReflectionAdaptiveStepMultiplier);
+
+    static LLCachedControl<F32> ssr_max_depth(gSavedSettings, "RenderScreenSpaceReflectionMaxDepth", 256.f);
+    static LLCachedControl<F32> ssr_max_roughness(gSavedSettings, "RenderScreenSpaceReflectionMaxRoughness", 1.f);
+    shader.uniform1f(sSSRMaxDepth, llmax(1.f, (F32)ssr_max_depth));
+    shader.uniform1f(sSSRMaxRoughness, llclamp((F32)ssr_max_roughness, 0.001f, 1.f));
 
     channel = shader.enableTexture(LLShaderMgr::SCENE_DEPTH);
     if (channel > -1)


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作)。

Cinematic 専用 `screenSpaceReflUtil.glsl` の uniform 配線が二重に壊れており、Cinematic mode の SSR が実質完全停止していたのを修正する。

## 何が壊れていたか

### 層 1: vec3 type mismatch (5 個の ray-march 制御 uniform が全部 0)

shader 側は ray march 制御を `vec3` で宣言:

\`\`\`glsl
// Declared to keep pipeline uniform setup happy   ← 自白コメント
uniform vec3 iterationCount;
uniform vec3 rayStep;
uniform vec3 distanceBias;
uniform vec3 depthRejectBias;
uniform vec3 adaptiveStepMultiplier;
\`\`\`

ところが \`pipeline.cpp::bindReflectionProbes\` (line 12192-12203) はこれを \`shader.uniform1f()\` で bind しているため、GLSL vec3 / GL uniform1f の type mismatch で \`GL_INVALID_OPERATION\`、uniform は 0 のまま GPU に上がる。

結果: \`STEP_SIZE = rayStep.x = 0\` / \`iterationCount.x = 0\` → ray march の for ループが 0 回 / step 0 で Cinematic SSR が完全停止。

### 層 2: maxZDepth / maxRoughness も bind されていない

shader 内で 6 箇所以上参照:

\`\`\`glsl
if (depth > maxZDepth)          // = if (depth > 0) → 常に true → 全 ray reject
if (roughness >= maxRoughness)  // = if (roughness >= 0) → 常に true → 全 pixel skip
float zFade = 1.0 - smoothstep(zFadeStart, maxZDepth, hitDepth);  // smoothstep(0,0,x) で NaN
\`\`\`

cvar \`RenderScreenSpaceReflectionMaxDepth\` / \`MaxRoughness\` は \`settings.xml:11702/11713\` に既存だが、pipeline.cpp から bind する経路がなく shader 側 0 のまま。

## 修正内容

1. shader uniform 5 個を \`vec3 → float\` に変更 (\`uniform1f\` が landing するように)
2. macro 整理:
   - \`MAX_STEP_SIZE = max(STEP_SIZE, maxZDepth / max(iterationCount, 1.0))\`
   - \`MAX_THICKNESS = max(distanceBias, STEP_SIZE * 0.5)\`
   - \`DEPTH_BIAS = depthRejectBias\` (scalar 化)
3. \`pipeline.cpp::bindReflectionProbes\` に \`maxZDepth\` / \`maxRoughness\` の bind を追加 (既存 cvar 利用、\`sSSRMaxDepth\` / \`sSSRMaxRoughness\` LLStaticHashedString 経由)

## 副作用範囲

- 影響: Cinematic mode + \`RenderScreenSpaceReflections=TRUE\` のみ
- AYAstorm View / Firestorm モードは別 shader 経路 (\`class3/deferred/\` の LL 標準)、無影響
- \`llshadermgr\` の \`mReservedUniforms\` 改変なし (LLStaticHashedString 経由)、symbol 衝突なし
- 既存ユーザーは「broken でそもそも効いていなかった」状態から「効くようになる」変化。cvar tuning が無意味だった分、デフォルト挙動が初めて顕在化

## 検証状況

- Linux で受け容れ判定済 (AYA OK 出し)
- Cinematic mode + 水面 / 金属 mesh 上での live A/B 検証は AYA 側で確認お願いします
- macOS / Windows は未検証