### PR TITLE
docs: r31 release page の r25 parcel music リンク切れ修正

### DIFF
--- a/docs/release/ayastorm-r31-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-github-release-page.en.md
@@ -46,7 +46,7 @@ A single jump from r24 to r31 bundles six releases (r25, r26, r27, r28, r30, r31
 - Skin SSS user guide (avatar photography): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
-- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r25 parcel music Ogg Vorbis investigation: [docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
 - r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker

--- a/docs/release/ayastorm-r31-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-github-release-page.ja.md
@@ -46,7 +46,7 @@ r24 から r31 への一括移行 tag。6 release (r25 / r26 / r27 / r28 / r30 /
 - Skin SSS ユーザーガイド (アバター撮影向け): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
-- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r25 parcel music Ogg Vorbis investigation: [docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
 - r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker

--- a/docs/release/ayastorm-r31-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-github-release-page.zh.md
@@ -46,7 +46,7 @@
 - Skin SSS 使用指南 (面向 avatar 摄影): [docs/specs/skin-sss-user-guide.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.md) / [.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.ja.md) / [.zh.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/skin-sss-user-guide.zh.md)
 
 ### Media audio
-- r25 parcel music Ogg Vorbis investigation: [docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
+- r25 parcel music Ogg Vorbis investigation: [docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r25-parcel-music-ogg-vorbis-investigation.md)
 - r26 MOAP 3D stream implementation plan: [docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31+bundle-fs.80646/docs/specs/ayastorm-r26-moap-3d-stream-implementation-plan.md)
 
 ### UX & picker


### PR DESCRIPTION
## Summary
- `docs/release/ayastorm-r31-github-release-page.{en,ja,zh}.md` の 49 行目で r25 parcel music Ogg Vorbis investigation 資料へのリンクが `docs/ayastorm-r25-...` を指していたが、実ファイルは `docs/specs/ayastorm-r25-...` にあるため 404 だった
- 3 言語とも同一行を `docs/specs/...` に修正
- r26 MOAP 資料のリンクは過去に同じパターンの修正が r26 だけ入っていたので、今回 r25 を揃える形

## Test plan
- [ ] HEAD で 3 ファイルの 49 行目が `docs/specs/...` になっていることを確認
- [ ] Merge 後、HEAD の release-page md からリンクをクリックして 200 になることを確認
- [ ] GitHub Release 本文 (タグ `v7.2.4-ayastorm-r31+bundle-fs.80646`) 側の同じリンクも別途 edit 必要 (こちらは PR では直せない)