### PR TITLE
docs: r31 broken link 修正 + README に重要資料への導線追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -131,6 +131,22 @@ HTTP オーディオストリーム (SHOUTcast / Icecast / 静的 MP3 / Vorbis /
 
 ---
 
+## ドキュメント
+
+### ユーザー向けガイド
+
+- **Skin SSS — アバター撮影**: [🇺🇸 en](docs/specs/skin-sss-user-guide.md) · [🇯🇵 ja](docs/specs/skin-sss-user-guide.ja.md) · [🇨🇳 zh](docs/specs/skin-sss-user-guide.zh.md)
+- **3D Stream タグ書式**: [🇺🇸 en](docs/guides/3dstream-tag-guide.en.md) · [🇯🇵 ja](docs/guides/3dstream-tag-guide.ja.md) · [🇨🇳 zh](docs/guides/3dstream-tag-guide.zh.md)
+
+### 公開技術資料 (他 SL Viewer 開発者向け)
+
+SL Viewer 全体に共通する bug と AYAstorm が採用した修正を、LL 派生 Viewer fork が PR 不要で自由に取込めるよう公開仕様として公開しています。
+
+- **Rigged Mesh Picker — GPU object-ID buffer**: [🇺🇸 en](docs/specs/rigged-mesh-picker-gpu-buffer.md) · [🇯🇵 ja](docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) · [🇨🇳 zh](docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+- **Double Alpha Block — forward alpha BLEND 修正** (公開用専用ブランチ): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md) · [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md) · [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+
+---
+
 ## ダウンロード
 
 最新版のビルド済みバイナリは **[GitHub Releases](https://github.com/mayatonton/phoenix-firestorm/releases/latest)** からダウンロードできます。

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ Configurable from Preferences → Chat → Chat Windows tab.
 
 ---
 
+## Documentation
+
+### User guides
+
+- **Skin SSS — avatar photography**: [🇺🇸 en](docs/specs/skin-sss-user-guide.md) · [🇯🇵 ja](docs/specs/skin-sss-user-guide.ja.md) · [🇨🇳 zh](docs/specs/skin-sss-user-guide.zh.md)
+- **3D Stream tag format**: [🇺🇸 en](docs/guides/3dstream-tag-guide.en.md) · [🇯🇵 ja](docs/guides/3dstream-tag-guide.ja.md) · [🇨🇳 zh](docs/guides/3dstream-tag-guide.zh.md)
+
+### Open technical specifications (for other SL viewer developers)
+
+SL-viewer-wide bugs and AYAstorm's fixes — published as open specs for free adoption by any LL-derived viewer fork. No PR required, pull what you need.
+
+- **Rigged Mesh Picker — GPU object-ID buffer**: [🇺🇸 en](docs/specs/rigged-mesh-picker-gpu-buffer.md) · [🇯🇵 ja](docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) · [🇨🇳 zh](docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+- **Double Alpha Block — forward alpha BLEND fix** (separate disclosure branch): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md) · [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md) · [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+
+---
+
 ## Download
 
 Pre-built binaries are available from **[GitHub Releases](https://github.com/mayatonton/phoenix-firestorm/releases/latest)**.

--- a/README.zh.md
+++ b/README.zh.md
@@ -131,6 +131,22 @@
 
 ---
 
+## 文档
+
+### 用户使用指南
+
+- **Skin SSS — Avatar 摄影**: [🇺🇸 en](docs/specs/skin-sss-user-guide.md) · [🇯🇵 ja](docs/specs/skin-sss-user-guide.ja.md) · [🇨🇳 zh](docs/specs/skin-sss-user-guide.zh.md)
+- **3D Stream 标签格式**: [🇺🇸 en](docs/guides/3dstream-tag-guide.en.md) · [🇯🇵 ja](docs/guides/3dstream-tag-guide.ja.md) · [🇨🇳 zh](docs/guides/3dstream-tag-guide.zh.md)
+
+### 公开技术规范 (面向其他 SL Viewer 开发者)
+
+将 SL Viewer 全体共通存在的 bug 与 AYAstorm 采用的修复方案以公开规范形式公开，便于 LL 派生 viewer fork 无需 PR 自由取入。
+
+- **Rigged Mesh Picker — GPU object-ID buffer**: [🇺🇸 en](docs/specs/rigged-mesh-picker-gpu-buffer.md) · [🇯🇵 ja](docs/specs/rigged-mesh-picker-gpu-buffer.ja.md) · [🇨🇳 zh](docs/specs/rigged-mesh-picker-gpu-buffer.zh.md)
+- **Double Alpha Block — forward alpha BLEND 修复** (公开专用分支): [🇺🇸 en](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.md) · [🇯🇵 ja](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.ja.md) · [🇨🇳 zh](https://github.com/mayatonton/phoenix-firestorm/blob/fix/double-alpha-block/docs/specs/double-alpha-block-fix.zh.md)
+
+---
+
 ## 下载
 
 最新编译版可在 **[GitHub Releases](https://github.com/mayatonton/phoenix-firestorm/releases/latest)** 下载。

--- a/docs/release/ayastorm-r31-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-github-release-page.en.md
@@ -47,7 +47,7 @@ A single jump from r24 to r31 bundles six releases (r25, r26, r27, r28, r30, r31
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
-- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+- r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker
 - r28 other rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)

--- a/docs/release/ayastorm-r31-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-github-release-page.ja.md
@@ -47,7 +47,7 @@ r24 から r31 への一括移行 tag。6 release (r25 / r26 / r27 / r28 / r30 /
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
-- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+- r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker
 - r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)

--- a/docs/release/ayastorm-r31-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-github-release-page.zh.md
@@ -47,7 +47,7 @@
 
 ### Media audio
 - r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
-- r26 MOAP 3D stream implementation plan: [docs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
+- r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker
 - r28 他人 rigged picker spec: [docs/specs/ayastorm-r28-other-rigged-picker.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r28-other-rigged-picker.md)


### PR DESCRIPTION
## Summary

- r31 release-page .md 3 言語の broken link 修正: `docs/ayastorm-r26-moap-3d-stream-implementation-plan.md` → `docs/specs/...` (t-noami commit `eb6b521cb1` で `docs/specs/` 配下に移動済だった link が tag-pinned URL で 404 になっていたのを修正)
- README 3 言語に `## Documentation` セクション追加 (Features と Download の間に配置)
  - **User guides**: Skin SSS user guide / 3D Stream tag format guide
  - **Open technical specifications**: Rigged Mesh Picker (GPU object-ID buffer) / Double Alpha Block (forward alpha BLEND fix) — 他 SL viewer 開発者向け公開資料

## Test plan

- [x] tag-pinned URL 7 件 すべて HTTP 200 (`v7.2.4-ayastorm-r31+bundle-fs.80646` 配下)
- [x] disclosure branch URL 3 件 すべて HTTP 200 (`fix/double-alpha-block` 配下)
- [x] Draft release body も同時に修正済 (broken link fix + `## Public disclosure: double alpha-block fix` セクション復元) — `gh release edit` で live 適用済、本 PR merge 後に repo .md と整合
- [ ] GitHub UI 上で README プレビュー確認
- [ ] release-page .md 3 言語の `## Public disclosure` セクションが既存 line 57-64 のまま維持されているか目視確認