### PR TITLE
r30 fix: Volumetric Lighting tuning (Multiplier 50→4 / Falloff 1.0→2.0 + Cinematic overlay 整備)

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -12345,13 +12345,13 @@ Change of this parameter will affect the layout of buttons in notification toast
   <key>RenderVolumetricLightingMultiplier</key>
   <map>
     <key>Comment</key>
-    <string>AYAstorm r30 P3: intensity multiplier for the volumetric lighting composite (godray_multiplier uniform). The new render engine's default is 1.0, but AYAstorm's ACES tone mapping + HDR scene buffer compress the additive contribution to near-imperceptible at 1.0. Default 50 picked for "現実世界に近い" subtle shafts; raise to 100-200 for stronger PV/cinematic look.</string>
+    <string>AYAstorm r30 P3: intensity multiplier for the volumetric lighting composite (godray_multiplier uniform). Default 4.0 keeps godrays visible without saturating the post-tonemap image.</string>
     <key>Persist</key>
     <integer>1</integer>
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>50.0</real>
+    <real>4.0</real>
   </map>
 
   <key>RenderVolumetricLightingFalloffMultiplier</key>
@@ -12363,7 +12363,7 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>Type</key>
     <string>F32</string>
     <key>Value</key>
-    <real>1.0</real>
+    <real>2.0</real>
   </map>
 
   <key>RenderVolumetricLightingDirectional</key>

--- a/indra/newview/app_settings/settings_cinematic_bd.xml
+++ b/indra/newview/app_settings/settings_cinematic_bd.xml
@@ -142,6 +142,18 @@
     <key>RenderScreenSpaceReflections</key>
     <boolean>1</boolean>
 
+    <key>RenderVolumetricLighting</key>
+    <boolean>1</boolean>
+
+    <key>RenderVolumetricLightingResolution</key>
+    <integer>16</integer>
+
+    <key>RenderVolumetricLightingMultiplier</key>
+    <real>4.0</real>
+
+    <key>RenderVolumetricLightingFalloffMultiplier</key>
+    <real>2.0</real>
+
     <key>RenderFSAAType</key>
     <integer>2</integer>
 

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -10160,6 +10160,10 @@ class AYAResetCinematic : public view_listener_t
             {"RenderMotionBlur",                LLSD(true)},
             {"RenderMotionBlurStrength",        LLSD(LLSD::Integer(8))},
             {"RenderScreenSpaceReflections",    LLSD(true)},
+            {"RenderVolumetricLighting",        LLSD(true)},
+            {"RenderVolumetricLightingResolution", LLSD(LLSD::Integer(16))},
+            {"RenderVolumetricLightingMultiplier", LLSD(4.0)},
+            {"RenderVolumetricLightingFalloffMultiplier", LLSD(2.0)},
             {"RenderFSAAType",                  LLSD(LLSD::Integer(2))}, // 2 = SMAA
             // BD camera DoF values — LL defaults are conservative, BD ships photo-tuned
             {"CameraFieldOfView",               LLSD(67.0)},

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -4949,8 +4949,8 @@ void LLPipeline::renderVolumetric(LLRenderTarget* src, LLRenderTarget* dst)
         (GLfloat)src->getWidth(), (GLfloat)src->getHeight());
 
     static LLCachedControl<U32> godray_res(gSavedSettings, "RenderVolumetricLightingResolution", 16);
-    static LLCachedControl<F32> godray_mult(gSavedSettings, "RenderVolumetricLightingMultiplier", 50.0f);
-    static LLCachedControl<F32> falloff_mult(gSavedSettings, "RenderVolumetricLightingFalloffMultiplier", 1.0f);
+    static LLCachedControl<F32> godray_mult(gSavedSettings, "RenderVolumetricLightingMultiplier", 4.0f);
+    static LLCachedControl<F32> falloff_mult(gSavedSettings, "RenderVolumetricLightingFalloffMultiplier", 2.0f);
 
     gVolumetricLightProgram.uniform1i(LLShaderMgr::GODRAY_RES, (S32)godray_res);
     gVolumetricLightProgram.uniform1f(LLShaderMgr::GODRAY_MULTIPLIER, (F32)godray_mult);


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作)。

