### PR TITLE
fix: r31 login panel version string r24→r31

### DIFF
--- a/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
+++ b/indra/newview/skins/default/xui/en/panel_fs_nui_login.xml
@@ -49,7 +49,7 @@
       width="970"
       min_width="970"
       height="152">
-  <!-- <FS:AYA> [r20 login branding] AYAstorm logo (4/5 of original 125px) + identifier text -->
+  <!-- <FS:AYA> [r31 login branding] AYAstorm logo (4/5 of original 125px) + identifier text -->
   <icon
     height="100"
     width="100"
@@ -66,7 +66,7 @@
     halign="center"
     text_color="EmphasisColor"
     name="aya_brand_line1">
-AYAstorm r24
+AYAstorm r31
   </text>
   <text
     left="0"


### PR DESCRIPTION
## Summary

- PR #108 で strings.xml の About ヘッダーは r20→r31 に更新したが、ログイン画面の hardcode 版数表示 (panel_fs_nui_login.xml の `aya_brand_line1`) が `AYAstorm r24` のまま残っていたのを r31 に修正
- 他言語版 panel_fs_nui_login.xml は `aya_brand` セクションを持たず en/ にフォールバックするため、en/ のみ修正で全言語に反映される

## Test plan

- [ ] AYAstorm を起動し、ログイン画面左上の AYAstorm ロゴ下に `AYAstorm r31` と表示されることを確認
- [ ] 言語設定を ja / zh 等に切替えてもログイン画面の版数表示が `AYAstorm r31` であることを確認 (en fallback)