### PR TITLE
r30 fix: RenderEnableFullbright live toggle 反映 (既 rez オブジェクトへの即時反映)

### DIFF
--- a/indra/newview/llviewercontrol.cpp
+++ b/indra/newview/llviewercontrol.cpp
@@ -48,6 +48,7 @@
 #include "llcinematicoverlay.h" // <FS:AYA r30 P5 R2> sentinel reset on mode switch
 #include "llagentcamera.h"
 #include "llconsole.h"
+#include "lldrawable.h"
 #include "lldrawpoolbump.h"
 #include "lldrawpoolterrain.h"
 #include "llflexibleobject.h"
@@ -381,6 +382,25 @@ static bool handleReleaseGLBufferChanged(const LLSD& newvalue)
 static bool handleEnableEmissiveChanged(const LLSD& newvalue)
 {
     return handleReleaseGLBufferChanged(newvalue) && handleSetShaderChanged(newvalue);
+}
+
+static bool handleRenderEnableFullbrightChanged(const LLSD& newvalue)
+{
+    for (S32 i = 0, count = gObjectList.getNumObjects(); i < count; ++i)
+    {
+        LLViewerObject* objectp = gObjectList.getObject(i);
+        LLDrawable* drawablep = objectp ? objectp->mDrawable.get() : nullptr;
+        if (drawablep && !drawablep->isDead())
+        {
+            if (LLVOVolume* volume = drawablep->getVOVolume())
+            {
+                volume->updateFaceFlags();
+                volume->markForUpdate();
+            }
+        }
+    }
+
+    return true;
 }
 
 static bool handleDisableVintageMode(const LLSD& newvalue)
@@ -1551,6 +1571,7 @@ void settings_setup_listeners()
     setting_setup_signal_listener(gSavedSettings, "RenderHDREnabled", handleEnableHDR);
     setting_setup_signal_listener(gSavedSettings, "RenderGlowNoise", handleSetShaderChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderGammaFull", handleSetShaderChanged);
+    setting_setup_signal_listener(gSavedSettings, "RenderEnableFullbright", handleRenderEnableFullbrightChanged);
     setting_setup_signal_listener(gSavedSettings, "FSOverrideVRAMDetection", handleOverrideVRAMDetectionChanged); // <FS:Beq/> Override VRAM detection support
     setting_setup_signal_listener(gSavedSettings, "RenderVolumeLODFactor", handleVolumeLODChanged);
     setting_setup_signal_listener(gSavedSettings, "RenderAvatarComplexityMode", handleUserImpostorByDistEnabledChanged);

--- a/indra/newview/llvovolume.cpp
+++ b/indra/newview/llvovolume.cpp
@@ -125,6 +125,17 @@ static bool enableVolumeSAPProtection()
 }
 // NaCl End
 
