### PR TITLE
r30 cleanup: RenderVolumetricLightingMultiplier 重複行削除 (#91 / #97 merge 後始末)

### DIFF
--- a/indra/newview/app_settings/settings_cinematic_bd.xml
+++ b/indra/newview/app_settings/settings_cinematic_bd.xml
@@ -205,18 +205,15 @@
     <key>AYAR18CloudVolumetricStrength</key>
     <real>0.7</real>
 
-    <!-- r30 Cinematic shadow / clip / volumetric defaults (2026-05-24 編入)。
-         AYA hands-on verify で「Cinematic で beam が薄く影が立たない」「奥が
-         見えない」「godray が控えめすぎる」を解消するための初起動焼き。
-         Reset D ボタン (parityTable) と値同期必須。 -->
+    <!-- r30 Cinematic shadow / clip defaults (2026-05-24 編入)。
+         AYA hands-on verify で「Cinematic で影が立たない」「奥が見えない」を
+         解消するための初起動焼き。Reset D ボタン (parityTable) と値同期必須。
+         Volumetric 関連は PR #97 が同 file 内 L145-156 に統合管理。 -->
 
     <key>RenderShadowResolutionScale</key>
     <real>3.0</real>
 
     <key>RenderFarClip</key>
     <real>400.0</real>
-
-    <key>RenderVolumetricLightingMultiplier</key>
-    <real>4.0</real>
   </map>
 </llsd>

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -10183,11 +10183,11 @@ class AYAResetCinematic : public view_listener_t
             {"AYAR17Strength",                               LLSD(0.5)},
             {"AYAR18CloudVolumetricInCinematicEnabled",      LLSD(true)},
             {"AYAR18CloudVolumetricStrength",                LLSD(0.7)},
-            // r30 Cinematic shadow / clip / volumetric defaults (2026-05-24)。
+            // r30 Cinematic shadow / clip defaults (2026-05-24)。
             // settings_cinematic_bd.xml overlay と値同期必須。
+            // Volumetric 関連は PR #97 が同 table 内 RenderVolumetricLighting* で統合管理。
             {"RenderShadowResolutionScale",                  LLSD(3.0)},
             {"RenderFarClip",                                LLSD(400.0)},
-            {"RenderVolumetricLightingMultiplier",           LLSD(4.0)},
         };
         return table;
     }


### PR DESCRIPTION
## 概要

PR #91 (godrays) と PR #97 (volumetric-lighting) が両方 \`RenderVolumetricLightingMultiplier=4.0\` を Cinematic overlay (\`settings_cinematic_bd.xml\`) と Reset D button parityTable (\`llviewermenu.cpp\`) に追加していたため、merge 後に同一 key が両ファイルで重複していた。

値はどちらも \`4.0\` で同じため挙動への影響はなしだが、XML/initializer_list の noise なので cleanup。

## 修正内容

PR #97 ブロック (\`RenderVolumetricLighting\` / \`Resolution\` / \`Multiplier\` / \`FalloffMultiplier\` を統合管理) を残し、PR #91 ブロックから \`Multiplier\` 行のみ削除。

#91 ユニークの \`RenderShadowResolutionScale=3.0\` / \`RenderFarClip=400.0\` は維持。

- \`settings_cinematic_bd.xml\` L219-220 削除、L208 コメントを「shadow / clip defaults」+ 「Volumetric は #97 が L145-156 で統合管理」注記に更新
- \`llviewermenu.cpp\` parityTable L10190 削除、L10186 コメント同様更新

## 副作用範囲

- 挙動への影響なし (値はどちらも 4.0、最終値は同じ)
- 重複 entry が消えて XML / std::map initializer_list が clean に

## 検証状況

- 同一 key で同一値の重複なので merge 後の挙動と区別不能、別途検証不要