### PR TITLE
docs: r31 WBOIT 廃案後の stale 参照整理

### DIFF
--- a/docs/specs/ayastorm-r30-cinematic-chapter.md
+++ b/docs/specs/ayastorm-r30-cinematic-chapter.md
@@ -126,7 +126,7 @@ Linux / macOS / Windows いずれかが落ちる状態では release を切ら�
 
 **注**: P1 では AYAstorm View に shader plumbing 引き上げ (SMAA/SSR default ON) は **行わない**。α 検証で絵が動かないと確認済み。
 
-### P2 Cinematic モード骨格 + velocity buffer + SMAA T2x (想定 r31)
+### P2 Cinematic モード骨格 + velocity buffer + SMAA T2x
 
 **スコープ確定** (§7-7 案 A 採用、2026-05-17): velocity buffer + SMAA T2x を **両方 P2 で完成**。視覚で確認しながら P3 以降を判断する方が後段スムーズという AYA 判断による。工数: velocity 5 日 + T2x 4-5 日 = **9-10 日**。
 

--- a/docs/specs/ayastorm-render-perf-survey.md
+++ b/docs/specs/ayastorm-render-perf-survey.md
@@ -511,7 +511,8 @@ cost 試算 (推測): 30 source × 64 OBB × ~50 ns/AABB-test ≒ 96 μs/tick。
 
 - **What**: `postSort` で `std::sort(sCull->beginAlphaGroups()...)` を CPU で group ごとに距離 sort、その後 `LLDrawPoolAlpha::renderAlpha` で per-DrawInfo に流す。
 - **Where**: `pipeline.cpp:4281-4289`, `lldrawpoolalpha.cpp:583-743`
-- **Why GPU**: WBOIT (weighted blended OIT) や per-pixel linked list で sort 自体を消せる。draw 順を CPU で気にしなくて済む。
+- **Why GPU**: per-pixel linked list / depth peeling 系で sort 自体を消せる。draw 順を CPU で気にしなくて済む。
+- **検証結果 (r31 attempt, 2026-05)**: **WBOIT (Weighted Blended OIT) は SL では使い物にならなかった**。weighted-average は重なる alpha 層の色を必ず平均化するため、SL 主流の多層 strand 髪 mesh で「内側の dark hair 層が外側の silver 層を平準化してしまい、本来の髪色が出せない (hijiki 症状)」という構造的劣化が出る。SL の典型 asset 形態と相性が悪いと判明、候補から外す。残る筋は per-pixel linked list / depth peeling 系のみ。
 - **Risk**: 上流の deferred renderer と shader 全部書き換え、AYAstorm の water exclusion / atmospherics pass の挟み込み (`pipeline.cpp:4794-4814`) と衝突。
 - **Effort**: L
 - **Priority**: 中 — 効果はアバター集会 / 透明 mesh 多数の sim で目に見えるが、上流の PBR/GLTF 移行待ちのほうが筋がいい。


### PR DESCRIPTION
## Summary
- r31 で試した WBOIT (Weighted Blended OIT) が SL の多層 strand 髪 mesh と構造的に相性が悪いと判明 (hijiki 症状) し、WBOIT branch を廃棄した
- それに伴い r30 系 docs の stale な r31/WBOIT 参照を整理

## 変更点
- `docs/specs/ayastorm-r30-cinematic-chapter.md` §P2 見出しから `(想定 r31)` を削除 (r31 は bundle release に再定義され、velocity buffer + SMAA T2x phase と紐付かなくなったため)
- `docs/specs/ayastorm-render-perf-survey.md` §6.1 alpha sort OIT 候補から WBOIT を削除、検証結果行で SL 不適合の構造的理由を明記 (将来の再提案抑止用 signal)

## Test plan
- [x] docs only — viewer build/動作に影響なし
- [x] grep で他に "r31" 標榜の docs が残っていないことを確認 (汎用言及 / 変数名 / widget ID のみ)