### PR TITLE
docs: r31 リリース資料作成 + About ヘッダー r20→r31 更新

### DIFF
--- a/docs/release/ayastorm-r31-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-github-release-page.en.md
@@ -1,0 +1,96 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.zh.md)
+
+# AYAstorm r31+bundle-fs.80646 — 3D Stream unified tag + photography-grade render engine (AYAstorm View) + parcel music Ogg Vorbis fix + MOAP 3D stream routing + macOS branding + other-avatar rigged picker + Firestorm upstream FS-7.1.18.80646 carry-over
+
+A single jump from r24 to r31 bundles six releases (r25, r26, r27, r28, r30, r31) into one tag, together with the Firestorm upstream FS-7.1.18.80646 carry-over. r29 was skipped during chapter pivoting. The headline this time is r31 — the 3D Stream tag is unified under `[3dstream:...]`, so a single prefix now covers mono URL streams and linkset distributed routing (stereo / 5.1 / MOAP). The r30 photography-grade render engine (AYAstorm View) and the r25–r28 audio / branding / picker features ship in the same bundle. For the full notes per release, see the per-language release notes in the repo (tag-pinned permalinks — they will not break when docs are updated later).
+
+## Release notes (per release × language)
+
+### Headline: 3D Stream chapter (r31)
+- 🇺🇸 English: [docs/release/ayastorm-r31-release-note.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md)
+- 🇯🇵 日本語: [docs/release/ayastorm-r31-release-note.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md)
+- 🇨🇳 中文: [docs/release/ayastorm-r31-release-note.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### 3D Stream chapter (r31)
+- **r31** — 3D Stream unified tag: a single `[3dstream:...]` prefix now covers both mono URL streams and linkset distributed routing (stereo / 5.1 / MOAP). Legacy `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` are still accepted. `{bin}` / `{binaural}` default changes to `off` (venues opt in). 5.1ch codec guidance refreshed for Vorbis 6ch / Opus 6ch / FLAC 6ch: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### Photography chapter (r30)
+- **r30** — View Mode picker reshuffle: Cinematic promoted to the new AYAstorm View. Velocity buffer / SMAA T2x / Volumetric Light / BD-class DoF chain / Motion Blur / Chromatic Aberration / 35-cvar AYAstorm Controls floater. Restart-required mode switching, one-shot migration from the r14–r20 AYAstorm View: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.zh.md)
+
+### Media audio (parcel music / MOAP)
+- **r25** — Parcel music Ogg Vorbis live stream playback fix (broken since r10.x-bugfix-1, Ogg Opus support preserved): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.zh.md)
+- **r26** — MOAP audio routes through 3D Stream's speaker routing (`{ch:L}/{ch:R}/{ch:FL}/...` distributed stereo / 5.1 placement / HRTF / venue reverb / occlusion now work from MOAP faces): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.zh.md)
+
+### Cross-platform polish
+- **r27** — macOS branding unification (menu bar / window title / Apple About panel now say "AYAstorm", `(based on Firestorm)` attribution preserved in About): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.zh.md)
+
+### UX & picker
+- **r28** — Other rigged picker (extends r21 GPU object-ID picker to other avatars' rigged attachments, one armed target at a time, by @t-noami): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.zh.md)
+
+### Firestorm upstream carry-over
+- **Firestorm FS-7.1.18.80646 bundle** — Firestorm upstream FS-7.1.18.80646 carried over into AYAstorm. This is a platform refresh of the viewer base with no dedicated release note; it ships inside the umbrella tag. For the Firestorm-side change list, see the [Firestorm release notes](https://wiki.firestormviewer.org/release_notes).
+
+## Key documents (tag-pinned)
+
+### 3D Stream chapter (r31)
+- r31 unified tag spec (single source of truth): [docs/specs/ayastorm-r31-3dstream-unified-tag.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r31-3dstream-unified-tag.md)
+- Cumulative 3D stream tag guide (r6 onward): [docs/guides/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.zh.md)
+- 3D stream user-facing how-to: [docs/specs/3dstream-user-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.zh.md)
+
+### Photography chapter (r30)
+- r30 release decision (single source of truth): [docs/specs/ayastorm-r30-view-mode-reshuffle.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-view-mode-reshuffle.md)
+- r30 chapter status block (P1–P6 lineage, points forward to reshuffle): [docs/specs/ayastorm-r30-cinematic-chapter.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-chapter.md)
+- P1 restart-switch infrastructure: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
+- BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
+- Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS user guide (avatar photography): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
+
+### Media audio
+- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+
+### UX & picker
+- r28 other rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)
+- r21 self-rigged picker spec (sibling feature): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer technical spec (for other viewer forks): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+
+## Public disclosure: double alpha-block fix (cross-viewer common bug)
+
+A forward alpha BLEND rendering bug common to all SL viewers (LL / Firestorm / Alchemy / Black Dragon) — "double alpha block" — and the 2-line fix AYAstorm adopted is published as a 3-language public spec + verification screenshots, so other viewer forks can pull it in without a PR. A dedicated reference branch `fix/double-alpha-block` is kept as a permanent anchor (HEAD tracks the latest doc revision):
+
+- Primary spec (English): [docs/specs/double-alpha-block-fix.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md)
+- 日本語: [docs/specs/double-alpha-block-fix.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md)
+- 中文: [docs/specs/double-alpha-block-fix.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+- Reference branch: [fix/double-alpha-block](https://github.com/mayatonton/phoenix-firestorm/tree/fix/double-alpha-block)
+
+## Compatibility with existing setups
+
+All features ship without breaking r24 setups:
+
+- **r31 3D Stream unified tag**: prefer `[3dstream:...]` for new content. Legacy `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` continue to be accepted, so existing content does not need rewriting. The `{bin}` / `{binaural}` default change applies only to the new `[3dstream:...]` tag — venues that want binaural should opt in with `{bin:on}`.
+- **r30 view-mode reshuffle**: existing r24-era AYAstorm View users (`AYAVisualRealismEnabled = 1`) are silently migrated to the new AYAstorm View (`= 2`) by an idempotent one-shot migration on first launch. No user-facing prompt. The r14–r20 visual-realism layer is reachable as opt-in additions on top of the new engine through the AYAstorm Controls floater (`Alt+C`). Switching to Firestorm View remains available for streaming / low-resource use. Restart required to switch modes.
+- **r25 parcel music Ogg Vorbis fix**: Icecast Ogg Vorbis live streams now play correctly. Full Ogg Opus support preserved. No setting required.
+- **r26 MOAP 3D stream routing**: existing 3D Stream tag conventions (`{ch:L}/{ch:R}/{ch:FL}/...`) now apply to MOAP face URLs. Streamers without these tags are unaffected.
+- **r27 macOS branding**: pure surface-level rename on macOS. No functional change; non-macOS builds unaffected.
+- **r28 other rigged picker**: GPU object-ID buffer pass extended to other avatars. Master switch `FSOtherRiggedPickerEnable` defaults ON; `FSOtherRiggedPickerGPU` kill-switch retained. Default-camera gate and 1.0 s arm window keep load bounded. The r21 self picker is unchanged.
+- **Firestorm upstream FS-7.1.18.80646**: viewer base platform refresh. AYAstorm-specific features and existing setups are unaffected.
+
+## IR license
+
+Venue IRs bundled in r11 (and still shipping) are from OpenAIR (CC-BY 4.0). Sources in [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/indra/newview/app_settings/venue_ir/CREDITS.md).
+
+## Render engine credit
+
+The AYAstorm View pipeline draws extensively from NiranV Dean's Black Dragon viewer (LGPL-2.1, license matched to viewerlgpl). The port is acknowledged in `floater_about.xml` and BD repository commit references are preserved in port-spec headers.
+
+## Downloads
+
+_To be filled in by @mayatonton after the 3 OS build completes._
+
+- Windows Installer
+- macOS Installer
+- Linux Installer
+
+## Contributors
+
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-github-release-page.ja.md
@@ -1,0 +1,96 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.zh.md)
+
+# AYAstorm r31+bundle-fs.80646 — 3D Stream unified tag + 撮影品質描画エンジン (AYAstorm View) + parcel music Ogg Vorbis fix + MOAP 3D stream routing + macOS branding 統一 + 他人 avatar rigged picker + Firestorm upstream FS-7.1.18.80646 取込
+
+r24 から r31 への一括移行 tag。6 release (r25 / r26 / r27 / r28 / r30 / r31) を 1 つの tag に同梱し、あわせて Firestorm upstream FS-7.1.18.80646 を取込みます。r29 は章移行中に skip されました。今回の柱は r31 — 3D Stream のタグを `[3dstream:...]` に一本化し、mono URL stream と linkset 分散 routing (stereo / 5.1 / MOAP) を同一 prefix で書けるようにしています。r30 の撮影品質描画エンジン (AYAstorm View)、r25〜r28 の audio / branding / picker 機能も同梱出荷します。各 release の完全な note は repo 内の per-language release note を参照 (tag-pinned permalink — 後日 docs が更新されても壊れません)。
+
+## Release notes (release × 言語)
+
+### 今回の柱: 3D Stream chapter (r31)
+- 🇺🇸 English: [docs/release/ayastorm-r31-release-note.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md)
+- 🇯🇵 日本語: [docs/release/ayastorm-r31-release-note.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md)
+- 🇨🇳 中文: [docs/release/ayastorm-r31-release-note.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### 3D Stream chapter (r31)
+- **r31** — 3D Stream unified tag: `[3dstream:...]` 1 種類で mono URL stream と linkset 分散 routing (stereo / 5.1 / MOAP) を表記。既存 `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` は全て互換受付。`{bin}` / `{binaural}` の既定値が off へ変更 (会場側 opt-in)。5.1ch codec 案内を Vorbis 6ch / Opus 6ch / FLAC 6ch の現状に整理: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### 撮影描画章 (r30)
+- **r30** — View Mode picker reshuffle: Cinematic を新しい AYAstorm View へ promote。velocity buffer / SMAA T2x / Volumetric Light / BD クラス DoF chain / Motion Blur / Chromatic Aberration / 35 cvar の AYAstorm Controls floater。再起動必須のモード切替、r14〜r20 AYAstorm View からの 1-shot migration: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.zh.md)
+
+### Media audio (parcel music / MOAP)
+- **r25** — parcel music Ogg Vorbis live stream 再生 fix (r10.x-bugfix-1 以降の regression、Ogg Opus サポートは維持): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.zh.md)
+- **r26** — MOAP audio を 3D Stream の speaker routing 経由に (`{ch:L}/{ch:R}/{ch:FL}/...` 分散ステレオ / 5.1 配置 / HRTF / venue reverb / occlusion が MOAP 面でも動作): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.zh.md)
+
+### Cross-platform polish
+- **r27** — macOS branding 統一 (menu bar / window title / Apple About panel が「AYAstorm」表記に、About 内の `(based on Firestorm)` 表記は維持): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.zh.md)
+
+### UX & picker
+- **r28** — 他人 rigged picker (r21 GPU object-ID picker を他人 avatar の rigged attachment へ拡張、同時 armed は 1 人、by @t-noami): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.zh.md)
+
+### Firestorm upstream 取込
+- **Firestorm FS-7.1.18.80646 bundle** — Firestorm upstream FS-7.1.18.80646 を AYAstorm に取込。viewer 基盤の platform refresh で、専用の release note はなく、umbrella tag に同梱されます。Firestorm 側の change list は [Firestorm release notes](https://wiki.firestormviewer.org/release_notes) を参照
+
+## 主要ドキュメント (tag-pinned)
+
+### 3D Stream chapter (r31)
+- r31 unified tag spec (単一の真実): [docs/specs/ayastorm-r31-3dstream-unified-tag.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r31-3dstream-unified-tag.md)
+- 3D stream tag guide (r6 以降の累積): [docs/guides/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.zh.md)
+- 3D stream user guide (使い方): [docs/specs/3dstream-user-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.zh.md)
+
+### 撮影描画章 (r30)
+- r30 release 判断の単一の真実: [docs/specs/ayastorm-r30-view-mode-reshuffle.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-view-mode-reshuffle.md)
+- r30 章 status block (P1–P6 系譜、reshuffle へ forward 参照): [docs/specs/ayastorm-r30-cinematic-chapter.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-chapter.md)
+- P1 再起動切替インフラ: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
+- BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
+- Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS ユーザーガイド (アバター撮影向け): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
+
+### Media audio
+- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+
+### UX & picker
+- r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)
+- r21 self rigged picker spec (姉妹機能): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer 技術資料 (他 viewer 取込用): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+
+## 公開資料: 二重 alpha block fix (他 SL viewer 共通 bug の公開)
+
+LL / Firestorm / Alchemy / Black Dragon 全 SL viewer に共通する forward alpha BLEND 描画 bug (「二重 alpha block」) と、AYAstorm が採用した 2 行修正を、他 viewer fork が PR 不要で取込めるよう 3 言語の公開資料 + 検証スクショとして公開しています。専用 reference branch `fix/double-alpha-block` を永続的に保持しています (HEAD は最新 doc revision に追従):
+
+- 一次資料 (英語): [docs/specs/double-alpha-block-fix.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md)
+- 日本語: [docs/specs/double-alpha-block-fix.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md)
+- 中文: [docs/specs/double-alpha-block-fix.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+- Reference branch: [fix/double-alpha-block](https://github.com/mayatonton/phoenix-firestorm/tree/fix/double-alpha-block)
+
+## 既存設定との互換性
+
+r24 setup を壊さずに全機能が出荷されます:
+
+- **r31 3D Stream unified tag**: 新規作成では `[3dstream:...]` を推奨。既存 `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` は引き続き受け付けられ、既存コンテンツの書き換えは不要。`{bin}` / `{binaural}` の既定値変更は新規 `[3dstream:...]` タグでの挙動で、binaural を効かせる会場は `{bin:on}` を明示
+- **r30 view-mode reshuffle**: r24 時代の AYAstorm View ユーザー (`AYAVisualRealismEnabled = 1`) は初回起動時の冪等 1-shot migration で新しい AYAstorm View (`= 2`) に静かに移行されます。ユーザー向けプロンプトはなし。r14〜r20 の視覚的リアリズム層は AYAstorm Controls floater (`Alt+C`) から新エンジン上の opt-in 追加機能として到達可能。Firestorm View 切替は配信/低リソース用途向けに引き続き利用可。モード切替には再起動が必須
+- **r25 parcel music Ogg Vorbis fix**: Icecast Ogg Vorbis live stream が正常再生されます。Ogg Opus サポートは完全維持。設定不要
+- **r26 MOAP 3D stream routing**: 既存の 3D Stream tag 規約 (`{ch:L}/{ch:R}/{ch:FL}/...`) が MOAP 面 URL にも適用されます。タグを使っていない配信者には影響なし
+- **r27 macOS branding**: macOS 上の純表面 rename。機能変更なし、非 macOS build には影響なし
+- **r28 他人 rigged picker**: GPU object-ID buffer pass を他人 avatar に拡張。マスタースイッチ `FSOtherRiggedPickerEnable` は default ON、`FSOtherRiggedPickerGPU` kill-switch も維持。デフォルトカメラ gate と 1.0 秒 arm window で負荷を抑制。r21 self picker は不変
+- **Firestorm upstream FS-7.1.18.80646**: viewer 基盤の platform refresh。AYAstorm 独自機能と既存 setup には影響なし
+
+## IR ライセンス
+
+r11 で同梱して以来出荷を続けている venue IR は OpenAIR (CC-BY 4.0) を起源とします。出典は [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/indra/newview/app_settings/venue_ir/CREDITS.md)。
+
+## 描画エンジン credit
+
+AYAstorm View pipeline は NiranV Dean 氏の Black Dragon viewer (LGPL-2.1、viewerlgpl と互換) から大量に拝借しています。credit は `floater_about.xml` に明記、port spec の header に BD repository commit ref を保持しています。
+
+## Downloads
+
+_3 OS ビルド完了後 @mayatonton が記入。_
+
+- Windows Installer
+- macOS Installer
+- Linux Installer
+
+## Contributors
+
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-github-release-page.zh.md
@@ -1,0 +1,96 @@
+🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-github-release-page.zh.md)
+
+# AYAstorm r31+bundle-fs.80646 — 3D Stream unified tag + 摄影级渲染引擎 (AYAstorm View) + parcel music Ogg Vorbis fix + MOAP 3D stream routing + macOS 品牌统一 + 他人 avatar rigged picker + Firestorm upstream FS-7.1.18.80646 取入
+
+从 r24 到 r31 的一括发布 tag。将 6 个 release (r25 / r26 / r27 / r28 / r30 / r31) 同捆为 1 个 tag,并取入 Firestorm upstream FS-7.1.18.80646。r29 在章节切换中跳过。本次核心是 r31 —— 3D Stream 的 tag 统一到 `[3dstream:...]`,同一 prefix 可书写 mono URL stream 与 linkset 分布式 routing (stereo / 5.1 / MOAP)。r30 的摄影级渲染引擎 (AYAstorm View)、r25〜r28 的 audio / branding / picker 功能也同捆出货。各 release 的完整 note 参见 repo 内的 per-language release note (tag-pinned permalink —— 即使 docs 后续更新也不会失效)。
+
+## Release notes (release × 语言)
+
+### 本次核心: 3D Stream chapter (r31)
+- 🇺🇸 English: [docs/release/ayastorm-r31-release-note.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md)
+- 🇯🇵 日本語: [docs/release/ayastorm-r31-release-note.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md)
+- 🇨🇳 中文: [docs/release/ayastorm-r31-release-note.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### 3D Stream chapter (r31)
+- **r31** — 3D Stream unified tag: 1 种 `[3dstream:...]` 同时表记 mono URL stream 与 linkset 分布式 routing (stereo / 5.1 / MOAP)。既有 `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` 全部继续受理。`{bin}` / `{binaural}` 默认值变更为 off (会场侧 opt-in)。5.1ch codec 案内匹配 Vorbis 6ch / Opus 6ch / FLAC 6ch 现状整理: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r31-release-note.zh.md)
+
+### 摄影渲染章 (r30)
+- **r30** — View Mode picker reshuffle: Cinematic 提升为新的 AYAstorm View。velocity buffer / SMAA T2x / Volumetric Light / BD 级 DoF chain / Motion Blur / Chromatic Aberration / 35 cvar 的 AYAstorm Controls floater。模式切换需要重启,r14–r20 AYAstorm View 的 1-shot migration: [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r30-release-note.zh.md)
+
+### Media audio (parcel music / MOAP)
+- **r25** — parcel music Ogg Vorbis live stream 播放修复 (r10.x-bugfix-1 以来的 regression,Ogg Opus 支持保留): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r25-release-note.zh.md)
+- **r26** — MOAP audio 通过 3D Stream 的 speaker routing 路由 (`{ch:L}/{ch:R}/{ch:FL}/...` 分布式 stereo / 5.1 定位 / HRTF / venue reverb / occlusion 在 MOAP 面上也工作): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r26-release-note.zh.md)
+
+### Cross-platform polish
+- **r27** — macOS 品牌统一 (menu bar / window title / Apple About panel 显示 "AYAstorm",About 内 `(based on Firestorm)` 归属保留): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r27-release-note.zh.md)
+
+### UX & picker
+- **r28** — 他人 rigged picker (将 r21 GPU object-ID picker 扩展到他人 avatar 的 rigged attachment,同时 armed 1 人,by @t-noami): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.en.md) / [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.ja.md) / [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/release/ayastorm-r28-release-note.zh.md)
+
+### Firestorm upstream 取入
+- **Firestorm FS-7.1.18.80646 bundle** — Firestorm upstream FS-7.1.18.80646 取入到 AYAstorm。viewer 基盘的 platform refresh,无专用 release note,同捆于 umbrella tag 内。Firestorm 侧 change list 参见 [Firestorm release notes](https://wiki.firestormviewer.org/release_notes)
+
+## 主要文档 (tag-pinned)
+
+### 3D Stream chapter (r31)
+- r31 unified tag spec (单一真相): [docs/specs/ayastorm-r31-3dstream-unified-tag.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r31-3dstream-unified-tag.md)
+- 3D stream tag guide (r6 以来累积): [docs/guides/3dstream-tag-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/guides/3dstream-tag-guide.zh.md)
+- 3D stream 用户使用指南: [docs/specs/3dstream-user-guide.en.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.en.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/3dstream-user-guide.zh.md)
+
+### 摄影渲染章 (r30)
+- r30 release 决定的单一真相来源: [docs/specs/ayastorm-r30-view-mode-reshuffle.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-view-mode-reshuffle.md)
+- r30 章 status block (P1–P6 脉络,前指 reshuffle): [docs/specs/ayastorm-r30-cinematic-chapter.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-chapter.md)
+- P1 重启切换基础设施: [docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-p1-view-mode-restart-switch.md)
+- BD live cvar port reference: [docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-bd-full-port-phase6-live-cvar-port-spec.md)
+- Cinematic Controls floater audit: [docs/specs/ayastorm-r30-cinematic-controls-cleanup.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r30-cinematic-controls-cleanup.md)
+- Skin SSS 使用指南 (面向 avatar 摄影): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
+
+### Media audio
+- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+
+### UX & picker
+- r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)
+- r21 self rigged picker spec (姐妹功能): [docs/specs/ayastorm-r21-self-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r21-self-rigged-picker.md)
+- Rigged Mesh Picker — GPU object-ID buffer 技术资料 (供其他 viewer fork 取用): [docs/specs/rigged-mesh-picker-gpu-buffer.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+
+## 公开披露: 二重 alpha block fix (其他 SL viewer 通用 bug 公开资料)
+
+LL / Firestorm / Alchemy / BlackDragon 所有 viewer 共通存在的 forward alpha BLEND 渲染 bug ("二重 alpha block") 与 AYAstorm 采用的 2 行修复方案,以 3 语言公开资料 + 验证截图的形式公开,以便其他 viewer fork 无需 PR 即可取入。专用 reference branch `fix/double-alpha-block` 作为永久参照保持 (HEAD 跟踪最新 doc revision):
+
+- 一次资料 (英语): [docs/specs/double-alpha-block-fix.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md)
+- 日本語: [docs/specs/double-alpha-block-fix.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md)
+- 中文: [docs/specs/double-alpha-block-fix.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+- Reference branch: [fix/double-alpha-block](https://github.com/mayatonton/phoenix-firestorm/tree/fix/double-alpha-block)
+
+## 与现有 setup 的兼容性
+
+所有功能不破坏 r24 setup 出货:
+
+- **r31 3D Stream unified tag**: 新规作成推荐 `[3dstream:...]`。既有 `[3dstream-stereo:...]` / `[ayastream:...]` / `[ayastream-stereo:...]` 继续受理,既有内容无需改写。`{bin}` / `{binaural}` 默认值变更仅对新 `[3dstream:...]` tag 适用,需要 binaural 的会场请明示 `{bin:on}`
+- **r30 view-mode reshuffle**: r24 时代的 AYAstorm View 用户 (`AYAVisualRealismEnabled = 1`) 在首次启动时通过幂等 one-shot migration 静默迁移到新的 AYAstorm View (`= 2`)。无用户提示。r14–r20 视觉真实感层通过 AYAstorm Controls floater (`Alt+C`) 作为新引擎之上的 opt-in 追加功能到达。Firestorm View 切换继续用于直播/低资源用途。模式切换需要重启
+- **r25 parcel music Ogg Vorbis fix**: Icecast Ogg Vorbis live stream 正常播放。Ogg Opus 支持完整保留。无需设置
+- **r26 MOAP 3D stream routing**: 既有 3D Stream tag 约定 (`{ch:L}/{ch:R}/{ch:FL}/...`) 适用于 MOAP 面 URL。未使用 tag 的配信者不受影响
+- **r27 macOS 品牌**: macOS 上纯表面 rename。无功能变更,非 macOS build 不受影响
+- **r28 他人 rigged picker**: GPU object-ID buffer pass 扩展到他人 avatar。主开关 `FSOtherRiggedPickerEnable` 默认 ON,`FSOtherRiggedPickerGPU` kill-switch 保留。默认相机 gate 和 1.0 秒 arm window 约束负载。r21 self picker 不变
+- **Firestorm upstream FS-7.1.18.80646**: viewer 基盘的 platform refresh。AYAstorm 独自功能与既有 setup 不受影响
+
+## IR 许可
+
+r11 同捆以来持续出货的 venue IR 来源于 OpenAIR (CC-BY 4.0)。来源在 [`app_settings/venue_ir/CREDITS.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/indra/newview/app_settings/venue_ir/CREDITS.md)。
+
+## 渲染引擎 credit
+
+AYAstorm View pipeline 大量借鉴自 NiranV Dean 的 Black Dragon viewer (LGPL-2.1,与 viewerlgpl 兼容)。credit 在 `floater_about.xml` 中明示,port spec 的 header 中保留 BD repository commit ref。
+
+## Downloads
+
+_3 OS 构建完成后由 @mayatonton 填写。_
+
+- Windows Installer
+- macOS Installer
+- Linux Installer
+
+## Contributors
+
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-release-note.en.md
+++ b/docs/release/ayastorm-r31-release-note.en.md
@@ -1,0 +1,124 @@
+# AYAstorm r31 — Release Announcement
+
+**r31 unifies the 3D Stream linkset routing tag under `[3dstream:...]`**. The tag previously split between `[3dstream:...]` for single-prim mono URL streams and `[3dstream-stereo:...]` for linkset distributed routing is now reachable through a single `[3dstream:...]` prefix. All existing tags continue to be accepted for compatibility.
+
+> **Distribution**: r31 ships as one of the features in the r25–r30 + r31 bundle tag (`v7.2.4-ayastorm-r31+bundle-fs.80646`). Other bundled release notes and the Firestorm upstream FS-7.1.18.80646 carry-over are linked directly from the GitHub Release page.
+
+The single source of truth for the spec is `docs/specs/ayastorm-r31-3dstream-unified-tag.md`. The practical streamer guide is `docs/guides/3dstream-tag-guide.{en,ja,zh}.md` and the user guide is `docs/specs/3dstream-user-guide.{en,ja,zh}.md`. This note is the entry point and diff highlight.
+
+---
+
+## AYAstorm r31 — `[3dstream:...]` unified linkset tag
+
+### Headline: one tag for both mono and linkset routing
+
+Since r6, 3D Stream has had two tag prefixes:
+
+- `[3dstream:{url:...}]` — single-prim mono URL stream
+- `[3dstream-stereo:...]` — linkset distributed stereo / 5.1 / MOAP routing
+
+r31 collapses this into **one prefix** that new authors need to remember: `[3dstream:...]`. The same prefix now covers both mono and linkset routing.
+
+Promotion rule: whether `[3dstream:...]` is treated as linkset routing depends on whether any child prim in the linkset carries a valid `{ch:...}`. With no `{ch:...}` children, the root `[3dstream:{url:...}]` continues to play as mono just like before.
+
+### Compatibility
+
+All existing forms **continue to be accepted**. No rewrite of existing content is required:
+
+- `[3dstream:{url:...}]` — single-prim mono URL stream
+- `[ayastream:{url:...}]` — legacy mono alias
+- `[3dstream-stereo:...]` — legacy linkset/distributed tag
+- `[ayastream-stereo:...]` — legacy linkset/distributed alias
+
+For new content, prefer `[3dstream:...]`, but there is no need to rush existing content over.
+
+### Common forms
+
+**Mono URL (unchanged)**
+
+```text
+[3dstream:{url:http://example.com/stream.mp3}]
+```
+
+**Stereo / distributed (linkset)**
+
+```text
+root:  [3dstream:{url:http://example.com/stream.mp3}]
+left:  [3dstream:{ch:L}]
+right: [3dstream:{ch:R}]
+```
+
+With a `{ch:...}` child present, the root's mono binding is automatically promoted to linkset routing.
+
+**MOAP stereo / 5.1**
+
+```text
+root: [3dstream:{source:media}]
+L:    [3dstream:{ch:L}]
+R:    [3dstream:{ch:R}]
+```
+
+```text
+root: [3dstream:{source:media-5-1}]
+FL:   [3dstream:{ch:FL}]
+FR:   [3dstream:{ch:FR}]
+C:    [3dstream:{ch:C}]
+LFE:  [3dstream:{ch:LFE}]
+SL:   [3dstream:{ch:SL}]
+SR:   [3dstream:{ch:SR}]
+```
+
+### Configuration — `{bin}` / `{binaural}` default change
+
+For the new `[3dstream:...]` tag, the **default when `{bin}` / `{binaural}` is unspecified is now `off`**. Venues that want binaural DSP should opt in with `{bin:on}`.
+
+Rationale: changes to how existing placements sound, without tag rewrites, are kept to a minimum. The r12-era binaural DSP becomes an explicit opt-in for venues that want it. The listener-side debug override `Stream3DBinauralRender = 0 / 1` is still available (`-1` = follow tag).
+
+### 5.1ch streaming codec guidance
+
+5.1ch streaming codec guidance is refreshed to match the post-r9-opus state:
+
+- **Vorbis 6ch** — verified on the live build
+- **Opus 6ch** — verified on the live build via the r9-opus codec plugin (no FMOD parser seek constraint)
+- **FLAC 6ch** — codec layout is implemented, but some delivery paths require seek and can fail with `FMOD_ERR_FILE_COULDNOTSEEK`
+
+For live streaming, **prefer Opus 6ch**. [SurroundStreamer](https://github.com/t-noami/SurroundStreamer) is the recommended practical streaming path.
+
+### Upmix description change
+
+Stereo → 5.1 upmix is now described as **matrix upmix + band separation** without referring to any commercial decoder name. The implementation is a fixed `LLStereoUpmix` algorithm (center is `(L+R)/√2`, SL/SR are delayed `±(L-R)/√2`, LFE is the LPF), described in terms of its math rather than any product name.
+
+### Other-viewer / MOAP fallback
+
+Other viewers do not interpret 3D Stream tags:
+
+- `{url:...}` 3D Stream audio does not play on other viewers
+- The **media face itself** for `{source:media}` continues to display and play as a normal MOAP on other viewers
+- `{ch:...}` routing, upmix, binaural, and venue reverb are AYAstorm-only
+
+For setups that show a media surface while playing `{url:...}` 3D Stream audio, the media side continues to act as a normal MOAP for other viewers.
+
+### Error notification tag examples
+
+Local Chat tag-format error notifications (`BadCh` / `BadRange` / `BadVolume`, etc.) are now exemplified in the new recommended `[3dstream:...]` form. Legacy `[3dstream-stereo:...]` / `[ayastream-stereo:...]` are still accepted; the internal log label `[3dstream-stereo]` remains as a subsystem/debug label and does not imply user-facing tag recommendation.
+
+### Known constraints
+
+- **Linkset promotion only on `{ch:...}` discovery**: the mere existence of child prims does not promote `[3dstream:...]` from mono to linkset. At least one child with a valid `{ch:...}` is required
+- **Child description fetch delay**: while child prim descriptions are still being fetched, the root URL plays as mono; once `{ch:...}` is detected, the binding moves to linkset routing
+- **`{source:media}` / `{source:media-5-1}` have no mono fallback**: these are distributed source declarations and require at least one `{ch:...}` speaker
+
+### Implementation summary
+
+- `LLPositionalStreamMgr::parseDistributedStereoTag()` now reads `[3dstream:...]` as distributed grammar
+- `DistStereoTagData::unified_3dstream_prefix` records whether the tag came from the legacy `[3dstream-stereo:...]` or the unified `[3dstream:...]` form
+- `evaluateBinding()` treats `[3dstream:{url:...}]` as mono initially, then drops the mono binding and forwards to `evaluateLinkset()` once a `{ch:...}` is observed on the same tag or a known linkset child
+- `evaluateLinkset()` falls back unified `[3dstream:{url:...}]` roots with no `{ch:...}` speakers back to mono
+- `LLPositionalStreamMgr::effectiveBinaural()` resolves an unspecified tag as `false`
+
+### Documentation
+
+- r31 unified tag spec (single source of truth): `docs/specs/ayastorm-r31-3dstream-unified-tag.md`
+- Cumulative streamer-facing guide: `docs/guides/3dstream-tag-guide.{en,ja,zh}.md`
+- User-facing how-to: `docs/specs/3dstream-user-guide.{en,ja,zh}.md`
+- Earlier 3D Stream chapter lineage (r6 onward): `docs/specs/ayastorm-r*-*.md`

--- a/docs/release/ayastorm-r31-release-note.ja.md
+++ b/docs/release/ayastorm-r31-release-note.ja.md
@@ -1,0 +1,124 @@
+# AYAstorm r31 — リリース告知
+
+**r31 は 3D Stream の linkset routing タグを `[3dstream:...]` に一本化するリリース**。これまで mono URL stream 用の `[3dstream:...]` と、linkset 分散再生用の `[3dstream-stereo:...]` に分かれていたタグを、`[3dstream:...]` に統合します。既存タグはすべて互換性のため引き続き受け付けます。
+
+> **配信形態**: r31 は r25〜r30 + r31 を一括配信する tag (`v7.2.4-ayastorm-r31+bundle-fs.80646`) の 1 機能として出荷されます。同梱される他リリースの release note と Firestorm upstream FS-7.1.18.80646 取込分は GitHub Release ページから直接リンクされます。
+
+仕様の単一の真実は `docs/specs/ayastorm-r31-3dstream-unified-tag.md`、配信者向け実用ガイドは `docs/guides/3dstream-tag-guide.{en,ja,zh}.md` と `docs/specs/3dstream-user-guide.{en,ja,zh}.md` です。本ノートは差分ハイライトに徹します。
+
+---
+
+## AYAstorm r31 — `[3dstream:...]` unified linkset tag
+
+### r31 の柱: タグ 1 つで mono も linkset routing も書ける
+
+r6 以降、3D Stream には 2 種類のタグがありました:
+
+- `[3dstream:{url:...}]` — 単一プリム mono URL stream
+- `[3dstream-stereo:...]` — linkset 分散ステレオ / 5.1 / MOAP routing
+
+r31 では、新規にタグを書くユーザーが覚える形を **`[3dstream:...]` 1 つ** にまとめます。同じ prefix で mono も linkset routing も書けるようになります。
+
+判定ルール: linkset 内に有効な `{ch:...}` 子プリムがあるかどうかで mono / distributed が決まります。`{ch:...}` が無ければ root の `[3dstream:{url:...}]` は従来どおり mono として再生されます。
+
+### 互換性
+
+以下の既存形式は **すべて引き続き受け付けます**。既存コンテンツに書き換えは不要です:
+
+- `[3dstream:{url:...}]` — mono URL stream
+- `[ayastream:{url:...}]` — 旧 mono alias
+- `[3dstream-stereo:...]` — 旧 linkset/distributed タグ
+- `[ayastream-stereo:...]` — 旧 linkset/distributed alias
+
+新規作成では `[3dstream:...]` を推奨しますが、急いで置き換える必要はありません。
+
+### 主な書き方の例
+
+**Mono URL (従来どおり)**
+
+```text
+[3dstream:{url:http://example.com/stream.mp3}]
+```
+
+**Stereo / distributed (linkset)**
+
+```text
+root:  [3dstream:{url:http://example.com/stream.mp3}]
+left:  [3dstream:{ch:L}]
+right: [3dstream:{ch:R}]
+```
+
+子プリムに `{ch:...}` があるため、root の mono binding は自動的に linkset routing に昇格します。
+
+**MOAP stereo / 5.1**
+
+```text
+root: [3dstream:{source:media}]
+L:    [3dstream:{ch:L}]
+R:    [3dstream:{ch:R}]
+```
+
+```text
+root: [3dstream:{source:media-5-1}]
+FL:   [3dstream:{ch:FL}]
+FR:   [3dstream:{ch:FR}]
+C:    [3dstream:{ch:C}]
+LFE:  [3dstream:{ch:LFE}]
+SL:   [3dstream:{ch:SL}]
+SR:   [3dstream:{ch:SR}]
+```
+
+### 設定 — `{bin}` / `{binaural}` の既定値変更
+
+新規 `[3dstream:...]` タグで **`{bin}` / `{binaural}` の指定が無い場合の既定が off** に変わります。binaural を効かせたい会場は `{bin:on}` を明示してください。
+
+理由: 既存配置の音の出方を、タグ無改修ではなるべく変えないため。r12 由来の binaural DSP は有効化したい会場が明示的に opt-in する形に揃えます。listener 側 debug override `Stream3DBinauralRender = 0 / 1` は従来どおり利用可能です (`-1` = タグ通り)。
+
+### 5.1ch 配信 codec の整理
+
+5.1ch 配信に使える codec を r9-opus codec plugin 投入後の現状に合わせて整理しました:
+
+- **Vorbis 6ch** — 実機検証済み
+- **Opus 6ch** — r9-opus codec plugin 経由で実機検証済み (FMOD parser の seek 制約を受けません)
+- **FLAC 6ch** — codec layout は実装済み。ただし配信経路によっては seek が必要になり、`FMOD_ERR_FILE_COULDNOTSEEK` で開けない場合があります
+
+ライブ配信では **Opus 6ch を優先** してください。実用配信経路として [SurroundStreamer](https://github.com/t-noami/SurroundStreamer) を案内しています。
+
+### upmix の説明変更
+
+stereo → 5.1 upmix は、商標名を使わず **matrix upmix + 帯域分離** として説明します。実装は `LLStereoUpmix` による固定アルゴリズム (center は `(L+R)/√2`、SL/SR は `±(L-R)/√2` を遅延、LFE は LPF) で、特定の商用 decoder 名や方式名としては記述しません。
+
+### 他 Viewer / MOAP fallback
+
+他 Viewer では 3D Stream タグは解釈されません:
+
+- `{url:...}` の 3D Stream 音声は他 Viewer では鳴らない
+- `{source:media}` の **media 面自体** は、他 Viewer でも通常の MOAP として表示・再生される
+- `{ch:...}` routing、upmix、binaural、venue reverb は AYAstorm 専用
+
+media 画面を見せながら `{url:...}` の 3D Stream を鳴らす構成では、他 Viewer では media 側だけが通常 MOAP として扱われます。
+
+### エラー通知文のタグ例
+
+Local Chat に出るタグ書式エラー (`BadCh` / `BadRange` / `BadVolume` 等) の例示は、新規推奨タグの `[3dstream:...]` 形式に統一しています。旧 `[3dstream-stereo:...]` / `[ayastream-stereo:...]` の受付は互換性のため残しますが、内部ログの `[3dstream-stereo]` 表記は subsystem/debug label として残るのみで、ユーザー向けの推奨記法を意味しません。
+
+### 既知の制約
+
+- **linkset 昇格は `{ch:...}` 検出時のみ**: 子プリムが存在するだけでは mono → linkset に昇格しません。`{ch:...}` を持つ子プリムが 1 つ以上必要です
+- **子 Description 取得遅延**: 子プリム Description が未取得の間は、root URL の mono playback で先に再生され、`{ch:...}` 検出後に linkset routing へ移行します
+- **`{source:media}` / `{source:media-5-1}` には mono fallback なし**: distributed source declaration なので、少なくとも 1 つの `{ch:...}` speaker が必要です
+
+### 実装サマリ
+
+- `LLPositionalStreamMgr::parseDistributedStereoTag()` が `[3dstream:...]` を distributed grammar として読む
+- `DistStereoTagData::unified_3dstream_prefix` で、旧 `[3dstream-stereo:...]` 由来か unified `[3dstream:...]` 由来かを保持
+- `evaluateBinding()` は `[3dstream:{url:...}]` をまず mono 互換として扱い、同タグまたは linkset child に `{ch:...}` が見つかった時点で mono binding を消して `evaluateLinkset()` に渡す
+- `evaluateLinkset()` は `{ch:...}` speaker が 1 つもない unified `[3dstream:{url:...}]` root を mono fallback に戻す
+- `LLPositionalStreamMgr::effectiveBinaural()` は tag 未指定を `false` として解決
+
+### 関連資料
+
+- r31 unified tag spec (単一の真実): `docs/specs/ayastorm-r31-3dstream-unified-tag.md`
+- 配信者向け実用ガイド (累積): `docs/guides/3dstream-tag-guide.{en,ja,zh}.md`
+- ユーザー向け使い方ガイド: `docs/specs/3dstream-user-guide.{en,ja,zh}.md`
+- 過去章 (r6 以降の 3D Stream 系譜): `docs/specs/ayastorm-r*-*.md`

--- a/docs/release/ayastorm-r31-release-note.zh.md
+++ b/docs/release/ayastorm-r31-release-note.zh.md
@@ -1,0 +1,124 @@
+# AYAstorm r31 — 发布公告
+
+**r31 将 3D Stream 的 linkset routing tag 统一到 `[3dstream:...]`**。此前分为单 prim mono URL stream 用的 `[3dstream:...]` 和 linkset 分布式播放用的 `[3dstream-stereo:...]` 的 tag,统合到 `[3dstream:...]`。既有 tag 全部因兼容性保留并继续受理。
+
+> **发布形态**: r31 作为 r25–r30 + r31 一括发布 tag (`v7.2.4-ayastorm-r31+bundle-fs.80646`) 的 1 个功能出货。同捆的其他 release note 与 Firestorm upstream FS-7.1.18.80646 取入分,从 GitHub Release 页面直接 link。
+
+规格的单一真相来源是 `docs/specs/ayastorm-r31-3dstream-unified-tag.md`,面向配信者的实用指南是 `docs/guides/3dstream-tag-guide.{en,ja,zh}.md`、面向用户的使用指南是 `docs/specs/3dstream-user-guide.{en,ja,zh}.md`。本 note 仅作入口与差异 highlight。
+
+---
+
+## AYAstorm r31 — `[3dstream:...]` unified linkset tag
+
+### r31 的核心: 1 个 tag 同时书写 mono 与 linkset routing
+
+r6 以来,3D Stream 有 2 种 tag:
+
+- `[3dstream:{url:...}]` — 单 prim mono URL stream
+- `[3dstream-stereo:...]` — linkset 分布式 stereo / 5.1 / MOAP routing
+
+r31 将新规作成时用户需要记忆的形式 **统合到 `[3dstream:...]` 1 个**。同一 prefix 现可书写 mono 与 linkset routing。
+
+判定规则: `[3dstream:...]` 是否作为 linkset routing 处理,取决于 linkset 内是否存在有效的 `{ch:...}` 子 prim。无 `{ch:...}` 时,root 的 `[3dstream:{url:...}]` 与以前一致,继续作为 mono 播放。
+
+### 兼容性
+
+以下既存形式 **全部继续受理**。既存内容无需改写:
+
+- `[3dstream:{url:...}]` — mono URL stream
+- `[ayastream:{url:...}]` — 旧 mono alias
+- `[3dstream-stereo:...]` — 旧 linkset/distributed tag
+- `[ayastream-stereo:...]` — 旧 linkset/distributed alias
+
+新规作成时推荐 `[3dstream:...]`,但无需匆忙置换。
+
+### 主要书写示例
+
+**Mono URL (与以前一致)**
+
+```text
+[3dstream:{url:http://example.com/stream.mp3}]
+```
+
+**Stereo / distributed (linkset)**
+
+```text
+root:  [3dstream:{url:http://example.com/stream.mp3}]
+left:  [3dstream:{ch:L}]
+right: [3dstream:{ch:R}]
+```
+
+由于子 prim 含 `{ch:...}`,root 的 mono binding 自动昇格为 linkset routing。
+
+**MOAP stereo / 5.1**
+
+```text
+root: [3dstream:{source:media}]
+L:    [3dstream:{ch:L}]
+R:    [3dstream:{ch:R}]
+```
+
+```text
+root: [3dstream:{source:media-5-1}]
+FL:   [3dstream:{ch:FL}]
+FR:   [3dstream:{ch:FR}]
+C:    [3dstream:{ch:C}]
+LFE:  [3dstream:{ch:LFE}]
+SL:   [3dstream:{ch:SL}]
+SR:   [3dstream:{ch:SR}]
+```
+
+### 设置 — `{bin}` / `{binaural}` 默认值变更
+
+新规 `[3dstream:...]` tag 中,**`{bin}` / `{binaural}` 未指定时的默认值变更为 off**。需要 binaural 生效的会场请明示 `{bin:on}`。
+
+理由: 既存配置的音的播放方式,在 tag 无改修的状态下尽量不变。r12 以来的 binaural DSP 改为想启用的会场明示 opt-in 的形式。listener 侧 debug override `Stream3DBinauralRender = 0 / 1` 与以前一致可用 (`-1` = 跟随 tag)。
+
+### 5.1ch 配信 codec 整理
+
+5.1ch 配信可用的 codec,匹配 r9-opus codec plugin 投入后的现状整理:
+
+- **Vorbis 6ch** — 实机验证完毕
+- **Opus 6ch** — 经 r9-opus codec plugin 实机验证完毕 (不受 FMOD parser seek 制约)
+- **FLAC 6ch** — codec layout 已实装。但因配信路径不同,可能需要 seek,在 `FMOD_ERR_FILE_COULDNOTSEEK` 下无法打开
+
+live 配信中 **优先 Opus 6ch**。作为实用配信路径,推荐 [SurroundStreamer](https://github.com/t-noami/SurroundStreamer)。
+
+### upmix 说明变更
+
+stereo → 5.1 upmix,不使用商标名,改为 **matrix upmix + 带域分离** 描述。实装是 `LLStereoUpmix` 的固定算法 (center 为 `(L+R)/√2`、SL/SR 为延迟的 `±(L-R)/√2`、LFE 为 LPF),不以特定商用 decoder 名或方式名记述。
+
+### 其他 Viewer / MOAP fallback
+
+其他 Viewer 不解释 3D Stream tag:
+
+- `{url:...}` 的 3D Stream 音频在其他 Viewer 中不播放
+- `{source:media}` 的 **media 面本身**,在其他 Viewer 中作为通常的 MOAP 显示与播放
+- `{ch:...}` routing、upmix、binaural、venue reverb 为 AYAstorm 专用
+
+显示 media 画面同时播放 `{url:...}` 3D Stream 音频的配置中,在其他 Viewer 中仅 media 侧作为通常 MOAP 处理。
+
+### 错误通知的 tag 示例
+
+Local Chat 上输出的 tag 格式错误 (`BadCh` / `BadRange` / `BadVolume` 等) 的示例,统一为新推荐 tag 的 `[3dstream:...]` 形式。旧 `[3dstream-stereo:...]` / `[ayastream-stereo:...]` 的受理因兼容性保留,内部 log 的 `[3dstream-stereo]` 表记仅作为 subsystem/debug label 保留,不意味着面向用户的推荐书写。
+
+### 已知制约
+
+- **linkset 昇格仅在检出 `{ch:...}` 时**: 子 prim 仅存在不会从 mono 昇格至 linkset。至少需要 1 个含 `{ch:...}` 的子 prim
+- **子 Description 取得延迟**: 子 prim Description 未取得期间,先以 root URL 的 mono playback 播放,检出 `{ch:...}` 后移行至 linkset routing
+- **`{source:media}` / `{source:media-5-1}` 无 mono fallback**: 由于是 distributed source declaration,至少需要 1 个 `{ch:...}` speaker
+
+### 实装摘要
+
+- `LLPositionalStreamMgr::parseDistributedStereoTag()` 将 `[3dstream:...]` 作为 distributed grammar 读取
+- `DistStereoTagData::unified_3dstream_prefix` 保持 tag 是来自旧 `[3dstream-stereo:...]` 还是 unified `[3dstream:...]`
+- `evaluateBinding()` 将 `[3dstream:{url:...}]` 首先作为 mono 兼容处理,同 tag 或 linkset child 检出 `{ch:...}` 时,删除 mono binding 转交 `evaluateLinkset()`
+- `evaluateLinkset()` 将无任何 `{ch:...}` speaker 的 unified `[3dstream:{url:...}]` root 退回 mono fallback
+- `LLPositionalStreamMgr::effectiveBinaural()` 将 tag 未指定解析为 `false`
+
+### 相关资料
+
+- r31 unified tag spec (单一真相): `docs/specs/ayastorm-r31-3dstream-unified-tag.md`
+- 配信者实用指南 (累积): `docs/guides/3dstream-tag-guide.{en,ja,zh}.md`
+- 用户使用指南: `docs/specs/3dstream-user-guide.{en,ja,zh}.md`
+- 过去章 (r6 以来 3D Stream 脉络): `docs/specs/ayastorm-r*-*.md`

--- a/indra/newview/skins/default/xui/az/strings.xml
+++ b/indra/newview/skins/default/xui/az/strings.xml
@@ -29,7 +29,7 @@
 		Grafika başladıla bilmədi. Zəhmət olmasa, video kartın sürücüsünü yeniləyin
 	</string>
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE] bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE] bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Second Life Viewer ilə uyğunluq: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/de/strings.xml
+++ b/indra/newview/skins/default/xui/de/strings.xml
@@ -26,7 +26,7 @@
 		Grafikinitialisierung fehlgeschlagen. Bitte aktualisieren Sie Ihren Grafiktreiber.
 	</string>
 	<string name="AboutHeader">
-		[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+		[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Parität mit dem Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -26,7 +26,7 @@
 
 	<!-- about dialog/support string-->
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Parity with Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/es/strings.xml
+++ b/indra/newview/skins/default/xui/es/strings.xml
@@ -31,7 +31,7 @@
 		Error de inicialización de gráficos. Actualiza tu controlador de gráficos.
 	</string>
 	<string name="AboutHeader">
-		[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) ([CHANNEL] [ADDRESS_SIZE]bit / [SIMD])
+		[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) ([CHANNEL] [ADDRESS_SIZE]bit / [SIMD])
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Paridad con Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/fr/strings.xml
+++ b/indra/newview/skins/default/xui/fr/strings.xml
@@ -26,7 +26,7 @@
 		Échec d&apos;initialisation des graphiques. Veuillez mettre votre pilote graphique à jour.
 	</string>
 	<string name="AboutHeader">
-		[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
+		[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Parité avec le client Second Life: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/it/strings.xml
+++ b/indra/newview/skins/default/xui/it/strings.xml
@@ -22,7 +22,7 @@
 		Inizializzazione grafica non riuscita. Aggiornare il driver della scheda grafica.
 	</string>
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Parità con Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/ja/strings.xml
+++ b/indra/newview/skins/default/xui/ja/strings.xml
@@ -19,7 +19,7 @@
 		グラフィックを初期化できませんでした。グラフィックドライバを更新してください。
 	</string>
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Second Life Viewer との互換性: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/pl/strings.xml
+++ b/indra/newview/skins/default/xui/pl/strings.xml
@@ -19,7 +19,7 @@
 		Nie można zainicjować grafiki. Zaktualizuj sterowniki!
 	</string>
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Zgodność z Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/pt/strings.xml
+++ b/indra/newview/skins/default/xui/pt/strings.xml
@@ -23,7 +23,7 @@
 		Falha na inicialização dos gráficos. Atualize seu driver gráfico!
 	</string>
 	<string name="AboutHeader">
-		[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
+		[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 	</string>
 	<string name="BuildConfig">

--- a/indra/newview/skins/default/xui/ru/strings.xml
+++ b/indra/newview/skins/default/xui/ru/strings.xml
@@ -38,7 +38,7 @@
 		Инициализация графики не удалась. Пожалуйста, обновите драйвер видеокарты!
 	</string>
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]бит / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]бит / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Соответствие Second Life Viewer: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/tr/strings.xml
+++ b/indra/newview/skins/default/xui/tr/strings.xml
@@ -35,7 +35,7 @@
 		Grafik başlatma başarılamadı. Lütfen grafik sürücünüzü güncelleştirin!
 	</string>
 	<string name="AboutHeader">
-		[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
+		[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL])
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 Second Life Viewer ile uyumluluk: [VIEWER_VERSION_LL]
 	</string>

--- a/indra/newview/skins/default/xui/zh/strings.xml
+++ b/indra/newview/skins/default/xui/zh/strings.xml
@@ -46,7 +46,7 @@
 	</string>
 	<!-- about dialog/support string-->
 	<string name="AboutHeader">
-[APP_NAME] r20 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
+[APP_NAME] r31 (based on FS [VIEWER_VERSION_0].[VIEWER_VERSION_1].[VIEWER_VERSION_2] build [VIEWER_VERSION_3]) [BUILD_DATE] [BUILD_TIME] ([ADDRESS_SIZE]bit / [SIMD]) ([CHANNEL]) [BUILD_TYPE]
 [[VIEWER_RELEASE_NOTES_URL] [ReleaseNotes]]
 与 Second Life Viewer 保持一致: [VIEWER_VERSION_LL]
 	</string>


### PR DESCRIPTION
## Summary
- r31 用 release-note を 3 言語で新規作成 (3D Stream unified tag、bin 既定 off、5.1ch codec 整理、MOAP fallback、他 Viewer fallback、エラー通知タグ例、既知制約、実装サマリ)
- r31 umbrella GitHub Release ページを 3 言語で新規作成 (tag `v7.2.4-ayastorm-r31+bundle-fs.80646`、r25/r26/r27/r28/r30/r31 + Firestorm upstream FS-7.1.18.80646 同梱)
- 12 言語 (`en/ja/zh/de/fr/it/es/pl/pt/ru/az/tr`) の `strings.xml` の About ヘッダーを `[APP_NAME] r20 (based on FS ...)` → `[APP_NAME] r31 (based on FS ...)` に更新

ログイン画面 (`panel_fs_nui_login.xml`) と shader cache tag (`llviewershadermgr.cpp`) の `r24` → `r31` は別 PR (#106) で対応済み。

## Test plan
- [ ] About panel (`Help → About AYAstorm`) で `AYAstorm r31 (based on FS 7.1.18.80646 ...)` が表示されることを確認
- [ ] 3 OS (Linux / macOS / Windows) ビルドが成功する
- [ ] release ページの tag-pinned permalink が `v7.2.4-ayastorm-r31+bundle-fs.80646` で正しく解決される (tag 作成後)