### PR TITLE
AYAstormのリリース表記をr31に更新

### DIFF
--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -604,7 +604,7 @@ void LLViewerShaderMgr::setShaders()
             // r19 → r20 would silently hit stale compiled shaders on all
             // three OS. Bump this string at every AYAstorm release — grep
             // "AYASTORM_SHADER_CACHE_TAG" to find every site that needs it.
-            const char* const AYASTORM_SHADER_CACHE_TAG = "AYAstorm r24";
+            const char* const AYASTORM_SHADER_CACHE_TAG = "AYAstorm r31";
             hash_obj.update(AYASTORM_SHADER_CACHE_TAG);
             // </FS:AYA>
             // <FS:AYA r30 Phase 3.8> Mix Cinematic mode into the cache key so

--- a/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
@@ -66,7 +66,7 @@
     halign="center"
     text_color="EmphasisColor"
     name="aya_brand_line1">
-AYAstorm r24
+AYAstorm r31
   </text>
   <text
     left="0"


### PR DESCRIPTION
## 概要
- AYAstormのログイン画面表示を `AYAstorm r24` から `AYAstorm r31` に更新
- シェーダーキャッシュタグ `AYASTORM_SHADER_CACHE_TAG` を `AYAstorm r24` から `AYAstorm r31` に更新

## 補足
`AYASTORM_SHADER_CACHE_TAG` の直前コメントに以下の記載があるため、リリース表記に合わせて `AYAstorm r31` へ更新しています。

> r19 → r20 would silently hit stale compiled shaders on all
> three OS. Bump this string at every AYAstorm release — grep
> "AYASTORM_SHADER_CACHE_TAG" to find every site that needs it.

## 確認内容
- macOS向けに `xcodebuild` / `llpackage` でビルド成功
- 生成済みapp内のログイン画面XMLが `AYAstorm r31` になっていることを確認
- 本体バイナリ内の文字列に `AYAstorm r31` が含まれることを確認