+static bool renderFullbrightEnabled()
+{
+    static LLCachedControl<bool> render_fullbright(gSavedSettings, "RenderEnableFullbright", true);
+    return render_fullbright;
+}
+
+static bool teFullbrightEnabled(const LLTextureEntry* te)
+{
+    return te && renderFullbrightEnabled() && te->getFullbright();
+}
+
 // Implementation class of LLMediaDataClientObject.  See llmediadataclient.h
 class LLMediaDataClientObjectImpl : public LLMediaDataClientObject
 {
@@ -1889,7 +1900,7 @@ void LLVOVolume::updateFaceFlags()
         LLFace *face = mDrawable->getFace(i);
         if (face)
         {
-            bool fullbright = getTEref(i).getFullbright();
+            bool fullbright = renderFullbrightEnabled() && getTEref(i).getFullbright();
             face->clearState(LLFace::FULLBRIGHT | LLFace::HUD_RENDER | LLFace::LIGHT);
 
             if (fullbright || (mMaterial == LL_MCODE_LIGHT))
@@ -5622,7 +5633,7 @@ void LLVolumeGeometryManager::registerFace(LLSpatialGroup* group, LLFace* facep,
         (type == LLRenderPass::PASS_INVISIBLE) ||
         (type == LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK) ||
         (type == LLRenderPass::PASS_ALPHA && facep->isState(LLFace::FULLBRIGHT)) ||
-        (facep->getTextureEntry()->getFullbright());
+        teFullbrightEnabled(facep->getTextureEntry());
 
     if (!fullbright &&
         type != LLRenderPass::PASS_GLOW &&
@@ -6381,7 +6392,7 @@ void LLVolumeGeometryManager::rebuildGeom(LLSpatialGroup* group)
                             { //needs normal + tangent
                                 add_face(sBumpFaces, bump_count, facep);
                             }
-                            else if (te->getShiny() || !te->getFullbright())
+                            else if (te->getShiny() || !teFullbrightEnabled(te))
                             { //needs normal
                                 add_face(sSimpleFaces, simple_count, facep);
                             }
@@ -6598,9 +6609,9 @@ struct CompareBatchBreaker
         {
             return lte->getBumpmap() < rte->getBumpmap();
         }
-        else if (lte->getFullbright() != rte->getFullbright())
+        else if (teFullbrightEnabled(lte) != teFullbrightEnabled(rte))
         {
-            return lte->getFullbright() < rte->getFullbright();
+            return teFullbrightEnabled(lte) < teFullbrightEnabled(rte);
         }
         else if (lte->getMaterialID() != rte->getMaterialID())
         {
@@ -6998,7 +7009,7 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
                 // things without normals down the materials pipeline and will
                 // render poorly if not crash NORSPEC-240,314
                 //
-                if (te->getFullbright())
+                if (teFullbrightEnabled(te))
                 {
                     if (mat->getDiffuseAlphaMode() == LLMaterial::DIFFUSE_ALPHA_MODE_MASK)
                     {
@@ -7136,7 +7147,7 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
                 }
                 else if (facep->canRenderAsMask() && !hud_group)
                 {
-                    if (te->getFullbright() || LLPipeline::sNoAlpha)
+                    if (teFullbrightEnabled(te) || LLPipeline::sNoAlpha)
                     {
                         registerFace(group, facep, LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK);
                     }
@@ -7164,7 +7175,7 @@ U32 LLVolumeGeometryManager::genDrawInfo(LLSpatialGroup* group, U32 mask, LLFace
                 }
                 else if (!hud_group)
                 { //deferred rendering
-                    if (te->getFullbright())
+                    if (teFullbrightEnabled(te))
                     { //register in post deferred fullbright shiny pass
                         registerFace(group, facep, LLRenderPass::PASS_FULLBRIGHT_SHINY);
                         if (te->getBumpmap())


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作)。

mayatonton 側 r30 BD full port Phase 6 step 2 で実装済の \`RenderEnableFullbright\` cvar に、**ライブ toggle 反映** を加える。

## 現状の問題

mayatonton 側既存実装 (commit \`c1b2e20d83\`) は BD と 1:1 parity で \`llprimitive.cpp\` の TE parse 層 (\`packTEMessage\` / \`unpackTEMessage\`) に wiring されている。
これは sim から TE データを受信する瞬間に fullbright bit を strip するため、**toggle 後に新規受信した TE にのみ効く** = 既に rez 済のオブジェクトには即時反映されない。

ユーザー体感: 「Disable Fullbright」を ON にしても見た目が変わらず、再起動か object 再 rez が必要。

## 修正内容

\`llvovolume.cpp\` の render pass routing 5 サイトに \`teFullbrightEnabled(te) = renderFullbrightEnabled() && te->getFullbright()\` ラッパーを追加 + \`llviewercontrol.cpp\` に cvar 変更 listener (\`handleRenderEnableFullbrightChanged\`) を追加し、cvar 変更時に全 VOVolume を walk して \`updateFaceFlags() + markForUpdate()\` を呼ぶ。

→ cvar 変更が即座に既 rez オブジェクトの描画にも反映される。

## 副作用範囲

- cvar default は \`true\` (LL / SL 標準動作)、変更なし → **default 体感は不変**
- cvar を ON のままの全ユーザーには影響ゼロ
- cvar を OFF に倒した時にだけ追加の即時反映が走る (ユーザーが意図的に使う機能)
- mayatonton 既存 BD wiring と層が違うため revert 不要、上乗せで動作

## doctrine 整合性

r30 BD 改善 phase の趣旨 (\`BD default は変えず追加処理で改善\`) に整合。BD parity 層 (llprimitive) は触らず、render 層に live trigger を追加。

## 検証状況

- Linux で受け容れ判定済 (AYA OK 出し)
- macOS / Windows は未検証