### PR TITLE
docs: r30 release page に SSS/Picker 公開資料リンク追記 + r20 SSS spec の whitelist 出荷状態明記

### DIFF
--- a/docs/release/ayastorm-r30-github-release-page.en.md
+++ b/docs/release/ayastorm-r30-github-release-page.en.md
@@ -30,6 +30,7 @@ A single jump from r24 to r30 bundles five releases (r25, r26, r27, r28, r30) in
 - P1 restart-switch infrastructure: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
 - BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
 - Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS user guide (avatar photography): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
@@ -39,6 +40,7 @@ A single jump from r24 to r30 bundles five releases (r25, r26, r27, r28, r30) in
 ### UX & picker
 - r28 other rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r28-other-rigged-picker.md)
 - r21 self-rigged picker spec (sibling feature): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer technical spec (for other viewer forks): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
 
 ## Public disclosure: double alpha-block fix (cross-viewer common bug)
 

--- a/docs/release/ayastorm-r30-github-release-page.ja.md
+++ b/docs/release/ayastorm-r30-github-release-page.ja.md
@@ -30,6 +30,7 @@ r24 から r30 への一括移行 tag。5 release (r25 / r26 / r27 / r28 / r30) 
 - P1 再起動切替インフラ: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
 - BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
 - Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS ユーザーガイド (アバター撮影向け): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
@@ -39,6 +40,7 @@ r24 から r30 への一括移行 tag。5 release (r25 / r26 / r27 / r28 / r30) 
 ### UX & picker
 - r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r28-other-rigged-picker.md)
 - r21 self rigged picker spec (姉妹機能): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer 技術資料 (他 viewer 取込用): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
 
 ## 公開資料: 二重 alpha block fix (他 SL viewer 共通 bug の公開)
 

--- a/docs/release/ayastorm-r30-github-release-page.zh.md
+++ b/docs/release/ayastorm-r30-github-release-page.zh.md
@@ -30,6 +30,7 @@
 - P1 重启切换基础设施: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
 - BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
 - Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS 使用指南 (面向 avatar 摄影): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
@@ -39,6 +40,7 @@
 ### UX & picker
 - r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r28-other-rigged-picker.md)
 - r21 self rigged picker spec (姐妹功能): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer 技术资料 (供其他 viewer fork 取用): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r30/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
 
 ## 公开披露: 二重 alpha block fix (其他 SL viewer 通用 bug 公开资料)
 

--- a/docs/specs/ayastorm-r20-avatar-skin-sss.md
+++ b/docs/specs/ayastorm-r20-avatar-skin-sss.md
@@ -45,6 +45,8 @@ SL の Mesh body / head は deferred で **`materialF` (Legacy) または `pbrop
 
 実際の Name / Description pattern は P0 で実機サンプリングして確定 (例: 「LELUTKA EVOX 〇〇」「Maitreya Lara V〇」等の prefix が typical)。
 
+> **実装版での結論**: default whitelist は **空** で出荷しています。本セクションに列挙した主流 Mesh body / head 製品は **設計段階の想定リスト** であり、実機での asset UUID キュレーションを継続的にメンテする運用負荷を回避するため、出荷物には含めず、ユーザー側で右クリック UX (`Add to SSS whitelist` / `Add entire linkset to SSS whitelist`) または手動編集で登録する形を採っています。ユーザー向け案内は [`docs/specs/skin-sss-user-guide.md`](./skin-sss-user-guide.md) 参照。
+
 ### 2.3 アプローチ全体図
 
 ```


### PR DESCRIPTION
## Summary

- **r30 GitHub release page (3 言語)** に PR #101 (SSS user guide + picker 技術資料 公開) で追加した新規資料へのリンクを追記:
  - 「撮影描画章 (r30)」セクション → **Skin SSS ユーザーガイド** (`docs/specs/skin-sss-user-guide.{md,ja.md,zh.md}`)
  - 「UX & picker」セクション → **Rigged Mesh Picker GPU object-ID buffer 技術資料** (`docs/specs/rigged-mesh-picker-gpu-buffer.{md,ja.md,zh.md}`)
  - いずれも r30 tag-pinned URL で既存リンクと形式を統一
- **r20 avatar skin SSS engineering spec** (`docs/specs/ayastorm-r20-avatar-skin-sss.md`) §2.2「想定 whitelist」末尾に「**実装版での結論: default whitelist は空で出荷**」注記を追加。Maitreya / Legacy / Lelutka EvoX 等は設計段階の想定リストで、出荷物は空 → ユーザー登録前提という事実を明示し、ユーザー向け案内 (`skin-sss-user-guide.md`) へ誘導

## Test plan

- [ ] r30 タグ作成後、release page 内の新規リンク 6 本 (SSS user guide × 3 言語、picker tech doc × 3 言語) が 200 で解決すること
- [ ] r20 spec を §2.2 から通しで読み、「主流 Mesh body / head は最初から whitelist 入り」と誤読される余地が無くなっていること
- [ ] PR #101 で公開済の skin-sss-user-guide.{md,ja.md,zh.md} 自体に変更が無いこと (本 PR は references の追加のみ、本体は触らず)