\`RenderVolumetricLightingMultiplier\` / \`FalloffMultiplier\` の global default を実用値に揃え、Cinematic overlay に volumetric 関連 4 件を一括で焼き込む。AYA さんの hands-on verify (「Multiplier=4.0 で OK」) を default に反映する。

## 修正内容 (4 layer)

### 1. \`settings.xml\` global default

| key | before | after |
|---|---|---|
| \`RenderVolumetricLightingMultiplier\` | 50.0 | **4.0** |
| \`RenderVolumetricLightingFalloffMultiplier\` | 1.0 | **2.0** |

旧 comment (「AYAstorm の ACES tone mapping で 1.0 では薄い → 50 にした」) は AYA verify 結果 4.0 OK で過剰と判明。新 comment 「Default 4.0 keeps godrays visible without saturating the post-tonemap image」に rewrite。

### 2. \`settings_cinematic_bd.xml\` Cinematic overlay

mode 2 起動時 1 度焼きに 4 件追加:

\`\`\`xml
<key>RenderVolumetricLighting</key>            <boolean>1</boolean>
<key>RenderVolumetricLightingResolution</key>  <integer>16</integer>
<key>RenderVolumetricLightingMultiplier</key>  <real>4.0</real>
<key>RenderVolumetricLightingFalloffMultiplier</key> <real>2.0</real>
\`\`\`

→ Cinematic では volumetric lighting を強制 ON、解像度・倍率を AYA tuning に固定。

### 3. \`llviewermenu.cpp::AYAResetCinematic::parityTable\`

上記 overlay と同じ 4 件を Reset D button 用 parityTable に追加。

### 4. \`pipeline.cpp::renderVolumetric\` LLCachedControl fallback

settings.xml が万一欠落した時の C++ 側 fallback も 50→4 / 1.0→2.0 に同期。hygiene。

## PR #91 との conflict (取込順序)

PR #91 (\`fix/r30-cinematic-godrays-sun-shadow-permutation\`、commit \`1dd92c5ee5\`) でも Cinematic overlay + parityTable に \`RenderVolumetricLightingMultiplier=4.0\` を追加している (#91 はそれ単独 + ShadowResolutionScale + FarClip の bundle)。

**取込順序: 本 PR を先に merge → その後 #91 を rebase して \`Multiplier=4.0\` 重複 2 行 (overlay + parityTable) を drop する想定**。

理由:
- 本 PR は t-noami branch、私が rebase 不要
- #91 は私の branch、rebase + force-push 制御が容易
- conflict は 2 行 trivial、#91 のユニーク 2 件 (ShadowResolutionScale / FarClip) は影響なし

## 副作用範囲

- global default 50→4 は **Cinematic 以外のモード (Firestorm View / AYAstorm View) にも適用**。volumetric lighting を有効にした全モードで光源 multiplier が薄くなる。
- ただし AYA hands-on で 4.0 = 妥当値判定、50 は過剰だった (旧 ACES 補正前提の数値)。
- 既存ユーザーは settings.xml default 変更でも persist=1 cvar により自分の保存値があれば上書きされない。新規ユーザーのみ 4.0/2.0 で起動。

## doctrine

BD parity 強制は 2026-05-24 解除済 (\`project_ayastorm_r30_bd_improvement_phase\`)。global default 変更も技術判断 (AYA verify 済) で受け容れ可。

## 検証状況

- Linux で受け容れ判定済 (AYA Multiplier=4.0 verify 済)
- Falloff=2.0 は AYA 未検証、t-noami tuning。気になれば後追い調整可
- macOS / Windows は未検証