### PR TITLE
r30 fix: macOS GLSL shader guard / Apple Silicon Metal 安全化補完 + shader link failure graceful degradation

### DIFF
--- a/indra/cmake/00-Common.cmake
+++ b/indra/cmake/00-Common.cmake
@@ -241,6 +241,10 @@ if (LINUX OR DARWIN)
     add_compile_options(-Wno-unused-local-typedef)
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    add_compile_options(-Wno-inconsistent-missing-override)
+  endif()
+
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-stringop-truncation -Wno-parentheses -Wno-maybe-uninitialized)
   endif()

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredF.glsl
@@ -25,6 +25,14 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef HAS_DOF_CHROMA
+#define HAS_DOF_CHROMA 0
+#endif
+
+#ifndef FRONT_BLUR
+#define FRONT_BLUR 0
+#endif
+
 out vec4 frag_color;
 
 uniform sampler2D diffuseRect;
@@ -106,7 +114,9 @@ void main()
 #if FRONT_BLUR
         if (sc > 0.5)
         {
-            while (sc > 0.5)
+            // Apple Silicon Metal safety: bound the loop in case sc becomes NaN
+            // or otherwise fails to converge under the translation layer.
+            for (int safety = 0; safety < 32 && sc > 0.5; ++safety)
             {
                 int its = int(max(1.0,(sc*3.7)));
                 for (int i=0; i<its; ++i)
@@ -127,7 +137,8 @@ void main()
 // </AYAstorm r30 P4 step 1>
         {
             sc = abs(sc);
-            while (sc > 0.5)
+            // Apple Silicon Metal safety: bounded loop (see comment above).
+            for (int safety = 0; safety < 32 && sc > 0.5; ++safety)
             {
                 int its = int(max(1.0,(sc*3.7)));
                 for (int i=0; i<its; ++i)

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredHQDoFF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredHQDoFF.glsl
@@ -33,6 +33,14 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef HAS_DOF_CHROMA
+#define HAS_DOF_CHROMA 0
+#endif
+
+#ifndef FRONT_BLUR
+#define FRONT_BLUR 0
+#endif
+
 out vec4 frag_color;
 
 uniform sampler2D diffuseRect;

--- a/indra/newview/app_settings/shaders/class1/deferred/postDeferredNoDoFF.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/postDeferredNoDoFF.glsl
@@ -25,6 +25,10 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef HAS_DOF_CHROMA
+#define HAS_DOF_CHROMA 0
+#endif
+
 out vec4 frag_color;
 
 uniform sampler2D diffuseRect;

--- a/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityAlphaV.glsl
+++ b/indra/newview/app_settings/shaders/class1/deferred/skinnedVelocityAlphaV.glsl
@@ -49,6 +49,7 @@ uniform mat3x4 lastMatrixPalette[MAX_JOINTS_PER_MESH_OBJECT];
 mat4 getObjectSkinnedTransform();
 mat4 getLastObjectSkinnedTransform();
 
+void passTextureIndex();
 void writeVaryVelocity(vec4 pos, vec4 last_pos);
 
 // <FS:AYA r30 Phase 3.8 Cinematic mount fix> Phase 3.8 step 2 overwrote
@@ -83,4 +84,5 @@ void main()
 
     vary_texcoord0 = (texture_matrix0 * vec4(texcoord0, 0, 1)).xy;
     vertex_color = diffuse_color;
+    passTextureIndex();
 }

--- a/indra/newview/app_settings/shaders/class1/effects/glowExtractF.glsl
+++ b/indra/newview/app_settings/shaders/class1/effects/glowExtractF.glsl
@@ -25,6 +25,10 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef HAS_NOISE
+#define HAS_NOISE 0
+#endif
+
 out vec4 frag_color;
 
 uniform sampler2D diffuseMap;

--- a/indra/newview/app_settings/shaders/class2/deferred/sunLightSSAOF.glsl
+++ b/indra/newview/app_settings/shaders/class2/deferred/sunLightSSAOF.glsl
@@ -24,6 +24,10 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef HAS_HBAO
+#define HAS_HBAO 0
+#endif
+
 out vec4 frag_color;
 
 //class 2 -- shadows and SSAO

--- a/indra/newview/app_settings/shaders/class3/deferred/volumetricLightF.glsl
+++ b/indra/newview/app_settings/shaders/class3/deferred/volumetricLightF.glsl
@@ -32,6 +32,10 @@
 
 /*[EXTRA_CODE_HERE]*/
 
+#ifndef GODRAYS_FADE
+#define GODRAYS_FADE 0
+#endif
+
 out vec4 frag_color;
 
 uniform sampler2D diffuseRect;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -110,6 +110,7 @@
 #include "llmutelist.h"
 #include "lltoolpie.h"
 #include "llnotifications.h"
+#include "llnotificationsutil.h"
 #include "llpathinglib.h"
 #include "llfloaterpathfindingconsole.h"
 #include "llfloaterpathfindingcharacters.h"
@@ -157,6 +158,51 @@
 
 extern bool gSnapshot;
 bool gShiftFrame = false;
+
+static void notifyMotionBlurSkippedOnce(const std::string& message)
+{
+    static bool sNotified = false;
+    if (sNotified)
+    {
+        return;
+    }
+
+    sNotified = true;
+
+    LLSD args;
+    args["MESSAGE"] = message;
+    LLNotificationsUtil::add("ChatSystemMessageTip", args);
+}
+
+static void notifySSAOShadowSkippedOnce(const std::string& message)
+{
+    static bool sNotified = false;
+    if (sNotified)
+    {
+        return;
+    }
+
+    sNotified = true;
+
+    LLSD args;
+    args["MESSAGE"] = message;
+    LLNotificationsUtil::add("ChatSystemMessageTip", args);
+}
+
+static void notifyDoFSkippedOnce(const std::string& message)
+{
+    static bool sNotified = false;
+    if (sNotified)
+    {
+        return;
+    }
+
+    sNotified = true;
+
+    LLSD args;
+    args["MESSAGE"] = message;
+    LLNotificationsUtil::add("ChatSystemMessageTip", args);
+}
 
 //cached settings
 bool LLPipeline::WindLightUseAtmosShaders;
@@ -4872,6 +4918,21 @@ void LLPipeline::renderGeomMotionBlur()
         return;
     }
 
+    auto is_complete_with_rigged_variant = [](const LLGLSLShader& shader)
+    {
+        return shader.isComplete() &&
+            (!shader.mRiggedVariant || shader.mRiggedVariant->isComplete());
+    };
+
+    if (!is_complete_with_rigged_variant(gVelocityProgram) ||
+        !is_complete_with_rigged_variant(gVelocityAlphaProgram) ||
+        !gAvatarVelocityProgram.isComplete())
+    {
+        LL_WARNS_ONCE("Pipeline") << "Skipping motion blur velocity pass because one or more velocity shaders failed to link." << LL_ENDL;
+        notifyMotionBlurSkippedOnce("AYAstorm: Motion blur was disabled because a required velocity shader failed to load. Check AYAstorm.log for shader details.");
+        return;
+    }
+
     mVelocityMap.bindTarget();
     mVelocityMap.clear(GL_COLOR_BUFFER_BIT);
 
@@ -4904,6 +4965,13 @@ void LLPipeline::renderMotionBlurComposite(LLRenderTarget* src, LLRenderTarget* 
 {
     LL_PROFILE_ZONE_SCOPED_CATEGORY_DISPLAY;
     LL_PROFILE_GPU_ZONE("motion blur composite");
+
+    if (!gDeferredMotionBlurProgram.isComplete())
+    {
+        LL_WARNS_ONCE("Pipeline") << "Skipping motion blur composite because the deferred motion blur shader failed to link." << LL_ENDL;
+        notifyMotionBlurSkippedOnce("AYAstorm: Motion blur was disabled because the motion blur composite shader failed to load. Check AYAstorm.log for shader details.");
+        return;
+    }
 
     dst->bindTarget();
 
@@ -9691,6 +9759,16 @@ void LLPipeline::renderDoF(LLRenderTarget* src, LLRenderTarget* dst)
 
         if (sDoFEnabled) // <FS:Beq/> // FIRE-32023 Render focus point
         {
+            if (!gDeferredCoFProgram.isComplete() ||
+                !gDeferredPostProgram.isComplete() ||
+                !gDeferredDoFCombineProgram.isComplete())
+            {
+                LL_WARNS_ONCE("Pipeline") << "Skipping depth of field because one or more DoF shaders failed to link." << LL_ENDL;
+                notifyDoFSkippedOnce("AYAstorm: Depth of Field was disabled because a required post-processing shader failed to load. Check AYAstorm.log for shader details.");
+                copyRenderTarget(src, dst);
+                return;
+            }
+
             LLGLDisable blend(GL_BLEND);
 
             // depth of field focal plane calculations
@@ -11009,30 +11087,38 @@ void LLPipeline::renderDeferredLighting()
         if ((RenderDeferredSSAO && !gCubeSnapshot) || RenderShadowDetail > 0)
         {
             LL_PROFILE_GPU_ZONE("sun program");
-            deferred_light_target->bindTarget();
-            {  // paint shadow/SSAO light map (direct lighting lightmap)
-                LL_PROFILE_ZONE_NAMED_CATEGORY_PIPELINE("renderDeferredLighting - sun shadow");
-
-                LLGLSLShader& sun_shader = gCubeSnapshot ? gDeferredSunProbeProgram : gDeferredSunProgram;
-                bindDeferredShader(sun_shader, deferred_light_target);
-                mScreenTriangleVB->setBuffer();
-                glClearColor(1, 1, 1, 1);
-                deferred_light_target->clear(GL_COLOR_BUFFER_BIT);
-                glClearColor(0, 0, 0, 0);
-
-                sun_shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
-                                              (GLfloat)deferred_light_target->getWidth(),
-                                              (GLfloat)deferred_light_target->getHeight());
-
-                {
-                    LLGLDisable   blend(GL_BLEND);
-                    LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_ALWAYS);
-                    mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
-                }
-
-                unbindDeferredShader(sun_shader);
+            LLGLSLShader& sun_shader = gCubeSnapshot ? gDeferredSunProbeProgram : gDeferredSunProgram;
+            if (!sun_shader.isComplete())
+            {
+                LL_WARNS_ONCE("Pipeline") << "Skipping SSAO/shadow light pass because the deferred sun shader failed to link." << LL_ENDL;
+                notifySSAOShadowSkippedOnce("AYAstorm: SSAO/shadow smoothing was disabled because the deferred sun shader failed to load. Check AYAstorm.log for shader details.");
             }
-            deferred_light_target->flush();
+            else
+            {
+                deferred_light_target->bindTarget();
+                {  // paint shadow/SSAO light map (direct lighting lightmap)
+                    LL_PROFILE_ZONE_NAMED_CATEGORY_PIPELINE("renderDeferredLighting - sun shadow");
+
+                    bindDeferredShader(sun_shader, deferred_light_target);
+                    mScreenTriangleVB->setBuffer();
+                    glClearColor(1, 1, 1, 1);
+                    deferred_light_target->clear(GL_COLOR_BUFFER_BIT);
+                    glClearColor(0, 0, 0, 0);
+
+                    sun_shader.uniform2f(LLShaderMgr::DEFERRED_SCREEN_RES,
+                                                  (GLfloat)deferred_light_target->getWidth(),
+                                                  (GLfloat)deferred_light_target->getHeight());
+
+                    {
+                        LLGLDisable   blend(GL_BLEND);
+                        LLGLDepthTest depth(GL_TRUE, GL_FALSE, GL_ALWAYS);
+                        mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+                    }
+
+                    unbindDeferredShader(sun_shader);
+                }
+                deferred_light_target->flush();
+            }
         }
 
         // <FS:AYAstorm r30 P4> RenderDeferredBlurLight gates the soften-shadow blur pass.


### PR DESCRIPTION
## 概要

PR #89 を機能単位に分割した受け容れ branch (t-noami さん作)。

macOS (Apple Silicon Metal) で発生する GLSL リンク / 実行時 failure に対する 4 種類の防衛コードをまとめて投入する。AYA さんは Mac 環境を持たないため、t-noami さんの Mac 実機検証を信任して as-is 受け容れ (\`feedback_mac_only_fixes_accept_as_is\`)。

## 修正内容 (4 category)

### A. GLSL permutation define guards (7 ファイル / 25 行)

\`postDeferredF.glsl\` / \`postDeferredHQDoFF.glsl\` / \`postDeferredNoDoFF.glsl\` / \`glowExtractF.glsl\` / \`sunLightSSAOF.glsl\` / \`volumetricLightF.glsl\` の冒頭に \`#ifndef X #define X 0 #endif\` を追加。

C++ 側で permutation define (\`HAS_DOF_CHROMA\` / \`FRONT_BLUR\` / \`HAS_NOISE\` / \`HAS_HBAO\` / \`GODRAYS_FADE\` 等) が注入されない経路 (Mac Metal で観測) に対する fallback で 0 評価 = 標準的な cross-platform GLSL hygiene。

### B. \`postDeferredF.glsl\` while → bounded for (既存 Mac 安全化 fix の漏れ補完)

既存 commit \`03831684f7\` (r30 GLSL Apple Silicon Metal 安全化) は \`postDeferredHQDoFF.glsl\` の \`while (sc > 0.5)\` を bounded for に修正したが、**\`postDeferredF.glsl\` (HQ なし版) は漏れていた**。t-noami fix が同じパターンで補完。

\`\`\`glsl
// before
while (sc > 0.5) { ... }
// after
for (int safety = 0; safety < 32 && sc > 0.5; ++safety) { ... }
\`\`\`

### C. \`skinnedVelocityAlphaV.glsl\` \`passTextureIndex()\` 追加 (2 行)

velocity 計算する skinned alpha vertex shader に \`passTextureIndex()\` の宣言 + 呼出を追加。texture array indexing の Mac リンク要件。Linux/Win では no-op。

### D. \`pipeline.cpp\` shader isComplete() ガード + graceful degradation (124 行)

shader link failure 時に **黒画面/crash でなくスキップ + ユーザー通知** で復帰する graceful degradation を追加:

- 3 つの \`notifyXxxSkippedOnce\` helper (Motion Blur / SSAO Shadow / DoF)
- \`renderGeomMotionBlur / renderMotionBlurComposite / renderDoF / renderDeferredLighting\` (SSAO block) で \`shader.isComplete()\` チェック
- 失敗時は \`LLNotificationsUtil::add("ChatSystemMessageTip", ...)\` で英語チャットチップ通知

通知は \`sNotified\` static で session 中 1 回のみ。Mac で実際に link failure が起きる経路に対する safety net。

## 副作用範囲

- Category A/B/C: 全 OS 共通、Linux/Win では no-op、Mac で防衛発動
- Category D: 通常時はコスト無し (isComplete check は cheap)、shader 失敗時のみ通知発動
- Linux/Win では発火条件に到達しない想定

## 既知の improvement 余地 (後追い)

- **D の通知は英語限定** (\`"AYAstorm: Motion blur was disabled because..."\`)。JA 翻訳 + localization 経路は別 PR で対応予定
- **\`"AYAstorm:"\` prefix がユーザー可視**: 内部命名露出、後追いで文言整理可
- **per-frame \`isComplete()\` チェック**: architectural drift だが perf 影響無視可、機能優先

## 検証状況

- macOS: t-noami さん実機検証済 (本 PR の動機)
- Linux: AYA で受け容れ判定済 (no-op として影響なし)
- Windows: 未検証 (Category A/B/C は no-op 想定、D は通常時無発火)

## doctrine

\`feedback_mac_only_fixes_accept_as_is\` 方針により as-is 受け入れ。Mac 環境を持たない AYA + Claude では再現検証不能、t-noami の Mac 実機検証を信任。