### PR TITLE
fix: SSS dispatch 前倒しで FullBright 越し pink bleed 解消

### DIFF
--- a/docs/specs/ayastorm-environment-rendering-routing.md
+++ b/docs/specs/ayastorm-environment-rendering-routing.md
@@ -1,0 +1,483 @@
+# AYAstorm Environment Rendering Routing リファレンス
+
+**作成日**: 2026-05-25 (effect 軸地図シリーズ 4 本目: SSS / FullBright / Glow / 環境 のうち「環境」)
+**対象**: 環境 (Sky / Cloud / Water / Terrain) が deferred pipeline で踏む **全描画 path** の確定マップ。「装着物」「Rez Object」が `mAttachedToAvatar` 軸でオブジェクトを切ったのに対し、本書は **環境系 pool** という別軸 (オブジェクト軸ではなく effect 軸) で 4 種をまとめた。
+**作成経緯**: 「FullBright prim 越しに sky が透ける」bug (r30 BD改善期、commit `4188880321` "Fix sky emissive alpha blending") が即修正できた一方、続く「FullBright prim 越しに SSS pink shadow が漏れる」bug の前哨戦として、sky/cloud/water/terrain 描画ルートを地図化しておけば類似 bug の予防/解析に効く、という動機。
+
+> **再利用方針**: 環境描画系を触る前 (例: sky shader に何か注入する / water reflection に何か乗せる / terrain blend を変える / SSS や FullBright と環境の干渉を追う) に **まず本書を参照**。pool 配線や pass 順序が code 変更で動く可能性があるので、本書の年月日より新しい commit が `pipeline.cpp` の `renderGeomDeferred` / `renderGeomPostDeferred` / `LLDrawPoolWLSky` / `LLDrawPoolWater` / `LLDrawPoolTerrain` 周辺に入っていたら本書の更新要否を確認すること。
+
+---
+
+## 0. 結論先出し (4 種を貫く構造的特徴 3 行)
+
+1. **Sky / Cloud / Sun / Moon / Star は全て LLDrawPoolWLSky 単一 pool に収束する** (`LLDrawPoolSky` は deprecated stub、`LLVOSky` 自体は POOL_SKY に face を生やすが実描画は `LLDrawPoolWLSky::renderDeferred` 経由で `gSky.mVOSkyp` の face を直叩き)。**そして sky pass は `endDeferredPass()` で `glClear(GL_DEPTH_BUFFER_BIT)` を呼んで描画直後に depth を全消去する** (`lldrawpoolwlsky.cpp:92`) — 「sky の depth は haze/post に持ち越されない」が本 pipeline の前提。FB 透け bug の鍵だった部分。
+2. **Water は 2 段構え RT 系統**: ① `mWaterDis` (画面サイズ、color+depth、毎フレーム水面を描く直前に画面 color と deferred depth を copy して refraction 入力にする) ② `mHeroProbeRT` + Hero Reflection Probe cubemap (mirror flip の古典 reflection は廃止、`RenderMirrors` 有効時のみ `LLHeroProbeManager::renderProbes` で水面位置 cubemap を 6 面更新)。**従来の `mWaterRef` は code から消えており**、水面反射は cubemap reflection probe に統一されている。
+3. **Terrain は普通の opaque pool だが、上の 3 種 (sky/cloud/water) と違い `mAttachedToAvatar` / `mIsBoMBodyOrHead` 等の per-draw flag を経由しない**。LLDrawInfo を作らず `mDrawFace` を直叩きする face-iter pattern。装着物資料 / Rez Object 資料の canary uniform 配線は terrain には届かない (= 環境系を識別したいなら本書側で別 uniform を設計する必要)。
+
+**FB 透け bug が即修正できた理由 (構造観察)**: §A.2 の「sky `frag_data[3].a`」を `0.0` から `1.0` に戻すだけで済んだのは、sky の write 先 attachment と blend mode が **opaque path で完結している** ため。深い trace 不要だった。一方 SSS 漏れは同じ `gbuffer3.a` を SSS mask として再利用しており、sky が `0` を書く必要がある (alpha leak で SSS 誤発火) — つまり同じ 1bit に **2 つの意味** (MRT blend alpha / SSS skin mask) が乗っており、これが透過装飾物との干渉を生む。詳細 §A.6。
+
+---
+
+## 1. オブジェクト → Pool → Shader 早見表 (4 種全表)
+
+| 環境種別 | LLVO クラス | Pool (`lldrawpool.h:57-79`) | Bound shader (fragment) | 描画関数 |
+|---|---|---|---|---|
+| **Sky dome (haze / atmospheric)** | `LLVOWLSky` + `LLVOSky` | `POOL_WL_SKY` (= 3) | `class1/deferred/skyF.glsl` (WL preset) / `gEnvironmentMapProgram` (HDRI sky 時) | `LLDrawPoolWLSky::renderSkyHazeDeferred` (`lldrawpoolwlsky.cpp:143`) |
+| **Cloud (2D + AYAstorm r18 volumetric)** | `LLVOWLSky` (drawDome 共用) | `POOL_WL_SKY` (= 3) | `class1/deferred/cloudsF.glsl` | `LLDrawPoolWLSky::renderSkyCloudsDeferred` (`lldrawpoolwlsky.cpp:290`) |
+| **Sun disc** | `LLVOSky` (FACE_SUN) | `POOL_SKY` (= 1) face owner だが描画は `LLDrawPoolWLSky` 経由 | `class1/deferred/sunDiscF.glsl` | `LLDrawPoolWLSky::renderHeavenlyBodies` (`lldrawpoolwlsky.cpp:354`) |
+| **Moon** | `LLVOSky` (FACE_MOON) | 同上 | `class1/deferred/moonF.glsl` | 同上 (`lldrawpoolwlsky.cpp:419`) |
+| **Stars** | `LLVOWLSky::drawStars` | `POOL_WL_SKY` (= 3) | `class1/deferred/starsF.glsl` | `LLDrawPoolWLSky::renderStarsDeferred` (`lldrawpoolwlsky.cpp:219`) |
+| **HDRI sky (Reflection probe 用)** | `gEXRImage` (texture only、geometry は sky dome 流用) | `POOL_WL_SKY` (= 3) | `class1/deferred/skyF.glsl` (`#ifdef HAS_HDRI` permutation) | sky haze と同じ関数内 `use_hdri_sky()` 分岐 (`lldrawpoolwlsky.cpp:152-175`) |
+| **Water (region + void)** | `LLVOWater` (region) / `LLVOVoidWater` (edge patch) | `POOL_WATER` (= 19) | `class3/environment/waterF.glsl` (above) / `class3/environment/underWaterF.glsl` (camera < waterHeight) | `LLDrawPoolWater::renderPostDeferred` (`lldrawpoolwater.cpp:142`) |
+| **Water exclusion mask (invisible prim占有)** | (専用 VO 無し、`PASS_INVISIBLE` batch + water plane 自体) | `POOL_WATEREXCLUSION` (= 2) | `gDrawColorProgram` (uniform color のみ) | `LLDrawPoolWaterExclusion::render` (`lldrawpoolwaterexclusion.cpp:43`) |
+| **Water haze (sky 由来の遠景 fog 適用)** | (専用 VO 無し、screen-space pass) | (pool 外、`doWaterHaze()` 直接 dispatch) | `class3/deferred/waterHazeV.glsl` + `waterHazeF.glsl` (`gHazeWaterProgram`) | `LLPipeline::doWaterHaze` (`pipeline.cpp:11923`) |
+| **Legacy terrain (4-texture splat)** | `LLVOSurfacePatch` | `POOL_TERRAIN` (= 8) | `class1/deferred/terrainF.glsl` | `LLDrawPoolTerrain::renderDeferred` → `renderFullShaderTextures` (`lldrawpoolterrain.cpp:147`) |
+| **PBR terrain** | `LLVOSurfacePatch` | `POOL_TERRAIN` (= 8) | `class1/deferred/pbrterrainF.glsl` (`gDeferredPBRTerrainProgram[paint_type]`) | `LLDrawPoolTerrain::renderDeferred` → `renderFullShaderPBR` (`lldrawpoolterrain.cpp:147`) |
+
+参考 (本書 scope 外、Rez Object 資料 §0 で「Rez Object に含まれないもの」として除外されている):
+- **Grass** — `LLDrawPoolGrass` (POOL_GRASS = 9)、Linden grass
+- **Particles** — alpha pool 内分岐
+
+---
+
+## 2. 描画順序 (deferred pipeline 全体マップ)
+
+pool 番号 (`lldrawpool.h:57-79`) は **render order** も兼ねている。コメント (`lldrawpool.h:52-55`): *"Correspond to LLPipeline render type. Also controls render order, so passes that don't use alpha masking/blending should come before other passes to preserve hierarchical Z for occlusion queries."*
+
+### 2.1 `LLPipeline::renderGeomDeferred` (`pipeline.cpp:5039`) で走る pool (= gbuffer/Z 書き込み)
+
+順序は pool 番号順:
+
+| 順 | Pool | 環境系? | 備考 |
+|---|---|---|---|
+| 1 | `POOL_SKY` (= 1) | (sky face owner) | `LLDrawPoolSky` は **deprecated stub** (`lldrawpoolsky.cpp` 全関数空)、実描画なし |
+| 2 | `POOL_WATEREXCLUSION` (= 2) | **環境** | `gDrawColorProgram` で water plane を depth-only マスクとして書く (実 color は後段で上書き) |
+| 3 | **`POOL_WL_SKY` (= 3)** | **環境 (sky / cloud / sun / moon / star 全部)** | `LLDrawPoolWLSky::renderDeferred` (`lldrawpoolwlsky.cpp:471`) — sky haze → 太陽/月 → 星 → 雲 の順 |
+| 4 | `POOL_SIMPLE` (= 4) | — | (Rez Object / 装着物の opaque) |
+| ... | (5〜7: FULLBRIGHT / BUMP / MATERIALS / GLTF_PBR) | — | |
+| 8 | **`POOL_TERRAIN` (= 8)** | **環境** | `LLDrawPoolTerrain::renderDeferred` (`lldrawpoolterrain.cpp:147`) — legacy or PBR terrain |
+| 9 | `POOL_GRASS` (= 9) | (環境扱いだが本書 scope 外) | occlusion query の境界 (`pipeline.cpp:5109` で `cur_type >= POOL_GRASS` で occlusion off) |
+| 10〜18 | (mask alpha / tree / avatar / glow / 等) | — | |
+| 19 | **`POOL_WATER` (= 19)** | **環境** | renderDeferred では描かない (getNumDeferredPasses=0)、POST に回る |
+
+**観察**: sky/cloud/star/sun/moon が **pool 番号 3** = 早い段階で描かれる。terrain は 8、water は 19。**occlusion query の境界が POOL_GRASS (9)** で、sky/cloud (3) / terrain (8) は occlusion 対象外。
+
+### 2.2 `LLPipeline::renderGeomPostDeferred` (`pipeline.cpp:5178`) で走る pool (= forward 合成)
+
+順序は pool 番号順、ただし **special pass** が間に挟まる:
+
+| 順 | Pool / Special pass | 環境系? | 備考 |
+|---|---|---|---|
+| (special) | **`doWaterExclusionMask()`** (`pipeline.cpp:5238`、`cur_type >= POOL_WATEREXCLUSION` で 1 度だけ) | **環境** | `mWaterExclusionMask` RT に water plane mask を書く |
+| (special) | **`doAtmospherics()`** (`pipeline.cpp:5244`、`cur_type >= POOL_ALPHA_POST_WATER` で 1 度だけ。**ただし `sUnderWaterRender` 時は `POOL_WATER` に前倒し**) | **環境** | screen + deferred depth を `mWaterDis` にコピー → `gHazeProgram` でフルスクリーン haze blend |
+| (special) | **`doGodrays()` / `doSkinSSS()`** (AYAstorm r15 / r20、`pipeline.cpp:5256-5263`) | (補助) | atmospherics 同タイミングで HDR scene buffer に追加 effect |
+| (special) | **`doWaterHaze()`** (`pipeline.cpp:5269`、`cur_type >= POOL_ALPHA_PRE_WATER` で 1 度だけ) | **環境** | water plane 形状で fog を water plane に焼く (`gHazeWaterProgram`) |
+| | `POOL_ALPHA_PRE_WATER` (= 17) | — | water より手前の alpha |
+| | `POOL_VOIDWATER` (= 18) | — | (POOL_WATER と同 shader で renderPostDeferred、edge patch) |
+| | **`POOL_WATER` (= 19)** | **環境** | `LLDrawPoolWater::renderPostDeferred` (`lldrawpoolwater.cpp:142`) — 水面 forward 合成 |
+| | `POOL_ALPHA_POST_WATER` (= 20) | — | water より奥の alpha (透過装着物の大半) |
+
+**観察**: water は POST の最後の方で forward 描画される (alpha 前後で挟む)。`POOL_WATER` の renderPostDeferred 前の `beginPostDeferredPass` で **screen color + depth を `mWaterDis` にコピー** (`lldrawpoolwater.cpp:111-140`、`LLPipeline::sRenderTransparentWater` 時) — これが refraction 入力。
+
+---
+
+## 3. Hero Reflection Probe (= 水面反射の現代版)
+
+旧 `mWaterRef` ベースの mirror-flip planar reflection は **削除済**。水面反射は `LLHeroProbeManager` (`llheroprobemanager.cpp`) が管理する **動的 cubemap reflection probe** に統一されている。
+
+### 3.1 起動条件
+
+- `RenderMirrors` cvar が ON (`pipeline.cpp:1566`)
+- `LLPipeline::sReflectionProbesEnabled` が ON
+- `gSnapshot` でない (`llviewerdisplay.cpp:827`)
+
+### 3.2 dispatch 地点 (`llviewerdisplay.cpp:832`)
+
+main `display()` の **scene 本描画より前**:
+
+```cpp
+if (gPipeline.RenderMirrors && !gSnapshot)
+{
+    gPipeline.mHeroProbeManager.update();
+    gPipeline.mHeroProbeManager.renderProbes();
+}
+```
+
+### 3.3 1 フレームあたりの更新量 (`llheroprobemanager.cpp:265-292`)
+
+- `RenderHeroProbeUpdateRate` で 1/2/3/6 のいずれかの rate
+- 1 フレームで `6 / rate` 面更新 (= rate=6 なら 1 面/frame、rate=1 なら 6 面/frame)
+- 6 面更新後 `generateRadiance()` で mip + roughness convolution
+- update 時は `gCubeSnapshot = true` (`llviewerwindow.cpp:6754`) と `gPipeline.mRT = &mHeroProbeRT` (`llheroprobemanager.cpp:319`) に切替
+
+### 3.4 cubemap 描画で実際に呼ばれるもの
+
+`LLReflectionMap::update` → `gViewerWindow->cubeSnapshot` → `display_cube_face` → 内部で **通常の `display()` 相当の scene render** を 1 face 分回す (camera を 90° 回転 6 方向)。よって:
+
+- **sky / cloud / sun / moon / star / terrain / water 全て probe にも描かれる**
+- ただし **cloud は `gCubeSnapshot && !isRadiancePass()` で skip** される ケースあり (`lldrawpoolwlsky.cpp:495`、irradiance map の popping 回避)
+- **HDRI sky は probe では強制的に使われる** (`lldrawpoolwlsky.cpp:137`、reflection probe の屋根が HDRI image になる)
+
+### 3.5 注意点 (類似 bug 候補)
+
+water reflection で類似 bug が起きそうな場所は **probe 内の sky depth 扱い**:
+
+- probe 内でも `LLDrawPoolWLSky::endDeferredPass` の `glClear(GL_DEPTH_BUFFER_BIT)` が走る (= sky の depth は probe 内でも捨てる)
+- probe の screen output は cubemap face → mip chain → roughness convolution を経由するので、**sky `frag_data[3].a` の値は post-process 経由で probe color に乗る**可能性がある (要確認 — 推測)
+- 「FB prim 越しに sky 透け」と同じ機構が **反射映像内でも起きうる**: 水面に映る FB 看板の縁から sky 色が滲む等。**ただし実観測は未確認、本書時点では理論上の警告のみ**
+
+---
+
+## A. Sky 章 (空 / 太陽 / 月 / 星 / 雲は全部 LLDrawPoolWLSky)
+
+### A.1 Sky dome geometry の生成
+
+| 関数/場所 | 役割 |
+|---|---|
+| `LLVOWLSky::createDrawable` (`llvowlsky.cpp:95`) | `RENDER_TYPE_WL_SKY` 設定 |
+| `LLVOWLSky::drawDome` (`llvowlsky.cpp:311`) | sky/cloud 共用 dome geometry を発行 |
+| `LLVOWLSky::drawStars` (`llvowlsky.cpp:286`) | star geometry (8000 点程度の billboard) を発行 |
+| `LLVOSky::createDrawable` (`llvosky.cpp:842`) | `POOL_SKY` (deprecated stub) に face 登録、FACE_SUN/MOON/BLOOM 用 face を作る |
+| `LLDrawPoolWLSky::renderDome` (`lldrawpoolwlsky.cpp:95`) | local camera coord 系で dome を回転・スケール (Y-up に permute) して `gSky.mVOWLSkyp->drawDome()` |
+
+**観察**: sky dome は WL coord 系 (Y up) で描画するため `gGL.rotatef(120°, 1/√3, 1/√3, 1/√3)` で軸 permute する (`lldrawpoolwlsky.cpp:115`)。reflection render 時 `camPosLocal.z > 256` だと z 半分に圧縮 (`lldrawpoolwlsky.cpp:103-105`)。
+
+### A.2 Sky 描画順序 (LLDrawPoolWLSky::renderDeferred、`lldrawpoolwlsky.cpp:471`)
+
+```
+1. renderSkyHazeDeferred (sky dome、HDRI or WL)
+2. renderHeavenlyBodies   (太陽 → 月)
+3. renderStarsDeferred    (星、ただし gCubeSnapshot 時はスキップ)
+4. renderSkyCloudsDeferred (雲、ただし gCubeSnapshot && !isRadiancePass 時はスキップ)
+```
+
+### A.3 各 shader の depth / blend / gbuffer
+
+| Shader | GL state クラス | depth test | depth write | blend | frag_data[0/1/2/3] | gbuffer flag |
+|---|---|---|---|---|---|---|
+| `skyF.glsl` (haze) | `LLGLSPipelineDepthTestSkyBox(true, true)` (`lldrawpoolwlsky.cpp:181`) | **ON** | **ON** | OFF | `[0]=vec4(color,1)` (HAS_EMISSIVE 時は `vec4(0)`) / `[1]=0` / `[2]=(0,0,0,SKIP_ATMOS)` (HDRI 時は `HAS_HDRI`) / `[3]=(color, 1.0)` (HAS_EMISSIVE 時、AYAstorm `4188880321` で `0.0`→`1.0` に戻し) | `SKIP_ATMOS` (= 0.0) / `HAS_HDRI` (= 1.0) |
+| `cloudsF.glsl` | `LLGLSPipelineBlendSkyBox(true, true)` (`lldrawpoolwlsky.cpp:301`) + `BT_ALPHA` | **ON** | **ON** | **ON (alpha blend)** | `[0]=(color, alpha1)` / `[1]=0` / `[2]=(0,0,0,SKIP_ATMOS)` / `[3]=(color, alpha1)` (HAS_EMISSIVE 時) | `SKIP_ATMOS` |
+| `sunDiscF.glsl` | `LLGLSPipelineBlendSkyBox(true, true)` (`lldrawpoolwlsky.cpp:358`) | ON | **ON** | ON (alpha blend) | `[0]=c` / `[1]=0` / `[2]=(0,1,0,SKIP_ATMOS)` / `[3]=(c.rgb, 0.0)` (HAS_EMISSIVE 時、SSS leak 防止で `0.0`) | `SKIP_ATMOS` |
+| `moonF.glsl` | 同上 | ON | **ON** (SL-14113 注: moon は depth 書く、stars を月の奥に追いやるため) | ON (alpha blend) | `[0]=(c.rgb, c.a)` / `[1]=0` / `[2]=(0,0,0,SKIP_ATMOS)` / `[3]=(c.rgb, 0.0)` (HAS_EMISSIVE 時) | `SKIP_ATMOS` |
+| `starsF.glsl` | `LLGLSPipelineBlendSkyBox(true, false)` + `BT_ADD_WITH_ALPHA` (`lldrawpoolwlsky.cpp:226-228`) | ON | **OFF** | **ON (additive)** | `[0]=col` / `[1]=0` / `[2]=(0,1,0,SKIP_ATMOS)` / `[3]=(col.rgb, 0.0)` (HAS_EMISSIVE 時) | `SKIP_ATMOS` |
+| `skyF.glsl` (HDRI 経路、`use_hdri_sky()` true) | 同 haze | ON | ON | OFF | `[2]=(0,0,0,HAS_HDRI)` 以外は haze と同じ | `HAS_HDRI` |
+
+**重要観察 (sky が透ける bug の鍵)**:
+1. **sky haze は `frag_data[0]` を `vec4(0)` で書き、実色は `frag_data[3]` (= emissive RT) に乗せる** (`HAS_EMISSIVE` permutation 経路、`skyF.glsl:122-133`)。これは r20 SSS で gbuffer3.a を skin mask に流用するための spec C 策。
+2. AYAstorm r30 BD改善期に「skin mask 誤発火」防止で **sky は `frag_data[3].a = 0` を書いていた** が、その後 commit `4188880321` ("Fix sky emissive alpha blending") で `frag_data[3].a = 1.0` に戻された。理由: **gbuffer3 attachment の MRT blend は `.a` を blend factor に使う構成があり、sky pixel が `.a=0` だと後段 FullBright 等の forward additive で sky 色が消滅 → 「FB 越しに sky が透ける」 = 正確には「FB 描画時に sky 色が乗らない」表現として観測**。
+3. 同じ 1bit (`gbuffer3.a`) を「MRT blend alpha」と「SSS skin mask」の 2 意味で再利用しているため、片方を立てるともう片方が壊れる構造。本書時点では sky は `.a=1`、SSS 側で「gbuffer flag が SKIP_ATMOS なら skin_mask 無視」の方向で gate する設計 (`cloudsF.glsl:159-163` のコメント参照)。
+
+### A.4 Sky 描画 *直後* の depth clear (= 重要)
+
+`LLDrawPoolWLSky::endDeferredPass` (`lldrawpoolwlsky.cpp:84-93`):
+
+```cpp
+void LLDrawPoolWLSky::endDeferredPass(S32 pass)
+{
+    sky_shader = cloud_shader = sun_shader = moon_shader = nullptr;
+    // clear the depth buffer so haze shaders can use unwritten depth as a mask
+    glClear(GL_DEPTH_BUFFER_BIT);
+}
+```
+
+**意味**:
+- sky / sun / moon / cloud は depth を書く (table A.3 参照) が、**pool 終端で depth を全消去**
+- 以降の opaque pool (simple/bump/material/terrain) は **depth = 1.0 (= 最遠)** の状態から始まる
+- atmospherics / haze pass は「depth buffer に書き込まれていない pixel」(= 後続 opaque が描かなかった = sky 領域) を sky としてマスクできる
+- これにより `doAtmospherics()` の haze blend は sky 領域以外にしか乗らない
+
+**FB 透け bug が即修正できた理由 (構造観察)**:
+- sky の visible color は `frag_data[3]` (emissive RT) に書かれている
+- sky の depth は pool 終端で消されるので、FB prim は通常 depth test を pass して sky 領域に書ける
+- bug は **「FB prim の forward blend で sky 色 (emissive RT) と合成する際、MRT blend factor `.a` が `0` だと sky 色が乗らない」** という単純な MRT blend 構成問題
+- 修正は shader 1 行 (`vec4(color.rgb, 0.0)` → `vec4(color.rgb, 1.0)`)
+- これが **「対称な深堀り trace 不要で即修正できた」理由**。一方 SSS 漏れは同 `.a` を SSS mask として 再使用するため修正が分岐する → 前哨戦の bug の方が単純だった
+
+### A.5 WindLight / EEP 設定の uniform 流入経路
+
+| Uniform 名 | source (`lldrawpoolwlsky.cpp`) | 流入 |
+|---|---|---|
+| `camPosLocal` | line 122 | `renderDome` 内で local camera coord |
+| `moisture_level` / `droplet_radius` / `ice_level` | lines 204-206 | `LLEnvironment::instance().getCurrentSky()` (= `LLSettingsSky`) |
+| `sun_moon_glow_factor` | line 208, 342 | 同上 |
+| `sun_up_factor` | line 210 | `psky->getIsSunUp()` |
+| `blend_factor` | lines 268, 340, 407 | sky preset blend (EEP cross-fade) |
+| `cloud_variance` | line 341 | preset |
+| `aya_r18_cloud_volumetric_enabled` / `aya_r18_strength` | `cloudsF.glsl:44-45` | AYAstorm r18 cvar (`AYAR18CloudVolumetricEnabled` 系)、`mShaderList` 配下なので `mShaderList` walk で自動 push |
+| `sky_hdr_scale` | line 172 | `RenderHDRIExposure` (HDRI sky 時のみ) |
+| `hdri_split_screen` | line 174 | `RenderHDRISplitScreen` |
+| `moon_brightness` / `moonlight_color` / `moon_dir` | lines 453-457 | preset |
+
+### A.6 SSS / FullBright と sky の干渉 (= 本書動機)
+
+| bug | 原因 | 修正 |
+|---|---|---|
+| **FB 越し sky 透け** (FB prim の forward blend で sky 色が消える) | `skyF.glsl` の `frag_data[3].a = 0.0` (AYAstorm 期に SSS 用に書いていた値) が MRT blend factor として消し色になっていた | `frag_data[3].a = 1.0` に戻し (commit `4188880321`) |
+| **FB 越し SSS pink 漏れ** (FB 描画 path の縁から SSS skin tint が滲む) — **本書執筆時点で未修正の bug** | 同じ `gbuffer3.a` を skin_mask に使っているため、sky `.a=1.0` 化で skin_mask が誤発火する側に振れた可能性。または cloud/moon/star の `.a=0` と FB pixel の MRT blend の組み合わせ要因。**要追加調査** | (未) |
+
+**構造的教訓**: `gbuffer3.a` (= emissive RT alpha) は **(1) MRT blend factor として OpenGL に解釈される / (2) SSS shader で skin mask として再 sample される** の 2 用途で取り合いになっている。1bit に 2 意味は持続不可能なので、長期的には **SSS skin mask を `gbuffer3.a` から分離する** ($→$ 別 RT or stencil bit に移す) 設計改修が必要。
+
+### A.7 Sky 関連 shader writer 一覧 (再掲)
+
+`ayastorm-gbuffer3-trace.md` §A から sky 系のみ抽出:
+
+| Shader | `frag_data[3].a` (HAS_EMISSIVE 時) | コメント |
+|---|---|---|
+| `skyF.glsl` | **`1.0`** (commit `4188880321` 以降) | 元 AYAstorm r30 期は `0.0`、FB 透け bug で revert |
+| `cloudsF.glsl` | `alpha1` (cloud 自身の opacity) | r30 P3.8 で `0.0` 試行 → 雲消失 → `alpha1` に戻し (commit `6ae5f9bf1c` / `b2decf0578`) |
+| `moonF.glsl` | `0.0` | 月縁の skin_mask 誤発火防止 |
+| `starsF.glsl` | `0.0` | 星点の skin_mask 誤発火防止 |
+| `sunDiscF.glsl` | `0.0` | 太陽縁の skin_mask 誤発火防止 |
+
+**観察**: sky (`1.0`) と cloud (`alpha1`) **だけ** が「MRT blend alpha としての正しい値」を維持。sun/moon/star は「SSS skin mask gate のために 0」を維持 — 同じ「sky 系」でも 2 派に分かれており、これは SSS と FullBright の取り合いで継続的に振動する可能性がある領域。
+
+---
+
+## B. Cloud 章
+
+### B.1 Cloud は何で描かれているか
+
+| 観点 | 実装 |
+|---|---|
+| Geometry | `LLVOWLSky::drawDome()` (`llvowlsky.cpp:311`) — sky dome geometry を **そのまま** cloud にも使う (別 mesh ではない) |
+| Shader | `cloudsV.glsl` + `cloudsF.glsl` (`gDeferredWLCloudProgram`) |
+| Pool | `POOL_WL_SKY` (sky と同 pool) |
+| 描画関数 | `LLDrawPoolWLSky::renderSkyCloudsDeferred` (`lldrawpoolwlsky.cpp:290`) |
+| 描画順 | renderDeferred 内で **sky haze → 天体 → 星 → 雲** (最後) |
+| Volumetric? | **基本 2D noise (`cloud_noise_texture` を sky dome 上に貼る)**。**AYAstorm r18 で slab raymarch 4-step の疑似 volumetric を追加** (`cloudsF.glsl:108-130`、`aya_r18_cloud_volumetric_enabled` cvar で opt-in、`aya_r18_strength` で legacy ↔ volumetric を lerp) |
+| Sprite cloud? | (なし、SL 標準には sprite cloud は無い。雲は全て sky dome に焼く 2D noise) |
+| Cloud shadow shader? | (個別 shader 無し、地上への shadow 投影は sun shadow map 経由で間接的) |
+
+### B.2 Cloud の blend / depth
+
+(table A.3 再掲)
+- depth test ON / depth write **ON** (`LLGLSPipelineBlendSkyBox(true, true)`)
+- blend ON (`BT_ALPHA`)
+- AYAstorm r18 volumetric は **shader 内部処理のみ**、render state は変えない
+
+### B.3 Reflection probe 時の cloud 抑制
+
+`lldrawpoolwlsky.cpp:495`:
+
+```cpp
+if (!gCubeSnapshot || gPipeline.mReflectionMapManager.isRadiancePass())
+{
+    renderSkyCloudsDeferred(origin, camHeightLocal, cloud_shader);
+}
+```
+
+**意味**: irradiance pass (= reflection probe の diffuse 用 1 段目) では雲を描かない (popping 回避)。radiance pass (= specular 用 2 段目) では描く。
+
+---
+
+## C. Water 章
+
+### C.1 関連 class
+
+| Class | 役割 |
+|---|---|
+| `LLDrawPoolWater` (`lldrawpoolwater.cpp`) | POOL_WATER の本体。**renderPostDeferred のみ実装**、renderDeferred は無 |
+| `LLDrawPoolWaterExclusion` (`lldrawpoolwaterexclusion.cpp`) | POOL_WATEREXCLUSION、water plane の depth-only mask 生成 |
+| `LLVOWater` | region water (各 SIM の 256x256 water plane) |
+| `LLVOVoidWater` (`mIsEdgePatch=true`) | void water (region 外の edge patch) |
+
+旧 `LLDrawPoolAlphaWater` は code から消えており、本書時点では `POOL_ALPHA_PRE_WATER` / `POOL_ALPHA_POST_WATER` という **alpha pool の前後配置** で「水の手前/奥」を分ける構成に移行済。
+
+### C.2 Water shader 全列挙
+
+| Shader | bind 先 | 用途 |
+|---|---|---|
+| `class3/environment/waterF.glsl` | `gWaterProgram` | 通常の water surface (camera 水面上) |
+| `class3/environment/underWaterF.glsl` | `gUnderWaterProgram` | camera が水中時の water surface (見上げる側) |
+| `class1/environment/waterV.glsl` | 共用 vertex shader | |
+| `class1/environment/waterFogF.glsl` | (forward 物体に link、water fog 計算 helper) | water に沈んでいる物体への水中 fog 適用 |
+| `class3/deferred/waterHazeF.glsl` + `waterHazeV.glsl` | `gHazeWaterProgram` | water 上 fog 描画 (`doWaterHaze` 経由)、water surface 形状で fog を焼く |
+| `gWaterEdgeProgram` (※ 過去版に存在、現在は `gWaterProgram` 統合) | — | edge patch 専用 — 2025-02-11 Geenz により region water と統合され削除 |
+
+**permutation**:
+- `TRANSPARENT_WATER` (1) — `sRenderTransparentWater` ON 時、`screenTex` + `depthMap` 経由で refraction
+- `HAS_SUN_SHADOW` (1) — sun shadow map 有効時
+
+### C.3 Reflection RT / Refraction RT
+
+#### 現代版 (2026-05-25 時点)
+
+| RT | サイズ | 用途 | 生成 |
+|---|---|---|---|
+| **`mWaterDis`** (`pipeline.h:987`) | 画面 resolution | **refraction 入力** (= water 越しの色 + depth) | `pipeline.cpp:1230` で確保。毎フレーム `LLDrawPoolWater::beginPostDeferredPass` (`lldrawpoolwater.cpp:111-140`) で screen color + deferred depth を copy。**transparent water OFF 時は scratch space としてのみ確保** |
+| **`mWaterExclusionMask`** | (要確認、おそらく画面 resolution) | water plane の mask (内側=反射対象 / 外側=透過対象) | `doWaterExclusionMask` (`pipeline.cpp:12007-12016`) で `gDrawColorProgram` 使って water plane を白で塗る |
+| **`mHeroProbeRT.screen / .deferredScreen / .deferredLight`** | `RenderHeroReflectionProbeResolution` (デフォルト 512?) | **水面 reflection probe の per-face render target** | `pipeline.cpp:1062-1064` で `RenderMirrors` ON 時のみ。Hero probe update 時に `gPipeline.mRT = &mHeroProbeRT` に hot-swap (`llheroprobemanager.cpp:319`) |
+| **Hero probe cubemap (`mProbes[0]->mCubeArray`)** | probe resolution の cubemap | 水面に映る 360° 環境マップ | 6 面分の `LLReflectionMap::update` 後 `generateRadiance` で mip chain + roughness convolution |
+
+#### 旧版 (削除済)
+
+- `mWaterRef` (planar mirror flip reflection texture) — **本書時点で code に存在しない**。Hero probe に置き換え済
+
+### C.4 Planar reflection pass のトレース
+
+**「水面に映る空 / アバター / 装飾物」がどの pool で描かれているか**:
+
+1. `display()` 冒頭で `gPipeline.mHeroProbeManager.renderProbes()` (`llviewerdisplay.cpp:832`)
+2. → `LLHeroProbeManager::renderProbes()` (`llheroprobemanager.cpp:242`) — 6 面分 (1/2/3/6 face/frame)
+3. → `LLHeroProbeManager::updateProbeFace` (`llheroprobemanager.cpp:313`)
+4. → `LLReflectionMap::update` (`llreflectionmap.cpp:52`)
+5. → `gViewerWindow->cubeSnapshot` (`llviewerwindow.cpp:6640`)
+6. → `gCubeSnapshot = true` (`llviewerwindow.cpp:6754`)
+7. → `display_cube_face()` — **通常 `display()` 相当の scene render を 1 face 分**
+8. 通常 scene render なので **sky / cloud / sun / moon / star / terrain / opaque / alpha / 全部** が cubemap face に焼かれる
+9. ただし `gCubeSnapshot` を見て一部 pool が skip:
+   - `LLDrawPoolWLSky::renderDeferred` (`lldrawpoolwlsky.cpp:490-492`) — `gCubeSnapshot && !isRadiancePass` なら星 / 雲 skip
+   - `LLDrawPoolWater::renderPostDeferred` — water 自体は cubemap 内で再帰描画されない (要確認、ここは推測)
+   - HUD / particles / 一部 debug は probe では off
+
+### C.5 Water surface の depth / blend / gbuffer
+
+`LLDrawPoolWater::renderPostDeferred` (`lldrawpoolwater.cpp:142-320`):
+
+| 項目 | 値 |
+|---|---|
+| Pool | `POOL_WATER` (= 19、POST 経路で描画) |
+| Shader | `gWaterProgram` (camera 水面上) / `gUnderWaterProgram` (camera 水中) |
+| Output | `frag_color` (= single MRT、forward 出力。**gbuffer 書かない**) |
+| Depth test | ON (sUnderWaterRender ? GL_FALSE : GL_TRUE で water plane geometry を描画) |
+| Depth write | (要確認、`bindDeferredShader` 経由なので shader-side で `gl_FragDepth` 書かない) |
+| Blend | **OFF** (`LLGLDisable blend(GL_BLEND);` `lldrawpoolwater.cpp:145`) — water 自体は forward だが、`frag_color` 直接書き込みで scene color を上書き |
+| Cull | OFF (`LLGLDisable cullface(GL_CULL_FACE);` line 306) — water plane は両面描画 |
+| Gbuffer 書き込み | **無し** (= forward path、SSAO/SSR/SSS post 全部対象外) |
+
+**観察**: water surface は **opaque 扱いで forward** 描画。深さ書き込みはあるが gbuffer は無いので、water 越しに見える物体 (refraction) は `mWaterDis` から sample する側で完結している。
+
+### C.6 Water reflection RT で類似 bug 起きそうな注意点
+
+**注意 1 個: 「水面に映る FB prim の縁から sky 色が滲む」可能性**。
+
+理由:
+1. Hero probe cubemap render は **通常の scene 描画 path をそのまま走らせる**ので、§A.4 で記述した「sky 後 depth clear → FB prim が forward 合成」path も probe 内で走る
+2. `gbuffer3.a` 経由の sky color leak (§A.6) も probe 内で同様に起きる
+3. probe の出力は mip chain → roughness convolution で **平均化されるので軽症化される**が、低 roughness (= 鏡面に近い水面) では平均が効かず元の bug を保存する
+4. 修正は probe 内でも有効 (shader 共通) なので「sky の `.a=1.0`」化で同時に治っている **はず** だが、SSS leak と FB 縁の干渉は probe 経由でも残っている可能性あり — 本書時点で **実観測未確認、潜在リスクとして列挙**
+
+---
+
+## D. Terrain 章
+
+### D.1 Class / Pool
+
+| Class | 役割 |
+|---|---|
+| `LLVOSurfacePatch` (`llvosurfacepatch.cpp`) | 地形 patch (各 region を 16x16 程度に分割) を持つ VO |
+| `LLDrawPoolTerrain` (`lldrawpoolterrain.cpp`) | POOL_TERRAIN、deferred 描画 + shadow + motion blur 担当 |
+| `LLVLComposition` | region の terrain composition (4 texture + heightmap blending 設定) |
+
+### D.2 Shader
+
+| Mode | Shader | bind 先 |
+|---|---|---|
+| **Legacy 4-texture splat** (`getMaterialType() == TEXTURE`) | `class1/deferred/terrainF.glsl` (+ `class1/deferred/terrainV.glsl`) | `gDeferredTerrainProgram` |
+| **PBR terrain** (`getMaterialType() == PBR_MATERIAL`、paint_type 別) | `class1/deferred/pbrterrainF.glsl` (+ `pbrterrainUtilF.glsl`) | `gDeferredPBRTerrainProgram[paint_type]` (paint_type 0〜TERRAIN_PAINT_TYPE_COUNT-1) |
+
+`renderFullShader` (`lldrawpoolterrain.cpp:267-291`) で分岐。
+
+### D.3 Detail / Heightmap blending
+
+`terrainF.glsl:44-69` (legacy):
+
+```glsl
+vec4 color0 = texture(detail_0, vary_texcoord0.xy);
+vec4 color1 = texture(detail_1, vary_texcoord0.xy);
+vec4 color2 = texture(detail_2, vary_texcoord0.xy);
+vec4 color3 = texture(detail_3, vary_texcoord0.xy);
+
+float alpha1 = texture(alpha_ramp, vary_texcoord0.zw).a;
+float alpha2 = texture(alpha_ramp, vary_texcoord1.xy).a;
+float alphaFinal = texture(alpha_ramp, vary_texcoord1.zw).a;
+vec4 outColor = mix( mix(color3, color2, alpha2), mix(color1, color0, alpha1), alphaFinal );
+
+outColor.a = 0.0; // yes, downstream atmospherics
+```
+
+- `detail_0/1/2/3` = 4 つの detail texture (region property、低/中/高/最高高度に割当)
+- `alpha_ramp` = heightmap 由来の blend mask
+- **`outColor.a = 0.0`** に注目 — terrain は alpha 0 で `frag_data[0]` を書く (= alpha channel を haze pass の通常 atmospherics gate に使うため)
+
+### D.4 Depth / blend / gbuffer
+
+| 項目 | 値 |
+|---|---|
+| Pool | `POOL_TERRAIN` (= 8、renderDeferred で描画) |
+| Shader | `gDeferredTerrainProgram` / `gDeferredPBRTerrainProgram[paint_type]` |
+| Depth test | ON (deferred 標準) |
+| Depth write | **ON** (普通の opaque) |
+| Blend | OFF (普通の opaque) |
+| Cull | ON |
+| Gbuffer write | **`[0]=outColor(rgb,0)` / `[1]=(0,0,0,-1)` / `[2]=encodeNormal(n,0,HAS_ATMOS)` / `[3]=vec4(0)` (HAS_EMISSIVE 時)** |
+| Gbuffer flag | `HAS_ATMOS` (= 0.34) — softenLightF Legacy 分岐へ (legacy terrain)、PBR 版は `HAS_PBR` (= 0.67) |
+| Shadow pass | あり (`renderShadow` `lldrawpoolterrain.cpp:189-200`、`gDeferredShadowProgram` で depth-only) |
+| Motion blur pass | あり (r30 P2 AYAstorm 追加、`renderMotionBlur` `lldrawpoolterrain.cpp:227-246`、`gVelocityProgram`) |
+| Mirror clip | あり (`mirrorClip(pos)` 呼出、`terrainF.glsl:46`) |
+| `mirrorClip` の意味 | hero probe pass 時に water plane で discard、water に terrain が二重に映らないようにする |
+
+### D.5 Terrain と装着物 canary
+
+**terrain は LLDrawInfo を経由しない (= `mAttachedToAvatar` flag を持たない)**。`LLDrawPoolTerrain::renderFullShaderTextures` (`lldrawpoolterrain.cpp:293`) 以下は `mDrawFace` を直接 walk して `facep->renderIndexed()` するため、装着物資料 / Rez Object 資料の canary uniform は **terrain には届かない**。
+
+**結論**: terrain を識別したい (例: 環境 effect から terrain だけ除外したい / terrain だけに lit を変えたい) なら **`mAttachedToAvatar` flag 経由ではなく**、shader bind 時に shader 全体に 1 度 `aya_environment_canary = TERRAIN` を流す方式が必要 (tree pool と同じ pattern、`ayastorm-rez-object-rendering-routing.md` §3.3 を参照)。
+
+---
+
+## 4. C++ shader bind 地点の主要ファイル (sky/water/terrain)
+
+| ファイル | 関数 | 行 | 役割 |
+|---|---|---|---|
+| `lldrawpoolwlsky.cpp` | `LLDrawPoolWLSky::renderDeferred` | 471 | WL sky + cloud + sun + moon + star 全体 dispatch |
+| `lldrawpoolwlsky.cpp` | `renderSkyHazeDeferred` | 143 | sky dome (HDRI or WL) |
+| `lldrawpoolwlsky.cpp` | `renderSkyCloudsDeferred` | 290 | cloud (gCubeSnapshot で skip 制御あり) |
+| `lldrawpoolwlsky.cpp` | `renderHeavenlyBodies` | 354 | sun + moon |
+| `lldrawpoolwlsky.cpp` | `renderStarsDeferred` | 219 | star (gCubeSnapshot で skip) |
+| `lldrawpoolwlsky.cpp` | `endDeferredPass` | 84 | **`glClear(GL_DEPTH_BUFFER_BIT)`** — sky pass 終端で depth 全消去 (FB 越し sky 表現の前提) |
+| `lldrawpoolwater.cpp` | `LLDrawPoolWater::renderPostDeferred` | 142 | water surface 本描画 |
+| `lldrawpoolwater.cpp` | `beginPostDeferredPass` | 111 | `mWaterDis` への screen color + depth copy |
+| `lldrawpoolwater.cpp` | `pushWaterPlanes` | 322 | water plane geometry 発行 (water exclusion からも共有呼出) |
+| `lldrawpoolwaterexclusion.cpp` | `LLDrawPoolWaterExclusion::render` | 43 | water plane mask 生成 |
+| `lldrawpoolterrain.cpp` | `LLDrawPoolTerrain::renderDeferred` | 147 | terrain dispatch (legacy or PBR) |
+| `lldrawpoolterrain.cpp` | `renderFullShader` | 267 | shader 切替 (`gDeferredTerrainProgram` / `gDeferredPBRTerrainProgram`) |
+| `lldrawpoolterrain.cpp` | `renderShadow` | 189 | terrain shadow caster |
+| `pipeline.cpp` | `LLPipeline::renderGeomDeferred` | 5039 | 全 pool walk (POOL_WL_SKY / POOL_TERRAIN を deferred で描画) |
+| `pipeline.cpp` | `LLPipeline::renderGeomPostDeferred` | 5178 | POOL_WATER の renderPostDeferred、間に `doAtmospherics` / `doWaterHaze` / `doWaterExclusionMask` を挟む |
+| `pipeline.cpp` | `doAtmospherics` | 11641 | screen-space atmospheric haze (depth を `mWaterDis` 経由で gHazeProgram に渡す) |
+| `pipeline.cpp` | `doWaterHaze` | 11923 | water 形状 fog (`gHazeWaterProgram`) |
+| `pipeline.cpp` | `doWaterExclusionMask` | 12007 | water plane mask (`mWaterExclusionMask` RT) |
+| `pipeline.cpp` | `markVisible` | 3081-3098 | sky / WL sky の drawable を毎フレーム cull pass に push |
+| `llviewerwindow.cpp` | `cubeSnapshot` | 6640 | `gCubeSnapshot = true` で probe cubemap 1 面分の scene render |
+| `llheroprobemanager.cpp` | `LLHeroProbeManager::renderProbes` | 242 | 水面 reflection probe の 6 面更新 dispatcher |
+| `llheroprobemanager.cpp` | `updateProbeFace` | 313 | 1 面分の render + mip chain |
+| `llviewershadermgr.cpp` | `loadShadersDeferred` | 3179-3265 | `gDeferredWLSkyProgram` / `gDeferredWLCloudProgram` / `gDeferredWLSunProgram` / `gDeferredWLMoonProgram` / `gDeferredStarProgram` の shader file load |
+| `llviewershadermgr.cpp` | `loadShadersWater` | 1008-1052 | `gWaterProgram` / `gUnderWaterProgram` の shader file load |
+
+---
+
+## 5. 推測でしか埋められなかった項目 (実コード確認が後追いで必要)
+
+本書執筆時に実コード確認できず、参考 grep + 既存資料の知識から推測で書いた箇所:
+
+1. **§3.5 / §C.6 「water reflection (hero probe) 内でも FB 越し sky leak / SSS pink leak が起きうる」**: 同じ shader path を通るので**論理的には起きるはず**だが、probe の mip chain + roughness convolution で軽症化される / されないかは実観測していない。要 canary 検証。
+2. **§C.5 water surface の `gl_FragDepth` write 有無**: `waterF.glsl` を grep した範囲では `gl_FragDepth` 書込みは無さそうだが、water plane geometry 描画時に GL 標準の depth write が ON / OFF どちらで bind されているかは `bindDeferredShader` の内部状態に依存。詳細追跡未完。
+3. **§C.4 probe 内で water 自体が再帰描画されるか**: `display_cube_face()` の実装まで降りていないので、water pool が probe pass 中に skip されるかどうかは未確認 (実装的にはする方が自然 — 水面の中に水面が映ったら無限再帰)。
+4. **§C.3 `mWaterExclusionMask` の解像度・format**: `pipeline.h` まで grep してないので画面 resolution / format は推測。
+5. **§B.1 「sprite cloud は SL に存在しない」**: 一般的な SL の知識として書いたが、最新の EEP に sprite cloud が追加されていないかの完全確認は未実施。
+6. **§A.6 「FB 越し SSS pink 漏れ bug」の正確な再現条件**: 本書ではユーザー指摘の bug として記述したが、commit 検索 (`grep -i sss.*pink`) で直接 hit する commit を見つけられなかった。記述は概念モデル止まり。
+
+---
+
+## 6. 関連リファレンス
+
+- `ayastorm-deferred-shader-routing.md` — gbuffer flag → softenLightF 分岐 (sky の `SKIP_ATMOS` / `HAS_HDRI` 分岐含む、§1 参照)
+- `ayastorm-gbuffer3-trace.md` — `frag_data[3]` storage 仕様 (sky/cloud/moon/star/sunDisc の `.a` write 値一覧含む)
+- `ayastorm-attachment-rendering-routing.md` — 装着物 (`mAttachedToAvatar.notNull()`) 軸の地図、本書と直交する effect 軸の対称資料
+- `ayastorm-rez-object-rendering-routing.md` — Rez Object (`mAttachedToAvatar.isNull()` + 非環境) 軸の地図、§0「Rez Object に含まれないもの」が本書 scope と一致
+
+---
+
+## 7. 更新履歴
+
+- 2026-05-25 初版: effect 軸地図シリーズ 4 本目。sky/cloud/water/terrain の pool / shader / depth / blend / gbuffer / 描画順序 / Hero probe との関係を確定マップ化。FB 越し sky 透け bug (commit `4188880321`) と SSS pink 漏れの構造的位置を §A.6 で示し、共通根 (`gbuffer3.a` の 1bit 2 意味化) を identify。

--- a/docs/specs/ayastorm-fullbright-rendering-routing.md
+++ b/docs/specs/ayastorm-fullbright-rendering-routing.md
@@ -1,0 +1,542 @@
+# AYAstorm FullBright Rendering Routing リファレンス
+
+**作成日**: 2026-05-25 (r31 WBOIT 着手前に「FB prim 越しに SSS pink が透ける」 bug の構造解析として作成)
+**対象**: FullBright effect で描画される全 path (pool / shader / depth / gbuffer writer) の確定マップ。「FB はどう描かれているか」「FB は gbuffer3.a (SSS skin flag) をどう触るか」を即座に引けるようにするためのリファレンス。
+**作成経緯**: SSS pass で「FB prim の後ろにいる avatar の SSS pink がアバター形状で FB prim 表面に透けて見える」 bug 解析。sky で同様の bug は短時間で潰れたが、SSS は 3-4h × 2 回外したので、推論を止めて FB の全経路を実コード trace で確定させる目的。
+
+> **再利用方針**: FullBright / Emissive / Glow 関連で挙動が壊れたとき、または SSS / glow / DoF など post-pass が「FB を特殊扱い」しない結果として副作用を引き起こしたときに **まず本書を参照**。FullBright shader 自体は単純だが、`POOL_FULLBRIGHT` / `POOL_FULLBRIGHT_ALPHA_MASK` / `POOL_ALPHA` 内の FB / `POOL_MATERIALS` の emissive=1 face / `POOL_GLTF_PBR` の unlit material と **5 系統に分岐** していて、bug 仮説で 1 系統だけ見ると外す。
+
+---
+
+## TL;DR — FB の core 問題は「gbuffer3.a を一切触らない」
+
+**`POOL_FULLBRIGHT` / `POOL_FULLBRIGHT_ALPHA_MASK` の標準経路 (`fullbrightF.glsl`) は `out vec4 frag_color;` 単一 RT 出力で、`frag_data[0..3]` には何も書かない**。すなわち FB pixel の覆う screen 領域では、**gbuffer3 (DEFERRED_EMISSIVE / `.a`= SSS skin flag) の値はその pixel に *元々* 書いていた deferred 物体の値がそのまま残る**。FB prim の手前に opaque な avatar / skin material が gbuffer 段で `aya_sss_skin_flag = 1.0` を書いていれば、FB が forward で scene color を上書きしても skin flag は 1.0 のまま → SSS pass はその pixel を skin と判定 → FB の color を入力に skin SSS blur をかける → アバター形状で pink が滲み出る。
+
+depth 側の挙動も裏付けになる: `LLDrawPoolFullbright::renderPostDeferred` は `LLGLDepthTest` を明示せず caller の継承 (deferred pass の `GL_LEQUAL` / depth write ON) で走るので、**FB は depth を書く**。よって SSS pass の `eye_dist` 復元 (skinSSSF.glsl:103 `texture(depthMap, tc).r`) は「ここに FB がある」と認識できる。しかし mask 側 (gbuffer3.a) は「ここに skin がある」と認識した *まま* なので、両者が矛盾し SSS blur が走る。**fix の方向は FB writer 群にも skin flag = 0 の gbuffer3.a write を追加すること** (`materialF` / `pbropaqueF` / `avatarF` と同じ pattern を `fullbrightF` / `fullbrightShinyF` にも入れる)。
+
+---
+
+## 0. クイック分岐表 — 「これは FB のどれ?」
+
+| 観測条件 | Pool | Shader | gbuffer3.a に書くか | bug 影響 |
+|---|---|---|---|---|
+| FB texture かつ alpha 無し / opaque | `POOL_FULLBRIGHT` | `fullbrightF.glsl` (no permutation) | **NO** | **SSS bleed の主犯** |
+| FB texture かつ alpha MASK (discard) | `POOL_FULLBRIGHT_ALPHA_MASK` | `fullbrightF.glsl` (`HAS_ALPHA_MASK`) | **NO** | SSS bleed する (discard 後の残 fragment は depth/color 書く) |
+| FB texture かつ alpha BLEND (半透明) | `POOL_ALPHA_PRE_WATER` / `POOL_ALPHA_POST_WATER` | `fullbrightF.glsl` (`HAS_ALPHA_MASK` + `IS_ALPHA`) | **NO** | depth write OFF なので SSS の depth opt-out (d>=0.9999) は効かないがそれ以外で flag 残留 |
+| FB + Shiny (env reflection) | `POOL_BUMP` (`renderFullbrightShiny`) | `fullbrightShinyF.glsl` | **NO** | SSS bleed する |
+| FB + Spec/Normal map (legacy material) | `POOL_MATERIALS` | `materialF.glsl` (emissive=1) | **YES** (`frag_data[3] = vec4(0,0,0, aya_sss_skin_flag)`) | gbuffer に書くので SSS 経路は他の deferred 物体と同じ |
+| GLTF PBR で `unlit=true` | `POOL_FULLBRIGHT_ALPHA_MASK` (内で `GLTFSceneManager::render(unlit=true)`) | GLTF unlit shader | (要確認、本書未完) | unverified |
+| FB Glow (`getGlow() > 0`) | `POOL_GLOW` (alpha 出力のみ) | `emissiveF.glsl` | **NO** (色は書かない、alpha のみ) | SSS pass の入力 color には影響しない |
+| HUD 上の FB | `POOL_FULLBRIGHT*` (sRenderingHUDs=true) | 同 shader (`IS_HUD` permutation) | **N/A** (HUD 経路は SSS 対象外) | bug 無関係 |
+
+→ **bug 影響範囲**: 1, 2, 3, 4 行目 (= `fullbrightF` / `fullbrightShinyF` で描かれる全 FB face)。5 行目 (materialF) は既に gbuffer に書くので影響無し。
+
+---
+
+## 1. FB pool 列挙
+
+`indra/newview/lldrawpool.h:60-78` の pool 順序 (= render order):
+
+```
+POOL_SIMPLE = 4
+POOL_FULLBRIGHT = 5           ← 本書 §2
+POOL_BUMP = 6                 ← FB Shiny 経路は POOL_BUMP の下位機能 §4
+POOL_MATERIALS = 7            ← FB material 系は materialF emissive 経路 §5
+POOL_GLTF_PBR = 8
+...
+POOL_FULLBRIGHT_ALPHA_MASK = 13   ← 本書 §3
+POOL_AVATAR = 15
+POOL_GLOW = 18                ← FB の glow channel 経路 §6
+POOL_ALPHA_PRE_WATER = 19     ← FB-alpha-blend 経路 §7
+POOL_ALPHA_POST_WATER = 21    ← FB-alpha-blend 経路 §7
+```
+
+| Pool | 番号 | render entrypoint | render stage | sort order | 責務 |
+|---|---|---|---|---|---|
+| `POOL_FULLBRIGHT` | 5 | `LLDrawPoolFullbright::renderPostDeferred` (lldrawpoolsimple.cpp:156) | **postDeferred** | front-to-back (opaque batch order) | FB opaque (alpha 無し) |
+| `POOL_FULLBRIGHT_ALPHA_MASK` | 13 | `LLDrawPoolFullbrightAlphaMask::renderPostDeferred` (lldrawpoolsimple.cpp:184) | **postDeferred** | front-to-back | FB alpha MASK (`discard`) |
+| (FB Shiny part of `POOL_BUMP`) | 6 | `LLDrawPoolBump::renderFullbrightShiny` (lldrawpoolbump.cpp:356) | postDeferred (called from `LLDrawPoolBump::renderPostDeferred`) | front-to-back | FB + env reflection |
+| (FB part of `POOL_ALPHA*`) | 19 / 21 | `LLDrawPoolAlpha::forwardRender` (lldrawpoolalpha.cpp:394) | postDeferred | **back-to-front** (alpha) | FB + alpha BLEND |
+| `POOL_GLOW` | 18 | `LLDrawPoolGlow::renderPostDeferred` (lldrawpoolsimple.cpp:45) | postDeferred | front-to-back | FB の glow channel 出力 (alpha のみ) |
+
+**重要**: 5 つすべて **`renderPostDeferred`** で動く = **gbuffer pass (`renderDeferred`) の後**。gbuffer は既に Simple / Bump / Materials / GLTF_PBR / Avatar が書き終わっていて、FB がそれを **forward で上書き** する形になる。これが §0 の bug 機構の根幹。
+
+ref:
+- pool render loop: `pipeline.cpp:5230-5318` (`renderGeomPostDeferred`)
+- pool 順序が render order を決める仕様 comment: `lldrawpool.h:52-56`
+
+---
+
+## 2. POOL_FULLBRIGHT (= `LLDrawPoolFullbright`)
+
+### 2.1 bind
+
+```cpp
+// lldrawpoolsimple.cpp:156-182
+void LLDrawPoolFullbright::renderPostDeferred(S32 pass)
+{
+    LLGLSLShader* shader = nullptr;
+    if (LLPipeline::sRenderingHUDs)
+        shader = &gHUDFullbrightProgram;
+    else
+        shader = &gDeferredFullbrightProgram;
+
+    gGL.setSceneBlendType(LLRender::BT_ALPHA);   // ← blend ON (= forward)
+
+    shader->bind();
+    pushBatches(LLRenderPass::PASS_FULLBRIGHT, true, true);
+
+    if (!LLPipeline::sRenderingHUDs) {
+        shader->bind(true);
+        pushRiggedBatches(LLRenderPass::PASS_FULLBRIGHT_RIGGED, true, true);
+    }
+}
+```
+
+### 2.2 shader (`gDeferredFullbrightProgram`)
+
+`llviewershadermgr.cpp:2023-2039`:
+- vertex: `deferred/fullbrightV.glsl`
+- fragment: `deferred/fullbrightF.glsl` (no permutation)
+- `make_rigged_variant` で `HAS_SKIN` permutation の rigged 変種生成
+
+### 2.3 fragment 出力
+
+`fullbrightF.glsl:28` および `:98`:
+```glsl
+out vec4 frag_color;
+...
+frag_color = max(color, vec4(0));
+```
+
+- **frag_data[0..3] への書き込み一切無し** ← **bug の鍵**
+- `color.rgb` は `srgb_to_linear(color.rgb)` で linear 化済 (line 83)
+- `IS_HUD` permutation のときだけ sRGB→linear 変換と atmospheric fog をスキップ
+- `IS_ALPHA` permutation のとき `waterClip` + sky/water fog を適用 (forward alpha 経路用、§7)
+
+### 2.4 depth / blend / state
+
+| state | 値 | 設定箇所 |
+|---|---|---|
+| Blend | `BT_ALPHA` (`SRC_ALPHA, 1-SRC_ALPHA`) | `lldrawpoolsimple.cpp:170` |
+| Depth test | GL_TRUE / func GL_LEQUAL | caller (`renderGeomPostDeferred` のデフォルト state) を継承 |
+| Depth write | **GL_TRUE** | caller (deferred pass 末尾の `LLGLDepthTest depth(GL_TRUE, GL_TRUE, GL_LEQUAL)` 継承) |
+| Color mask | (true, false) → `setColorMask` 直前で再設定の場合あり | `pipeline.cpp:5214` で post-deferred 入口時に `setColorMask(true, false)` |
+
+→ **opaque FB は depth を書く**。alpha 0 で完全透明な fragment でも (alpha discard が無いので) depth が書かれる。これは「FB prim の depth は scene depth として記録される」ことを意味し、skinSSSF.glsl:118 の `d_raw >= 0.9999` (sky opt-out) には引っかからない = **SSS は FB pixel を「scene 物体がある」と認識する**。
+
+### 2.5 gbuffer3.a への寄与
+
+**ゼロ**。`fullbrightF.glsl` は `frag_data[3]` に一切 write しない。よってその pixel の gbuffer3.a 値は:
+
+1. その pixel の手前に deferred 物体 (avatar / material face / PBR opaque) が `aya_sss_skin_flag` を書いていれば、**その値がそのまま残る**
+2. 何も書いていなければ deferred clear color のまま (= `(1.0, 0, 1.0, 1.0)` の `.a = 1.0`、`pipeline.cpp:addDeferredAttachments` の clear 仕様、`ayastorm-gbuffer3-trace.md` §C 参照)
+
+**bug 経路**: avatar が FB prim の **手前** に存在しなくても、avatar の z が FB の z より遠ければ deferred pass で avatar が先に gbuffer に skin_flag=1 を書き、FB が postDeferred で **scene color (frag_color) を後から上書き** するが gbuffer3.a は塗り直さない。SSS pass は gbuffer3.a だけ見て「skin」判定 → scene color の FB pixel を入力に blur → pink がアバター形状で滲む。
+
+---
+
+## 3. POOL_FULLBRIGHT_ALPHA_MASK (= `LLDrawPoolFullbrightAlphaMask`)
+
+### 3.1 bind
+
+```cpp
+// lldrawpoolsimple.cpp:184-214
+void LLDrawPoolFullbrightAlphaMask::renderPostDeferred(S32 pass)
+{
+    // GLTF unlit (alpha mask) を先に
+    LL::GLTFSceneManager::instance().render(true, false, true);
+    LL::GLTFSceneManager::instance().render(true, true, true);
+
+    LLGLSLShader* shader = (sRenderingHUDs)
+        ? &gHUDFullbrightAlphaMaskProgram
+        : &gDeferredFullbrightAlphaMaskProgram;
+
+    LLGLDisable blend(GL_BLEND);   // ← blend OFF (= alpha mask は不透明扱い)
+
+    shader->bind();
+    pushMaskBatches(LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK, true, true);
+
+    if (!sRenderingHUDs) {
+        shader->bind(true);
+        pushRiggedMaskBatches(LLRenderPass::PASS_FULLBRIGHT_ALPHA_MASK_RIGGED, true, true);
+    }
+}
+```
+
+### 3.2 shader
+
+`llviewershadermgr.cpp:2062-2082`:
+- 同じ `fullbrightV.glsl` / `fullbrightF.glsl` を使うが **`HAS_ALPHA_MASK` permutation** を立てる
+- `fullbrightF.glsl:70-75` で `if (color.a < minimum_alpha) discard;`
+
+### 3.3 fragment 出力 / depth / state
+
+- `frag_color` 単一 RT 出力 (§2.3 と同じ)
+- discard した fragment は depth / color とも書かない → FB が透けた領域 (cut-out 内側) では奥の deferred 物体の gbuffer3.a が **可視 pixel として** 残る
+- discard しなかった fragment は §2.4 と同じ state (depth write ON、blend OFF)
+- gbuffer3.a への寄与: §2.5 と同じ = **ゼロ**
+
+### 3.4 GLTFSceneManager 経由の unlit
+
+line 188-190 で `GLTFSceneManager::render(unlit=true, ...)` を呼ぶ。これは GLTF material の `unlit=true` を持つ face を別に dispatch する。bind される shader が `fullbrightF` か別 GLTF shader か未検証 (本書スコープ外、要確認)。
+
+---
+
+## 4. POOL_BUMP 内の FB Shiny (= `LLDrawPoolBump::renderFullbrightShiny`)
+
+### 4.1 bind
+
+```cpp
+// lldrawpoolbump.cpp:285-354 (beginFullbrightShiny) / :356-386 (renderFullbrightShiny)
+void LLDrawPoolBump::beginFullbrightShiny()
+{
+    shader = &gDeferredFullbrightShinyProgram;
+    if (LLPipeline::sRenderingHUDs)
+        shader = &gHUDFullbrightShinyProgram;
+    if (mRigged)
+        shader = shader->mRiggedVariant;
+    ...
+    shader->bind();
+    ...
+}
+
+void LLDrawPoolBump::renderFullbrightShiny()
+{
+    LLGLEnable blend_enable(GL_BLEND);   // ← blend ON
+
+    if (mShaderLevel > 1) {
+        if (mRigged) pushRiggedBatches(PASS_FULLBRIGHT_SHINY_RIGGED, true, true);
+        else         pushBatches(PASS_FULLBRIGHT_SHINY, true, true);
+    } else {
+        if (mRigged) pushRiggedBatches(PASS_FULLBRIGHT_SHINY_RIGGED);
+        else         pushBatches(PASS_FULLBRIGHT_SHINY);
+    }
+}
+```
+
+呼び出しは `LLDrawPoolBump::renderPostDeferred` (lldrawpoolbump.cpp:609) から:
+```cpp
+beginFullbrightShiny();
+renderFullbrightShiny();
+endFullbrightShiny();
+```
+
+### 4.2 shader
+
+- vertex: `deferred/fullbrightShinyV.glsl`
+- fragment: `class3/deferred/fullbrightShinyF.glsl` (class3 配下にしか fragment が無い)
+
+### 4.3 fragment 出力
+
+`fullbrightShinyF.glsl:28` および `:95`:
+```glsl
+out vec4 frag_color;
+...
+color.a = 1.0;
+frag_color = max(color, vec4(0));
+```
+
+- **frag_data 系一切無し** = gbuffer3.a に書かない
+- `color.a = 1.0` でハードコード = scene color の glow channel 用 alpha を 1.0 で潰す (glow を「最大」にしてしまう、`POOL_GLOW` 経路と干渉する場合あり、本書スコープ外)
+- env reflection は `sampleReflectionProbesLegacy` + `applyLegacyEnv` で applied (line 86, 90)
+
+### 4.4 depth / state
+
+| state | 値 | 設定箇所 |
+|---|---|---|
+| Blend | `GL_BLEND` enable | `lldrawpoolbump.cpp:361` |
+| Depth test | GL_TRUE / GL_LEQUAL | 継承 |
+| Depth write | **GL_TRUE** | 継承 (`renderPostDeferred` 入口の deferred default) |
+| gbuffer3.a 寄与 | **ゼロ** | shader が書かない |
+
+→ §2.5 と同じ bug pattern。SSS bleed 該当。
+
+---
+
+## 5. POOL_MATERIALS 内の FB face (= `materialF.glsl` の `emissive=1` 分岐)
+
+### 5.1 routing
+
+`LLVOVolume::genDrawInfo` (llvovolume.cpp:7018, :7039) で:
+- `getTextureEntry()->getFullbright()` かつ `mat` が non-null かつ alpha MASK → `PASS_FULLBRIGHT_ALPHA_MASK` (POOL_FULLBRIGHT_ALPHA_MASK 行き、§3)
+- それ以外で legacy material あり → `PASS_MATERIAL_ALPHA_EMISSIVE` / `PASS_SPECMAP_EMISSIVE` / `PASS_NORMMAP_EMISSIVE` / `PASS_NORMSPEC_EMISSIVE` (POOL_MATERIALS 行き、本節)
+
+`emissive_brightness` uniform が `materialF.glsl:37` で:
+```glsl
+uniform float emissive_brightness;  // fullbright flag, 1.0 == fullbright, 0.0 otherwise
+```
+
+→ **legacy material (Spec/Normal map) を貼った FB face は POOL_MATERIALS 経由で materialF を踏む**。これは `POOL_FULLBRIGHT` ではなく **deferred path** (gbuffer に書く)。
+
+### 5.2 fragment 出力
+
+`materialF.glsl:188`:
+```glsl
+out vec4 frag_data[4];
+```
+
+line 440-450 (DIFFUSE_ALPHA_MODE != BLEND 分岐):
+```glsl
+frag_data[0] = max(vec4(diffcol.rgb, emissive), vec4(0));        // emissive を gbuffer0.a に書く
+frag_data[1] = max(vec4(spec.rgb, glossiness), vec4(0));
+frag_data[2] = encodeNormal(norm, env, flag);
+#if defined(HAS_EMISSIVE)
+frag_data[3] = vec4(0, 0, 0, aya_sss_skin_flag);                 // ← gbuffer3.a を skin_flag で正しく書く
+#endif
+```
+
+→ **gbuffer3.a は `aya_sss_skin_flag` で書かれる**。FB であっても POOL_MATERIALS 経由ならば SSS の判定材料は正しく書かれる = **bug 影響なし**。
+
+### 5.3 bug 影響まとめ
+
+POOL_MATERIALS で FB を踏む face は SSS bleed しない。「FB prim 全部に SSS が透ける」のではなく **「Spec/Normal map を持たない素 FB prim (POOL_FULLBRIGHT 行き)」で透ける** という観測条件があり得る。AYA さんの実機検証で peeling パターンが prim 種別で違うようなら、それは POOL_FULLBRIGHT vs POOL_MATERIALS の分岐を踏んでいる。
+
+---
+
+## 6. POOL_GLOW (= `LLDrawPoolGlow`)
+
+### 6.1 bind / state
+
+`lldrawpoolsimple.cpp:45-71`:
+```cpp
+void LLDrawPoolGlow::renderPostDeferred(S32 pass)
+{
+    LLGLSLShader* shader = &gDeferredEmissiveProgram;
+
+    LLGLEnable blend(GL_BLEND);
+    LLGLEnable polyOffset(GL_POLYGON_OFFSET_FILL);
+    glPolygonOffset(-1.0f, -1.0f);
+    gGL.setSceneBlendType(LLRender::BT_ADD);              // ← additive
+    LLGLDepthTest depth(GL_TRUE, GL_FALSE);               // ← depth test ON / depth write OFF
+    gGL.setColorMask(false, true);                        // ← RGB 書かない、alpha のみ
+
+    shader->bind();
+    pushBatches(LLRenderPass::PASS_GLOW, true, true);
+
+    shader = shader->mRiggedVariant;
+    shader->bind();
+    pushRiggedBatches(LLRenderPass::PASS_GLOW_RIGGED, true, true);
+
+    gGL.setColorMask(true, false);
+    gGL.setSceneBlendType(LLRender::BT_ALPHA);
+}
+```
+
+### 6.2 shader / 出力
+
+`emissiveF.glsl:37`:
+```glsl
+frag_color = max(vec4(0, 0, 0, a), vec4(0));
+```
+
+- RGB は 0 (color mask で書かれない)
+- alpha のみ書く (scene color の glow channel = 後の blur で glow 効果に使う)
+- gbuffer3.a への寄与: **ゼロ**
+
+### 6.3 bug 影響
+
+POOL_GLOW は scene color の RGB を変更しないので SSS pass の入力 RGB に影響しない。**bug 経路と無関係**。FB の emissive 表現は POOL_GLOW で alpha (glow strength) を書き、POOL_FULLBRIGHT で RGB を書く、と役割分担している。
+
+(glow blur 全体経路は本書スコープ外、別 doc で整理する余地あり)
+
+---
+
+## 7. POOL_ALPHA 内の FB (= forward alpha BLEND 経路)
+
+### 7.1 routing
+
+FB かつ alpha BLEND な face は `LLVOVolume::registerFace` で `PASS_ALPHA` に登録される (llvovolume.cpp:7137 など):
+```cpp
+registerFace(group, facep, fullbright ? PASS_FULLBRIGHT : PASS_SIMPLE);  // line 7137: alpha mask ではない
+```
+
+…ではなく、alpha BLEND は `LLDrawPoolAlpha` 側で `mFullbright` 判定で shader を分けて bind:
+
+```cpp
+// lldrawpoolalpha.cpp:174-178
+fullbright_shader =
+    (sImpostorRender) ? &gDeferredFullbrightAlphaMaskProgram :
+    (sRenderingHUDs)  ? &gHUDFullbrightAlphaMaskAlphaProgram :
+                        &gDeferredFullbrightAlphaMaskAlphaProgram;
+```
+
+そして `renderAlpha` ループ (line 891 付近) で `params.mFullbright` を見て shader を切替:
+```cpp
+if (params.mFullbright)
+    target_shader = fullbright_shader;
+```
+
+### 7.2 shader
+
+`gDeferredFullbrightAlphaMaskAlphaProgram` の構成 (`llviewershadermgr.cpp:2108-2128`):
+- 同じ `fullbrightF.glsl` を使うが permutation 3 つ:
+  - `HAS_ALPHA_MASK = 1`
+  - `IS_ALPHA = 1` → fullbrightF.glsl:45-51, :84-93 の atmospheric/water fog ブロックが有効化される
+  - (HUD 版は更に `IS_HUD = 1`)
+
+### 7.3 fragment 出力 / depth
+
+- 出力: `frag_color` 単一 RT (§2.3 と同じ)、gbuffer 一切書かない
+- depth write: `LLDrawPoolAlpha::forwardRender` (lldrawpoolalpha.cpp:411):
+  ```cpp
+  bool write_depth = rigged ||
+      sSkipScreenCopy ||
+      sImpostorRenderAlphaDepthPass ||
+      getType() == POOL_ALPHA_PRE_WATER;
+
+  LLGLDepthTest depth(GL_TRUE, write_depth ? GL_TRUE : GL_FALSE);
+  ```
+  - **POOL_ALPHA_POST_WATER (=21) かつ非 rigged** の場合 `write_depth = false` → **depth write OFF**
+  - POOL_ALPHA_POST_WATER かつ rigged → depth write ON (2026-05-22 の二重アルファブロック fix で commit `2597b657ac` 以降は forward 順序が non-rigged → rigged に変更)
+  - POOL_ALPHA_PRE_WATER → depth write ON (water fog 整合性のため)
+
+### 7.4 bug 影響
+
+- depth write OFF の場合 (POST_WATER 非 rigged FB-alpha-blend): その pixel の scene depth は手前の opaque 物体 (deferred で書かれた値) のまま。skinSSSF の depth-based eye_dist 復元はその opaque 物体の z を使う = blur radius が opaque 物体距離基準
+- gbuffer3.a への寄与: **ゼロ** (FB shader が書かない)
+- → opaque pass で skin avatar が gbuffer3.a=1 を書いた pixel に、後段で FB-alpha-blend が乗ると SSS pass は依然「skin」と判定 → FB の半透明色を入力に blur
+
+---
+
+## 8. depth write 挙動の全列挙 (bug の鍵)
+
+| 経路 | depth test | depth write | blend | gbuffer3.a write | SSS bleed リスク |
+|---|---|---|---|---|---|
+| `POOL_FULLBRIGHT` opaque (§2) | GL_LEQUAL | **ON** | SRC_ALPHA/1-SRC_ALPHA | **NO** | **HIGH** (主犯) |
+| `POOL_FULLBRIGHT_ALPHA_MASK` (§3) | GL_LEQUAL | **ON** (discard 後の残 fragment) | OFF | **NO** | **HIGH** |
+| `POOL_BUMP` FB Shiny (§4) | GL_LEQUAL | **ON** | ON (BLEND) | **NO** | **HIGH** |
+| `POOL_MATERIALS` emissive=1 (§5) | GL_LEQUAL | **ON** | OFF (deferred) | **YES** | LOW (gbuffer に正しく書く) |
+| `POOL_GLOW` (§6) | GL_LEQUAL | **OFF** | ADD | NO | (RGB 書かないので無関係) |
+| `POOL_ALPHA_PRE_WATER` FB (§7) | GL_LEQUAL | **ON** | ON | **NO** | MEDIUM |
+| `POOL_ALPHA_POST_WATER` FB rigged (§7) | GL_LEQUAL | **ON** | ON | **NO** | MEDIUM |
+| `POOL_ALPHA_POST_WATER` FB non-rigged (§7) | GL_LEQUAL | **OFF** | ON | **NO** | MEDIUM (depth opt-out も効かない) |
+
+ref:
+- `POOL_FULLBRIGHT*` の depth: `lldrawpoolsimple.cpp:156-214` (明示なし、caller 継承)
+- caller の depth state: `pipeline.cpp:5230-5318` (`renderGeomPostDeferred` で `LLGLDepthTest` の明示無し → 直前の deferred pass の `GL_TRUE/GL_TRUE/GL_LEQUAL` が継承される)
+- `POOL_BUMP` FB Shiny: `lldrawpoolbump.cpp:285-406` (depth test 明示無し)
+- `POOL_GLOW`: `lldrawpoolsimple.cpp:57` (`LLGLDepthTest depth(GL_TRUE, GL_FALSE);` で明示)
+- `POOL_ALPHA*` forward: `lldrawpoolalpha.cpp:403-411`
+
+---
+
+## 9. SSS pass との接合 (bug 仮説の確定)
+
+`pipeline.cpp:11758-11920` (`LLPipeline::doSkinSSS`) の動作:
+
+1. **dispatch 地点**: `renderGeomPostDeferred` の loop 内で `cur_type >= POOL_ALPHA_POST_WATER (21)` に到達した時点で `doAtmospherics()` と並んで `doSkinSSS()` が呼ばれる (pipeline.cpp:5242-5263)。すなわち `POOL_FULLBRIGHT (5)` / `POOL_FULLBRIGHT_ALPHA_MASK (13)` / `POOL_BUMP FB Shiny (6)` / `POOL_GLOW (18)` は **すべて SSS pass の前** に描画される
+2. **入力**: `mRT->screen` (scene color、既に FB で塗られた状態) + `gbuffer3` (`.a` = skin flag) + `mRT->deferredScreen.depth`
+3. **判定**: `skinSSSF.glsl:171-172`:
+   ```glsl
+   float skin_mask = texture(emissiveRect, tc).a;
+   float skin_bit  = (skin_mask >= 0.5) ? 1.0 : 0.0;
+   ```
+4. **出力**: `frag_color = vec4(sum, aya_strength * skin_bit)` (skin_bit=0 ならば alpha=0 で blend pass-through)
+
+**bug 機構の確定**:
+- FB pool は `frag_data[3]` に書かない (§2.5 §3.3 §4.3 §7.3)
+- よって FB が covered pixel の gbuffer3.a は **その pixel に *opaque pass で先に書いていた deferred 物体* の値** で固定
+- avatar / skin material は `materialF` / `pbropaqueF` / `avatarF` で `aya_sss_skin_flag = 1.0` を書く (`ayastorm-deferred-shader-routing.md` §2、`ayastorm-gbuffer3-trace.md` §A)
+- FB prim の手前 / 同位置に avatar が opaque pass で gbuffer3.a=1 を書き、その後に FB が postDeferred で **scene color のみ** を上書きしても **gbuffer3.a は 1 のまま** → SSS pass は「ここは skin」 → FB の color (テクスチャ色) を入力に SSS blur をかける → pink がアバター形状で滲み出る
+
+### 9.1 fix の方向
+
+3 案:
+
+| 案 | 内容 | コスト | 副作用 |
+|---|---|---|---|
+| A | `fullbrightF` / `fullbrightShinyF` を MRT shader に書き換えて `frag_data[3] = vec4(0,0,0,0)` で skin_flag=0 を明示 write | low | FB pool の **forward 描画は currently single-RT に bind されている** ので、MRT bind に切り替える C++ 修正も要る (pool 側で `mRT->deferredScreen` を改めて bind 必要)。FB が deferred clear color の `.a=1.0` を `.a=0` で上書きする副作用も検討 (sky safety net `d_raw>=0.9999` 経路の保護は深度で別途効くので問題は出ない見込み) |
+| B | SSS pass 側で depth-based heuristic を追加: FB 検出のため別の判定材料 (gbuffer1 spec=0 + gbuffer2 normal=0 など、deferred 既定 clear で残るパターン) で「ここは forward 上書き済」を推定 | medium | 偽陽性リスク (gbuffer 値が他経路でも 0 になる可能性)。AYA さんが嫌う heuristic |
+| C | 別 RT (skin_mask 専用 R8 buffer) を追加して、forward FB の `frag_color` と並列に skin_mask=0 を書く | high | 帯域・メモリ増、3 OS 全部の addDeferredAttachments 改修必要 |
+
+**recommend: 案 A**。`materialF` / `pbropaqueF` / `avatarF` と完全に対称な実装になる (gbuffer3.a を 0 で明示 write)。MRT bind の C++ 修正は必要だが、`pipeline.cpp:addDeferredAttachments` が allocate する gbuffer attachment は `mRT->deferredScreen` で固定なので、`renderPostDeferred` 入口で `mRT->deferredScreen.bindTarget()` し直す形になる。ただし FB は **scene color (`mRT->screen`)** に書きたいので、bind 先は scene color のままで MRT に gbuffer3 を attach する hybrid 構成が必要。要検証。
+
+簡易代替案: SSS pass の発火を **POOL_FULLBRIGHT の前** に動かす。すなわち `pipeline.cpp:5242` の `atmospherics_pass = POOL_ALPHA_POST_WATER (21)` を `POOL_FULLBRIGHT (5)` まで下げる。SSS が走る時点では gbuffer3.a がまだ「skin pixel = 1」だけど scene color もまだ FB で上書きされていない avatar 色 → SSS が正しく avatar 色に blur → その後 FB が forward 上書き → FB pixel は SSS かかった結果の上に塗られる → bug 解消。ただし atmospherics と SSS の順序が逆転する副作用検討必要。これも案 D として記録。
+
+---
+
+## 10. AYAstorm 固有改変
+
+| commit | 説明 | FB への影響 |
+|---|---|---|
+| `4eb20eea93` (Fix fullbright global render toggle, 2026-05-23) | `RenderEnableFullbright` cvar を追加、`llvovolume.cpp:1900` で `face` の FULLBRIGHT state を gate、registerFace 経路で `teFullbrightEnabled` 経由判定に置換 | **cvar OFF にすると FB face が POOL_FULLBRIGHT に登録されない → POOL_SIMPLE 等の deferred 経路に流れる → gbuffer3.a が `aya_sss_skin_flag` で正しく書かれる**。SSS bleed bug の暫定回避になる (ただし FB 表現が消えるので運用は不可) |
+| `2597b657ac` (二重アルファブロック fix, 2026-05-22) | `LLDrawPoolAlpha::renderPostDeferred` の forward 順序を non-rigged → rigged に default 化 | POOL_ALPHA 内の FB-alpha-blend 経路 (§7) の描画順だけ影響、gbuffer3.a 周辺は無関係 |
+| `7d68ec63f3` (r30 P2 motion blur, lldrawpoolsimple.cpp:215+) | `LLDrawPoolFullbright::renderMotionBlur` / `LLDrawPoolFullbrightAlphaMask::renderMotionBlur` 追加 | motion blur 専用 pass で `gVelocityProgram` bind、本書スコープ外 |
+| `2c4d02465d` (r30 P5 透過 DoF L2-β) | alpha BLEND 経路に depth 再注入 logic | POOL_ALPHA 内 FB-alpha-blend (§7) の depth write 挙動に間接影響、本書 §7.3 の write_depth ロジックはこの修正後の状態 |
+
+### 10.1 r31 WBOIT と FB の関係
+
+(`project_ayastorm_r31_wboit.md` memory 参照)
+r31 WBOIT 化対象は forward alpha BLEND 経路 (POOL_ALPHA_PRE_WATER / POST_WATER)。FB-alpha-blend (§7) は WBOIT で accumulation + revealage 経路に乗る。WBOIT で gbuffer3.a の挙動が変わるか要確認 (現状想定: WBOIT 中も gbuffer は触らない、scene color の OIT 結合のみ)。本書の bug 仮説とは独立。
+
+---
+
+## 11. C++ shader / pool / pass の主要 cite
+
+| ファイル | 関数 / 行 | 役割 |
+|---|---|---|
+| `lldrawpoolsimple.cpp` | `LLDrawPoolFullbright::renderPostDeferred` (156) | POOL_FULLBRIGHT bind + dispatch (§2) |
+| `lldrawpoolsimple.cpp` | `LLDrawPoolFullbrightAlphaMask::renderPostDeferred` (184) | POOL_FULLBRIGHT_ALPHA_MASK bind (§3) |
+| `lldrawpoolsimple.cpp` | `LLDrawPoolGlow::renderPostDeferred` (45) | POOL_GLOW bind (§6) |
+| `lldrawpoolbump.cpp` | `LLDrawPoolBump::beginFullbrightShiny` (285) | POOL_BUMP FB Shiny bind (§4) |
+| `lldrawpoolbump.cpp` | `LLDrawPoolBump::renderFullbrightShiny` (356) | POOL_BUMP FB Shiny dispatch (§4) |
+| `lldrawpoolalpha.cpp` | `LLDrawPoolAlpha::beginRenderPass` (174-178) | POOL_ALPHA 内 FB shader 選択 (§7) |
+| `lldrawpoolalpha.cpp` | `LLDrawPoolAlpha::forwardRender` (394-455) | POOL_ALPHA forward 描画、depth write 判定 (§7.3) |
+| `llvovolume.cpp` | `LLVolumeGeometryManager::genDrawInfo` (7018, 7039, 7137, 7152, 7180, 7199, 7219, 7223, 7264) | face → PASS_FULLBRIGHT* / PASS_FULLBRIGHT_SHINY* / PASS_FULLBRIGHT_ALPHA_MASK* / POOL_FULLBRIGHT 登録 (§1, §5) |
+| `llvovolume.cpp` | `LLVolumeGeometryManager::registerFace` (5632-5639) | FB 判定の中心 |
+| `llvovolume.cpp` | `teFullbrightEnabled` (138, AYAstorm 追加) | `RenderEnableFullbright` cvar 経由の gate (§10) |
+| `llviewershadermgr.cpp` | `gDeferredFullbrightProgram` 構成 (2023-2039) | shader file binding (§2.2) |
+| `llviewershadermgr.cpp` | `gDeferredFullbrightAlphaMaskProgram` 構成 (2062-2082) | HAS_ALPHA_MASK permutation (§3.2) |
+| `llviewershadermgr.cpp` | `gDeferredFullbrightAlphaMaskAlphaProgram` 構成 (2108-2128) | HAS_ALPHA_MASK + IS_ALPHA permutation (§7.2) |
+| `llviewershadermgr.cpp` | `gDeferredFullbrightShinyProgram` 構成 (~2200) | FB Shiny shader (§4.2) |
+| `llviewershadermgr.cpp` | `gDeferredEmissiveProgram` 構成 (2204-2207) | POOL_GLOW shader (§6) |
+| `pipeline.cpp` | `renderGeomPostDeferred` (5178-5337) | postDeferred の pool loop + `doSkinSSS` dispatch (§9) |
+| `pipeline.cpp` | `doSkinSSS` (11758-11920) | SSS 2-pass blur 本体 (§9) |
+| `pipeline.cpp` | `renderShadow` (12380-12545) | shadow pass で FB / FB Shiny / FB Alpha Mask を含む (line 12392-12395, 12513) |
+
+## 12. shader file の主要 cite
+
+| ファイル | 行 | ポイント |
+|---|---|---|
+| `class1/deferred/fullbrightF.glsl` | 28 | `out vec4 frag_color;` 単一 RT 宣言 |
+| `class1/deferred/fullbrightF.glsl` | 70-75 | `HAS_ALPHA_MASK` で discard |
+| `class1/deferred/fullbrightF.glsl` | 82-94 | `IS_HUD` / `IS_ALPHA` permutation 分岐 |
+| `class1/deferred/fullbrightF.glsl` | 98 | `frag_color = max(color, vec4(0));` (gbuffer 不在の確定) |
+| `class1/deferred/fullbrightV.glsl` | 51-74 | HAS_SKIN permutation 経由の rigged 対応 |
+| `class3/deferred/fullbrightShinyF.glsl` | 28, 95 | `out vec4 frag_color;` / `frag_color = max(color, vec4(0));` (FB Shiny も単一 RT) |
+| `class3/deferred/fullbrightShinyF.glsl` | 93 | `color.a = 1.0` (glow alpha 強制) |
+| `class3/deferred/materialF.glsl` | 37 | `uniform float emissive_brightness;` (FB flag) |
+| `class3/deferred/materialF.glsl` | 188, 440-450 | MRT 出力、`aya_sss_skin_flag` を gbuffer3.a に書く |
+| `class1/deferred/emissiveF.glsl` | 37 | POOL_GLOW shader、alpha のみ書く |
+| `class1/deferred/skinSSSF.glsl` | 118-122 | sky safety net (d_raw>=0.9999 で frag_color=vec4(0)) |
+| `class1/deferred/skinSSSF.glsl` | 171-173 | skin_mask threshold + `frag_color = vec4(sum, aya_strength * skin_bit)` |
+| `class1/deferred/pbrglowF.glsl` | 28, 35-37 | HUD 用 forward fullbright PBR、`frag_color` 単一 RT |
+| `class1/deferred/pbralphaF.glsl` | 28 | PBR alpha forward、`frag_color` 単一 RT (gbuffer 書かない) |
+
+---
+
+## 13. 落とし穴 / 再発防止メモ
+
+1. **「FullBright」は 1 つの pool ではない**。POOL_FULLBRIGHT / POOL_FULLBRIGHT_ALPHA_MASK / POOL_BUMP の FB Shiny / POOL_ALPHA の FB 経路 / POOL_MATERIALS の emissive=1 と **5 系統**ある。bug 解析で 1 系統だけ修正して別系統で再発する罠。`fullbrightF.glsl` を触ったら `fullbrightShinyF.glsl` も同じ修正が必要 (§13.5)
+2. **POOL_FULLBRIGHT は `renderPostDeferred` でしか描画されない**。`renderDeferred` 経路にいないので「gbuffer 段で何かする」想定は崩れる。fix を入れるなら postDeferred 段で gbuffer3 を別途 bind する hybrid が必要
+3. **`emissive_brightness` uniform と FB pool は別物**。materialF が `emissive_brightness=1` で「FB のように振る舞う」ケースは POOL_MATERIALS 内で起きる (gbuffer に書く)。POOL_FULLBRIGHT の FB shader (`fullbrightF`) は `emissive_brightness` uniform を *持たない*
+4. **depth write は明示されていない**。`LLDrawPoolFullbright::renderPostDeferred` には `LLGLDepthTest` の明示 setup が無いので、caller の継承で動く。「FB は depth を書かない」と推測すると外す
+5. **`fullbrightShinyF.glsl` は class3 にしかない**。class1 配下に存在しないので `grep -r fullbrightShinyF class1` が空振る罠。`make_rigged_variant` で rigged 版を作るが fragment は同じ
+6. **`color.a = 1.0` を ShinyF が hardcode する** (line 93)。これは glow alpha 用の固定だが、FB Shiny pixel の scene color の `.a` チャネルが常に 1 になる = POOL_GLOW の glow buffer 計算と干渉する可能性。本 bug とは別軸
+7. **SSS pass は postDeferred の途中 (POOL_ALPHA_POST_WATER 到達時) で発火する**。FB pool は全部 SSS より **前** に描画されるが、それでも bug は起きる (gbuffer3.a が FB で上書きされないため)。「FB を SSS の後で描けば直る」のは半分だけ正しい (案 D の方向、§9.1)
+8. **`add_common_permutations` の `HAS_EMISSIVE` permutation** (`llviewershadermgr.cpp:272`) が `fullbrightF` には立たない。`materialF` / `pbropaqueF` / `avatarF` でしか `aya_sss_skin_flag` への gbuffer3.a 書き込みが有効化されない構造。fix で `fullbrightF` にも `HAS_EMISSIVE` 経路を追加する場合は `add_common_permutations` 適用も要確認
+
+---
+
+## 14. 関連ファイル / 姉妹資料
+
+- `docs/specs/ayastorm-deferred-shader-routing.md` — deferred 全体の object → pool → shader → gbuffer routing
+- `docs/specs/ayastorm-gbuffer3-trace.md` — gbuffer3 (DEFERRED_EMISSIVE / `.a` = SSS skin flag) の storage 仕様と writer 一覧
+- `docs/specs/ayastorm-attachment-rendering-routing.md` — 装着物 routing (alpha BLEND 系の peeling と関連)
+- `docs/specs/ayastorm-rez-object-rendering-routing.md` — Rez Object routing (二重アルファブロック fix 関連)
+- `docs/specs/ayastorm-r30-p4-bd-dof-chain-trace.md` — DoF 経路 (FB-alpha-blend の depth write と関連)
+
+## 15. 更新履歴
+
+- 2026-05-25 初版: SSS pink bleed bug 解析として、`POOL_FULLBRIGHT` / `POOL_FULLBRIGHT_ALPHA_MASK` / `POOL_BUMP` FB Shiny / `POOL_ALPHA` 内 FB / `POOL_MATERIALS` emissive=1 / `POOL_GLOW` の 6 経路を実コード trace で確定。fix 案 A (FB shader に `frag_data[3] = vec4(0,0,0,0)` write 追加) を recommend として記録。実機 canary 検証は未実施 (本書は静的解析ベース、AYA さん側で fix 案 A 試作 → 実機で peeling 解消確認の予定)

--- a/docs/specs/ayastorm-glow-rendering-routing.md
+++ b/docs/specs/ayastorm-glow-rendering-routing.md
@@ -1,0 +1,534 @@
+# AYAstorm Glow / Emissive Rendering Routing リファレンス
+
+**作成日**: 2026-05-25
+**対象**: deferred + forward を貫通する「emissive 出力 → 別 RT (`mGlow[3]`) → blur → composite」の確定マップ。effect 軸 4 本 (SSS / FullBright / Glow / 環境系) のうち **Glow / Emissive accumulation** 側を地図化する。
+**作成経緯**: FullBright prim 越しに SSS pink が漏れる bug 解析を直接の動機として SSS/FullBright/Glow/環境系 4 doc を整備中。Glow 自体は emissive を「**scene buffer の alpha channel**」と「**gbuffer3.rgb**」の 2 系統に書き、後段で `mGlow[3]` の独立 RT を経由して post-tonemap の後に composite される。経路が深く、FullBright 経路と密接に絡むため独立 doc として確定マップ化する。
+
+> **再利用方針**: glow / bloom / 撮影描画の post FX を触る前にまず本書を参照。**Glow を抑止すれば post チェーン (motion blur / DoF / FXAA) も止まる** ような単純構造ではなく、`combineGlow` は post FX (greyscale/sepia/posterize) の合成点でもあるので、Glow を bypass するなら post FX 合成点を別途確保する必要がある。
+> shader / RT 変更が `pipeline.cpp:generateGlow / combineGlow / addDeferredAttachments` あたりに入っていたら本書の更新要否を確認すること。
+
+---
+
+## 0. 結論先出し (3 行)
+
+1. **Glow 経路は「scene buffer.a」入力 + 「mGlow[3] 独立 RT」中継 + 「post-tonemap の glowcombineF」出力の三層**。FullBright/Emissive shader は **gbuffer3.rgb (deferred)** と **scene buffer.a (forward / LLDrawPoolGlow)** の 2 か所に emissive を分けて書き、softenLightF が gbuffer3.rgb を scene 加算する一方、scene buffer.a (= 「glow alpha」) は `generateGlow` で extract され `mGlow[3]` に格納される。
+2. **mGlow[3] は scene buffer と独立した解像度 (default 256×256)・format (RGBA / RGBA16F) の小型 ping-pong 3 枚で、blur (`glowF`) を kernel × iterations 回ローテートしたあと `combineGlow` で post-tonemap 結果と additive composite する**。「scene 解像度 = blur 解像度」ではないので、解像度を上げても scene quality は変わらず、glow の柔らかさだけが変わる。
+3. **合成順序 = `softenLightF (gbuffer3.rgb add)` → `forward alpha (scene.a += emissive)` → `LLDrawPoolGlow::renderPostDeferred (scene.a += legacy glow)` → `tonemap (scene → mPostPingMap)` → `generateGlow (extract → blur)` → `combineGlow (diff + emis)` → 以降の post (motion blur / DoF / FXAA / vignette)`**。
+   - つまり **glow blur は LDR tonemap 後の絵をソースに走る** ので、HDR ハイライトを直接 bloom にしているわけではない (sRGB に押し込んだ後の Luma しか入らない)。
+   - また **r30 BD post FX (greyscale / sepia / num_colors)** は `glowcombineF.glsl` で同時に乗る (`combineGlow` のついで処理)。glow を全 OFF にしても `combineGlow` 自体は走る (空の mGlow[1] と diff を足すだけになる) ので post FX は維持される — `sRenderGlow=false` 経路で `mGlow[1].clear()` だけして抜ける構造もこの「post FX 合成点を維持する」要請から来ている。
+
+---
+
+## 1. Glow RT 構築 (`pipeline.cpp:createGLBuffers`)
+
+`indra/newview/pipeline.h:993`:
+
+```cpp
+LLRenderTarget              mGlow[3];
+```
+
+`indra/newview/pipeline.cpp:1745-1754`:
+
+```cpp
+// allocate screen space glow buffers
+// <FS:AYAstorm r30 BD full port Phase 3.4> Cinematic では BD default (10) に固定
+const U32 glow_res = llmax(1, llmin(512, 1 << gSavedSettings.getS32("RenderGlowResolutionPow")));
+// </FS:AYAstorm>
+const bool glow_hdr = gSavedSettings.getBOOL("RenderGlowHDR");
+const U32 glow_color_fmt = glow_hdr ? GL_RGBA16F : GL_RGBA;
+for (U32 i = 0; i < 3; i++)
+{
+    mGlow[i].allocate(512, glow_res, glow_color_fmt);
+}
+```
+
+### 構造の確定値
+
+| 項目 | 値 | 注 |
+|---|---|---|
+| 枚数 | **3 枚** (`mGlow[0..2]`) | ping-pong 2 枚 + extract 用 1 枚 |
+| 解像度 (default) | **512 × `1 << RenderGlowResolutionPow`** (= 512 × 256 / 8 など) | width 固定 512、height は cvar で可変。`RenderGlowResolutionPow` default は通常 9 (= 512) だが r30 Cinematic では 10 を狙う |
+| Format | `GL_RGBA16F` (`RenderGlowHDR`=true) or `GL_RGBA` (false) | `mGlow[3]` は最初から alpha 持ち (gbuffer3 と違って `.a` は real storage) |
+| Depth/stencil | **なし** | post pass 用、3D geometry 描画しない |
+| 用途 |  | |
+| `mGlow[0]` | blur ping-pong 偶数 iter | 横方向 / 縦方向交互 |
+| `mGlow[1]` | blur ping-pong 奇数 iter / 最終結果 | `combineGlow` の `emissiveRect` source |
+| `mGlow[2]` | extract 結果 | `generateGlow` 最初の pass 出力、blur loop 0 回目入力 |
+
+release は `pipeline.cpp:1633-1636`。
+
+### `RenderGlowResolutionPow` の役割
+
+- shader cvar の `glow_res` (line 9003-9004 の `RenderGlowResolutionPow`) は **blur loop で kernel の delta を 1/glow_res 換算する** ためにも使用 (`pipeline.cpp:9007`)。
+- `glowResPow < 9` の時は delta を半分にする (line 9010-9013) ので、低解像度設定でも見た目が大きく崩れない。
+
+---
+
+## 2. Emissive 出力 source (どの shader が emissive を吐くか)
+
+emissive をどこに書くかは **「deferred opaque (= gbuffer3 経由)」** と **「forward / glow pool (= scene buffer.a 経由)」** の 2 系統に分かれる。表化:
+
+### 2.1 Deferred opaque writer (= gbuffer3.rgb / .a 経由)
+
+`grep "frag_data\[3\]"` 結果から emissive RGB を実際に書く writer は **pbropaqueF / pbrterrainF / pbrmetallicroughnessF の 3 種のみ** (legacy material 系は `.rgb=0`)。
+
+| Shader | gbuffer3 への書き込み | Pass / Pool | 流れる先 |
+|---|---|---|---|
+| `class1/deferred/pbropaqueF.glsl:131` | `vec4(emissive, aya_sss_skin_flag)` | POOL_GLTF_PBR / POOL_GLTF_PBR_ALPHA_MASK | softenLightF PBR 分岐 → `colorEmissive` |
+| `class1/deferred/pbrterrainF.glsl:436` | `vec4(mix_emissive, 0)` | POOL_TERRAIN (PBR) | softenLightF PBR 分岐 |
+| `class1/gltf/pbrmetallicroughnessF.glsl:249` | `vec4(emissive, 0)` | GLTF scene manager | softenLightF PBR 分岐 |
+| `class3/deferred/materialF.glsl:450` | `vec4(0, 0, 0, aya_sss_skin_flag)` | POOL_MATERIALS | **rgb=0 — emissive を gbuffer3 に書かない**。代わりに `frag_data[0].a = emissive` (= `glare`) に乗せる (line 440) |
+| `class1/deferred/avatarF.glsl:70` | `vec4(0, 0, 0, aya_sss_skin_flag)` | POOL_AVATAR | rgb=0 |
+| その他 (`bumpF` / `diffuseF` / `treeF` / `terrainF` / `impostorF` / `diffuseAlphaMask*F` / sky/celestial 系 / `highlightF`) | `vec4(0)` 系 | 各 deferred Pool | emissive 寄与なし |
+
+詳細: `docs/specs/ayastorm-gbuffer3-trace.md` 参照。**gbuffer3 は r20 で `GL_RGBA16F` に format 変更済** (LL 標準は `GL_RGB16F` で alpha なし) なので `.a` は AYAstorm では skin flag (SSS) と兼用。
+
+### 2.2 Forward / glow pool writer (= scene buffer.a 経由)
+
+scene buffer (`mRT->screen`) の alpha channel に additive で書く path:
+
+| Shader | scene.a 書き込み | Pool / Pass | 経由 dispatcher | Blend |
+|---|---|---|---|---|
+| `class1/deferred/emissiveF.glsl:37` | `vec4(0, 0, 0, diffuseLookup.a * vertex_color.a)` | POOL_GLOW / PASS_GLOW + PASS_GLOW_RIGGED | `LLDrawPoolGlow::renderPostDeferred` (`lldrawpoolsimple.cpp:45`) | `BT_ADD` + `setColorMask(false, true)` — **alpha だけ加算** |
+| `class1/deferred/pbrglowF.glsl:65` | `frag_color.rgb=0; frag_color.a = lum` (emissiveColor × emissiveMap の最大 ch) | POOL_GLTF_PBR / PASS_GLTF_GLOW + PASS_GLTF_GLOW_RIGGED | `LLDrawPoolGLTFPBR::renderPostDeferred` (`lldrawpoolpbropaque.cpp:76`, line 85-92) | `BT_ADD` 相当 + `setColorMask(false, true)` |
+| `class2/deferred/alphaF.glsl:317` (forward alpha BLEND) | `vec4(color.rgb, final_alpha)` | POOL_ALPHA | `LLDrawPoolAlpha::renderAlpha` | 通常 alpha blend — **`.a` には diffuse alpha が乗るので emissive ではない** が、それでも `mAYAAlphaColor.a` には溜まる |
+| `class1/deferred/fullbrightF.glsl:98` (forward, `IS_ALPHA`) | `vec4(color.rgb, final_alpha)` | POOL_ALPHA / POOL_FULLBRIGHT | forward alpha BLEND | 同上 |
+| `class1/deferred/fullbrightShinyF.glsl:93,95` (forward) | `color.a = 1.0; frag_color = color` | POOL_FULLBRIGHT_SHINY (forward) | — | alpha = 1 (= 「完全 fullbright として glow 全載せ」) で writes 後 BT_ADD は使わず、通常 forward blend に乗る |
+| `class1/deferred/pbralphaF.glsl` (forward alpha BLEND PBR) | `frag_color` (emissive 加算済 color) | POOL_ALPHA | forward alpha BLEND | emissive を **add 経由で別 draw** (= `renderPbrEmissives` / `renderRiggedPbrEmissives`) する。`lldrawpoolalpha.cpp:170` で `pbr_emissive_shader = &gPBRGlowProgram` |
+
+### 2.3 「FullBright が glow を強める」の意味
+
+FullBright surface は **lit を skip** して srgb texture をほぼそのまま scene に出すので、`fullbrightShinyF.glsl:93` で `color.a = 1.0` を立てると scene.a が 1 に近づく → `generateGlow` extract の **luminance gate (`minLuminance`) を簡単に超える** → glow にフル参加する。普通の lit 物体は `softenLightF.glsl:320` で `frag_color.a = 0.0` に明示クリアされるので、glow 寄与は gbuffer3.rgb 経由でしか乗らない。これが「**FullBright 越しに glow が乗りやすい**」観測の構造的根拠。
+
+---
+
+## 3. Glow extract pass (`generateGlow` / `glowExtractF.glsl`)
+
+呼び出し: `pipeline.cpp:10113` (`renderFinalize` の中、tonemap 直後)。
+
+```cpp
+generateGlow(&mPostPingMap);   // mPostPingMap = tonemap 後の scene
+```
+
+`pipeline.cpp:8947-9058` の本体:
+
+| ステップ | 動作 | 対象 RT |
+|---|---|---|
+| 1 | `mGlow[2].bindTarget(); mGlow[2].clear();` | extract dst |
+| 2 | `gGlowExtractProgram.bind()` + uniform set (`minLuminance` / `maxExtractAlpha` / `lumWeights` / `warmthWeights` / `warmthAmount`) | `effects/glowExtractF.glsl` |
+| 3 | `mPostPingMap` (= post-tonemap scene) を `DIFFUSE_MAP` に bind | scene src |
+| 4 | `BT_ADD_WITH_ALPHA` で fullscreen triangle 描画 | mGlow[2] に extract |
+| 5 | `mGlow[2].flush()` | |
+
+### `glowExtractF.glsl` の処理 (`indra/newview/app_settings/shaders/class1/effects/glowExtractF.glsl:47-67`):
+
+```glsl
+vec4 col = texture(diffuseMap, vary_texcoord0.xy);
+float lum     = smoothstep(minLuminance, minLuminance+1.0, dot(col.rgb, lumWeights));
+float warmth  = smoothstep(minLuminance, minLuminance+1.0,
+                           max(col.r*warmthWeights.r,
+                               max(col.g*warmthWeights.g, col.b*warmthWeights.b)));
+frag_color.rgb = col.rgb;
+frag_color.a   = max(col.a, mix(lum, warmth, warmthAmount) * maxExtractAlpha);
+```
+
+つまり mGlow[2] には:
+- `.rgb` = scene の RGB (そのまま)
+- `.a` = `max(scene.a, mix(lum, warmth, warmthAmount) * maxExtractAlpha)` = 「forward 経路で書かれた glow alpha」と「scene RGB の luminance/warmth から計算した派生 glow alpha」の合成
+
+が入る。
+
+### AYAstorm 固有改変 (r30 P4)
+
+`pipeline.cpp:8961-8963`:
+```cpp
+// <FS:AYAstorm r30 P4> Honor RenderGlowMinLuminance instead of hardcoded gate.
+gGlowExtractProgram.uniform1f(LLShaderMgr::GLOW_MIN_LUMINANCE, RenderGlowMinLuminance);
+```
+本家は `minLuminance` を hardcode していたが r30 P4 で `RenderGlowMinLuminance` cvar 経由に変更。
+
+### Noise (banding 緩和)
+
+`RenderGlowNoise=true` の時 (`pipeline.cpp:8971-8982`)、`glowNoiseMap` (= 128×128 noise texture) を bind して shader の `HAS_NOISE` 経路で extract 結果に dithering を加える。`maxExtractAlpha` を下げた時の精度損で出る banding を緩和する目的。
+
+---
+
+## 4. Blur pass (`glowF.glsl` / `glowV.glsl`)
+
+`pipeline.cpp:9006-9046`:
+
+```cpp
+S32 kernel = RenderGlowIterations * 2;      // r30 BD default: 5*2 = 10 回
+F32 delta  = RenderGlowWidth / glow_res;    // r30 BD: 3.6 / 256 など
+if (glowResPow < 9) delta *= 0.5f;
+F32 strength = RenderGlowStrength;          // r30 BD: 0.233
+
+gGlowProgram.bind();
+gGlowProgram.uniform1f(GLOW_STRENGTH, strength);
+
+for (S32 i = 0; i < kernel; i++)
+{
+    mGlow[i % 2].bindTarget();
+    mGlow[i % 2].clear();
+    if (i == 0)  bindTexture(DIFFUSE_MAP, &mGlow[2]);       // extract 結果
+    else         bindTexture(DIFFUSE_MAP, &mGlow[(i-1)%2]); // 前の iter
+
+    if (i % 2 == 0) uniform2f(GLOW_DELTA, delta, 0);   // 横方向
+    else            uniform2f(GLOW_DELTA, 0, delta);   // 縦方向
+
+    drawArrays(TRIANGLES, 0, 3);
+    mGlow[i % 2].flush();
+}
+```
+
+### `glowV.glsl` (`indra/newview/app_settings/shaders/class1/effects/glowV.glsl:43-51`):
+
+8 tap separable kernel の texcoord を `glowDelta * {-3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5}` で生成。
+
+### `glowF.glsl` (`indra/newview/app_settings/shaders/class1/effects/glowF.glsl:41-55`):
+
+```glsl
+float kern[8];
+kern[0]=0.25; kern[1]=0.5; kern[2]=0.8; kern[3]=1.0;
+kern[4]=1.0;  kern[5]=0.8; kern[6]=0.5; kern[7]=0.25;
+// 8 tap weighted sum → col
+frag_color = max(vec4(col.rgb * glowStrength, col.a), vec4(0));
+```
+
+8 tap × (`kernel = 2 * iterations`) 回。`RenderGlowIterations=5` なら **calc 10 pass、横→縦→横→縦… alternate** で 80 sample 相当の Gaussian-like blur。`mGlow[3]` の最終結果は **`mGlow[1]`** に残る (奇数 iter 終わり)。
+
+### `!sRenderGlow` 経路 (`pipeline.cpp:9051-9057`)
+
+```cpp
+else // !sRenderGlow, skip the glow ping-pong and just clear the result target
+{
+    mGlow[1].bindTarget();
+    glClearColor(0.f, 0.f, 0.f, 0.f);
+    mGlow[1].clear(GL_COLOR_BUFFER_BIT);
+    mGlow[1].flush();
+}
+```
+
+→ glow OFF でも `mGlow[1]` は 0 でクリアされ、後段 `combineGlow` は走り続ける。post FX (greyscale/sepia/posterize) の合成点として `combineGlow` が必要なので bypass しない構造。
+
+---
+
+## 5. Composite pass (`combineGlow` / `glowcombineF.glsl`)
+
+呼び出し: `pipeline.cpp:10136`:
+```cpp
+combineGlow(sourceBuffer, targetBuffer);   // sourceBuffer = tonemap 後の scene、targetBuffer = post 用 ping-pong
+std::swap(sourceBuffer, targetBuffer);
+```
+
+### `pipeline.cpp:9472-9507` 本体
+
+```cpp
+void LLPipeline::combineGlow(LLRenderTarget* src, LLRenderTarget* dst)
+{
+    dst->bindTarget();
+    gGlowCombineProgram.bind();
+    gGlowCombineProgram.bindTexture(DEFERRED_DIFFUSE,   src);
+    gGlowCombineProgram.bindTexture(DEFERRED_EMISSIVE, &mGlow[1]);
+
+    // <FS:AYAstorm:r30-bd-port> Phase 6 step 3: BD post FX (Cinematic only).
+    if (isCinematicMode())
+    {
+        uniform1f(GREYSCALE_STRENGTH, RenderGreyscaleStrength);
+        uniform1f(SEPIA_STRENGTH,     RenderSepiaStrength);
+        uniform1f(NUM_COLORS,         (GLfloat)RenderNumColors);
+    }
+    else
+    {
+        uniform1f(GREYSCALE_STRENGTH, 0.0f);
+        uniform1f(SEPIA_STRENGTH,     0.0f);
+        uniform1f(NUM_COLORS,         1.0f);
+    }
+
+    drawArrays(TRIANGLES, 0, 3);
+    dst->flush();
+}
+```
+
+### `glowcombineF.glsl` (`class1/interface/glowcombineF.glsl:39-63`)
+
+```glsl
+vec4 diff = texture(diffuseRect, tc);
+vec4 emis = texture(emissiveRect, tc);
+
+diff = diff + emis;                 // ← 単純 additive composite
+
+if (num_colors > 2)
+{
+    diff.rgb = pow(diff.rgb, vec3(0.6));
+    diff.rgb = floor(diff.rgb * num_colors) / num_colors;
+    diff.rgb = pow(diff.rgb, vec3(1.0/0.6));
+}
+diff.rgb = mix(diff.rgb, vec3(luma(diff)),   greyscale_str);
+diff.rgb = mix(diff.rgb, sepia_matrix*diff,  sepia_str);
+
+frag_color = diff;
+```
+
+合成は **`diff + emis` (= ONE/ONE additive)**。screen blend や softlight ではない。よって glow は **LDR tonemap 後の絵に対して輝度を足し増し** する操作で、HDR halo を直接表現しているわけではない。
+
+### Shader file binding
+
+`indra/newview/llviewershadermgr.cpp:3699-3710`:
+```cpp
+gGlowCombineProgram.mShaderFiles.push_back(make_pair("interface/glowcombineV.glsl", GL_VERTEX_SHADER));
+gGlowCombineProgram.mShaderFiles.push_back(make_pair("interface/glowcombineF.glsl", GL_FRAGMENT_SHADER));
+```
+
+`interface/` 配下にあるので class1 のみ (`class2`/`class3` バリアントなし)。
+
+---
+
+## 6. PBR vs non-PBR 分岐 (経路の差)
+
+| 観点 | non-PBR (legacy) | GLTF PBR |
+|---|---|---|
+| Glow 値の根 | prim 「Glow」スライダー (`te->getGlow()` `LLTextureEntry`) | GLTF material の emissive (`emissiveColor` × `emissiveMap`) |
+| 登録 path | `llvovolume.cpp:7273-7282` `!is_alpha && sRenderGlow && getGlow() > 0` 条件で `PASS_GLOW` 登録 | 同条件 + `gltf_mat` で `PASS_GLTF_GLOW` 登録 |
+| Pool | POOL_GLOW (`LLDrawPoolGlow`、`lldrawpool.h:196`) | POOL_GLTF_PBR / POOL_GLTF_PBR_ALPHA_MASK 内の post-deferred 第 2 pass |
+| dispatcher | `LLDrawPoolGlow::renderPostDeferred` (`lldrawpoolsimple.cpp:45-71`) | `LLDrawPoolGLTFPBR::renderPostDeferred` (`lldrawpoolpbropaque.cpp:76-94`) |
+| shader | `gDeferredEmissiveProgram` (`emissiveF.glsl`) | `gPBRGlowProgram` (`pbrglowF.glsl`) |
+| 書き先 | scene.a (= mRT->screen alpha channel)、`setColorMask(false, true)` | 同上 |
+| Forward alpha BLEND の emissive | `renderEmissives` (`lldrawpoolalpha.cpp:686`) で `gDeferredEmissiveProgram` を再利用 | `renderPbrEmissives` (`lldrawpoolalpha.cpp:699`) で `gPBRGlowProgram` を再利用 |
+| gbuffer3.rgb への emissive | 書かない (`materialF` は `frag_data[0].a = emissive` という legacy 別 channel) | `pbropaqueF:131` で書く |
+
+### softenLightF 側の差
+
+- PBR 分岐 (`softenLightF.glsl:213`): `pbrBaseLight(..., colorEmissive, ...)` で `colorEmissive` (= gbuffer3.rgb) を加算 (`deferredUtil.glsl:620` `color += colorEmissive`)
+- Legacy 分岐 (`softenLightF.glsl:234-312`): `colorEmissive` を **使わない** (PBR HDRI / SKIP_ATMOS 分岐のみ使う)。よって legacy material の emissive は softenLightF の scene 加算には乗らず、`renderPostDeferred` の `LLDrawPoolGlow` 経由で scene.a に書かれて glow blur で「halo」として再注入されるだけ。
+
+---
+
+## 7. FullBright との接合点
+
+FullBright/Emissive 関連 path の **scene 出力先と blend** をまとめる。FullBright doc (`docs/specs/ayastorm-fullbright-rendering-routing.md`) と冗長しても Glow 視点で書く:
+
+| Shader | Pool | dispatcher | 書き先 | scene.a (= glow seed) への影響 |
+|---|---|---|---|---|
+| `fullbrightF.glsl` (non-ALPHA, deferred opaque) | POOL_FULLBRIGHT | `LLDrawPoolFullbright::renderPostDeferred` | scene RGB (forward) | `final_alpha = color.a * vertex_color.a` がそのまま scene.a に乗る (line 81, 98)。texture alpha 1 = `color.a` 1 = glow seed 1 |
+| `fullbrightF.glsl` (`IS_ALPHA`, forward alpha BLEND) | POOL_ALPHA | `LLDrawPoolAlpha::renderAlpha` | scene RGB (forward) | 同上、blend で減衰 |
+| `fullbrightShinyF.glsl:93` (class3 forward) | POOL_FULLBRIGHT_SHINY / POOL_ALPHA | renderPostDeferred / renderAlpha | `color.a = 1.0` を hardcode | **scene.a が必ず 1 になる** → glow seed 飽和、「fullbright shiny は常に光って見える」原因 |
+| `emissiveF.glsl` (PASS_GLOW) | POOL_GLOW | `LLDrawPoolGlow::renderPostDeferred` | scene.a only (`setColorMask(false, true)`) | RGB 0 / A = diffuse.a × vertex.a を BT_ADD で書く。「prim Glow スライダー」の glow 注入点 |
+| `pbrglowF.glsl` (PASS_GLTF_GLOW) | POOL_GLTF_PBR | `LLDrawPoolGLTFPBR::renderPostDeferred` | scene.a only | RGB 0 / A = max(emissive.rgb) × vertex.a。「GLTF emissiveTexture」の glow 注入点 |
+| `pbropaqueF.glsl:131` (deferred opaque) | POOL_GLTF_PBR | `LLDrawPoolGLTFPBR::renderDeferred` | gbuffer3.rgb (emissive) + gbuffer3.a (skin flag) | softenLightF PBR 分岐で colorEmissive として **scene.RGB に加算** される (scene.a には乗らない) |
+| `materialF.glsl:440` (deferred opaque) | POOL_MATERIALS | `LLDrawPoolMaterials::render` | `frag_data[0].a = emissive` (= glare) | gbuffer0.a に乗るが softenLightF はこれを **読まない**。実際の glow 寄与は PASS_GLOW (= 上の `emissiveF.glsl`) 経由で別途 |
+
+### **観測される現象との対応**
+
+- 「FullBright prim の上を SSS pink (skin SSS overlay) が漏れる」 → SSS doc 参照だが、Glow 側から見ると **FullBright の `color.a` write (= scene.a)** が SSS post pass の `mask` read と取り違えられている可能性がある (gbuffer3.a / scene.a / mAYAAlphaColor.a の **3 つの "alpha" の混同**)。Glow seed としての scene.a は gate されず常時加算されるので、FullBright を貼ると glow 値も上がるが、SSS canary との直接因果は別経路の可能性が高い。詳細解析は SSS doc 側で続ける。
+- 「PBR emissive と prim Glow が二重に光る」 → GLTF PBR の emissive は **gbuffer3.rgb (softenLightF 経由) と PASS_GLTF_GLOW (scene.a 経由) の両方** に書かれる。GLTF emissiveTexture を強くした上で prim Glow を立てると **二重カウント**になる。これは LL 標準仕様、AYAstorm 改変なし。
+
+---
+
+## 8. gbuffer3 emissive bit (gbuffer3 channel 利用)
+
+詳細: `docs/specs/ayastorm-gbuffer3-trace.md`。Glow との接続点だけ抜粋:
+
+| Channel | 内容 | Writer | Reader |
+|---|---|---|---|
+| `gbuffer3.rgb` | linear emissive (PBR 専用) | `pbropaqueF` / `pbrterrainF` / `pbrmetallicroughnessF` | `softenLightF.glsl:152` (`colorEmissive = gb.emissive.rgb`)、`pointLightF.glsl:100` / `multiPointLightF.glsl:93` (local light の self-illumination)、`generateLuminance` (`pipeline.cpp:8644` で `mGlow[1]` を `DEFERRED_EMISSIVE` に bind するが、これは別話 — Luma 計算用) |
+| `gbuffer3.a` | AYAstorm r20: `aya_sss_skin_flag` (SSS mask) | `materialF` / `pbropaqueF` / `avatarF` (= skin writers) | `class3/deferred/skinSSSF.glsl` (`docs/ayastorm-sss-rendering-routing.md` 参照) |
+
+### `mGlow[1]` と `DEFERRED_EMISSIVE` の name collision 注意
+
+`pipeline.cpp:8644` (generateLuminance) と `pipeline.cpp:9484` (combineGlow) の両方で `mGlow[1]` を **`DEFERRED_EMISSIVE` という uniform 名で** bind しているが、これは「**glow blurred の最終結果**」であって「**gbuffer3 = emissiveRect**」ではない。同じ uniform slot 名を別 RT に流用しているだけで、storage は別。
+
+- generateLuminance 内: `mGlow[1]` (glow blur) を **`emissiveRect`** として読む → auto-exposure 計算に glow を反映する目的
+- combineGlow 内: `mGlow[1]` を **`emissiveRect`** として読む → diff + emis additive
+
+混同しないこと: `softenLightF` の `emissiveRect` は **gbuffer3 (= `mRT->deferredScreen` の color attachment 3)** であって `mGlow[1]` ではない。
+
+---
+
+## 9. AYAstorm 固有改変 (r30 周辺の Glow / Bloom)
+
+### r30 P4: `RenderGlowMinLuminance` cvar 化
+
+`pipeline.cpp:8961-8963`. 元は hardcode された minLuminance 閾値を cvar で可変に。撮影描画 (Cinematic) で luminance gate を下げて soft glow を狙うのが主用途。
+
+### r30 BD full port Phase 3.4: `RenderGlowResolutionPow` を Cinematic で BD default (10) に固定
+
+`pipeline.cpp:1746` のコメント参照。BD parity 検証中の cvar fixation。
+
+### r30 BD port Phase 6 step 3: `combineGlow` で post FX (greyscale / sepia / posterize) を統合
+
+`pipeline.cpp:9486-9500`. **Cinematic mode のみ** で `RenderPostGreyscaleStrength` / `RenderPostSepiaStrength` / `RenderPostPosterizationSamples` を `glowcombineF.glsl` に渡す。glow を OFF にしても post FX が乗るので、glow と post FX の switch を分離して扱える。
+- mode 0/1 (Firestorm/AYAstorm View) では `0/0/1` を渡す (= no-op)。
+
+### r30 P3 step 4: Volumetric Lighting (godrays) の挿入位置
+
+`pipeline.cpp:10118-10133`. **`generateGlow` の後・`combineGlow` の前** に挟まる別 post pass。Cinematic 専用、AY r15 lineage (`doGodrays`)。godrays は `mRT->screen` の atmospherics pass 段階 (`pipeline.cpp:5258`) でも別に乗るので二段構成。glow 経路とは別 RT 系統 (godrays は scene buffer に直接 additive)。
+
+### r30 P5 transparent-DoF C-(a): `mAYAAlphaColor` 経由の alpha-only RT
+
+`pipeline.cpp:10043-10082`. **glow とは独立した別 RT**。glow への副作用は line 10052-10058 のコメントに記録: alpha BLEND を `mAYAAlphaColor` に redirect する時、scene.a (= glow seed) を `(1 - plate.a)` で減衰させて LMB-on-HUD 経路との parity を取る。**これにより透過装着物の glow halo が「下に何があるかで変わる」挙動になる** ので、撮影描画で glow の見た目が異なる時はここを疑う。
+
+### r20: gbuffer3 format を `GL_RGBA16F` に変更
+
+`pipeline.cpp:394` (`addDeferredAttachments`)。gbuffer3 の `.a` を SSS skin flag に使うため LL 標準の `GL_RGB16F` を拡張。Glow 経路への影響は **storage が `.a` を持つようになった** こと自体だが、emissiveRect.a を「emissive 強度」として読む reader は存在しない (skin flag 専用)。
+
+---
+
+## 10. 経路まとめ図 (frame 1 回分の縦軸)
+
+```
+[1] deferred opaque draw
+   ├── pbropaqueF.glsl       → gbuffer3.rgb = emissive
+   ├── pbrterrainF.glsl      → gbuffer3.rgb = mix_emissive
+   ├── materialF.glsl        → frag_data[0].a = emissive (= glare、softenLightF は読まない)
+   └── その他 deferred writer → gbuffer3 = 0
+
+[2] softenLightF (renderDeferredLighting)
+   └── gbuffer3.rgb (PBR 分岐のみ) を scene.rgb に加算、frag_color.a=0 で scene.a クリア
+
+[3] renderGeomPostDeferred — 順序順に scene へ書く
+   ├── LLDrawPoolGlow::renderPostDeferred
+   │     └── emissiveF.glsl    → scene.a += diff.a * vertex.a (BT_ADD, mask false/true)
+   ├── LLDrawPoolGLTFPBR::renderPostDeferred (glow pass)
+   │     └── pbrglowF.glsl     → scene.a += lum(emissive) (BT_ADD, mask false/true)
+   ├── LLDrawPoolAlpha::renderAlpha
+   │     ├── 通常 alpha BLEND  → scene.rgba (alpha BLEND、scene.a も書かれる)
+   │     ├── renderEmissives    → emissiveF.glsl (= 上と同じ shader)
+   │     └── renderPbrEmissives → pbrglowF.glsl
+   └── (fullbright forward, fullbright_shiny forward 等)
+
+[4] tonemap (pipeline.cpp:10098)
+   └── mRT->screen (HDR) → mPostPingMap (LDR, sRGB)
+
+[5] generateGlow (pipeline.cpp:10113)
+   ├── mGlow[2] = glowExtractF(mPostPingMap)  // luminance/warmth gate
+   └── for i in [0..kernel): mGlow[i%2] = glowF(prev)  // separable blur
+
+[6] (optional) renderVolumetric (godrays、Cinematic only)
+   └── mPostPingMap → mPostPongMap
+
+[7] combineGlow (pipeline.cpp:10136)
+   └── targetBuffer = diff(src) + emis(mGlow[1]) + post FX
+       (greyscale / sepia / posterize は Cinematic only)
+
+[8] (optional) renderMotionBlurComposite、renderDoF、applyFXAA、renderVignette...
+```
+
+---
+
+## 11. 関連 cvar 一覧
+
+| cvar | default (本家) | r30 Cinematic 上書き値 (`settings_cinematic_bd.xml:62-92`) | 役割 |
+|---|---|---|---|
+| `RenderGlow` | true | (BD 値で同梱) | sRenderGlow master switch (`llviewershadermgr.cpp:649`) |
+| `RenderGlowResolutionPow` | 9 | 10 (`pipeline.cpp:1746` のコメント) | mGlow[] height = `1 << pow` |
+| `RenderGlowHDR` | true | — | mGlow[] format (`GL_RGBA16F` vs `GL_RGBA`) |
+| `RenderGlowIterations` | — | **5** (= 10 blur pass) | blur loop 回数 |
+| `RenderGlowWidth` | — | **3.6** | blur kernel spacing |
+| `RenderGlowStrength` | — | **0.233** | per-tap strength |
+| `RenderGlowWarmthAmount` | — | **16.0** | extract で luminance vs warmth 比率 |
+| `RenderGlowMaxExtractAlpha` | — | **0.03** | extract の output `.a` 上限 |
+| `RenderGlowMinLuminance` | — | **0.0** (r30 P4 で cvar 化) | extract luminance gate (smoothstep の下端) |
+| `RenderGlowLumWeights` | — | **(0.4, 0.3, 0.3)** | lum 計算重み (RGB) |
+| `RenderGlowWarmthWeights` | — | **(0.75, 0.6, 0.712)** | warmth 計算重み (RGB) |
+| `RenderGlowNoise` | (false) | — | dither ON で banding 緩和 |
+| `RenderPostGreyscaleStrength` | 0 | — (Cinematic UI で可変) | `combineGlow` の greyscale 強度 (Cinematic only) |
+| `RenderPostSepiaStrength` | 0 | — | `combineGlow` の sepia 強度 |
+| `RenderPostPosterizationSamples` | 1 | — | `combineGlow` の posterize 段階数 |
+
+---
+
+## 12. 落とし穴 / 注意
+
+1. **`emissiveRect` という uniform 名は 2 つの RT に流用される**: softenLightF の `emissiveRect` = `gbuffer3 (mRT->deferredScreen の attachment 3)`、`combineGlow` / `generateLuminance` の `emissiveRect` = `mGlow[1]` (blur 結果)。同名なので shader だけ見ると同じ RT に見えるが別物。
+2. **`glow_res` cvar は scene 解像度ではない**: `mGlow[]` は scene よりずっと低解像度 (default 512×256)。glow 解像度を上げても scene 描画コストは増えないが、blur 自体は scene-independent なので halo の柔らかさだけ変わる。
+3. **`!sRenderGlow` 経路でも `combineGlow` は走る**: post FX (greyscale / sepia / posterize) の唯一の合成点なので、glow を OFF にしても `mGlow[1]` を 0 で clear して `combineGlow` 自体は実行する。glow を完全 bypass する改変を入れる時はここを切ってはいけない。
+4. **`fullbrightShinyF.glsl:93` の `color.a = 1.0`** は **scene.a を強制的に 1 にする**。これにより fullbright_shiny は extract で必ず glow seed として残る。`alphaF.glsl` の `color.a = final_alpha` (= diffuse.a × vertex.a) と blend ルートが違うので、両者の glow 寄与は構造的に非対称。
+5. **legacy material (`materialF.glsl`) の emissive は softenLightF を経由しない**: `frag_data[0].a = emissive` で gbuffer0.a に書くが、softenLightF はこれを読まない。実際の glow 寄与は別 pool (POOL_GLOW) で `te->getGlow()` を `emissiveF` 経由で scene.a に書くだけ。legacy emissive を「surface 加算」したいなら別経路必要。
+6. **PBR emissive と prim Glow は二重カウントの可能性**: GLTF emissiveTexture (`pbropaqueF.glsl:131` で gbuffer3.rgb → softenLightF で scene.rgb 加算) と PASS_GLTF_GLOW (`pbrglowF.glsl` で scene.a 加算 → glow blur) は **両方発火する**。emissive を強くした上で `te->getGlow()` を立てると glow が想定外に強く見える。
+7. **glow blur source は LDR tonemap 後**: `generateGlow(&mPostPingMap)` の `mPostPingMap` は tonemap 結果。HDR ハイライトを直接 bloom にしているわけではないので、tonemap で sRGB に押し込まれた値を再度 luminance gate にかけている。物理的な HDR bloom が欲しい場合は tonemap 前で extract する別経路が必要。
+8. **`combineGlow` の合成は単純 `diff + emis` の additive**: screen blend / soft light ではないので、emis を強くすると簡単に sRGB clip する。`RenderGlowMaxExtractAlpha` (default 0.03) で extract 段階で抑えているのはこのため。
+
+---
+
+## 13. canary 設置パターン (再現用)
+
+shader path を実機で確認したい時は:
+
+- **`glowExtractF.glsl`** に `frag_color.rgb = vec3(1, 0, 1); frag_color.a = 1.0;` 等を書けば extract 直後の `mGlow[2]` を可視化 (scene 上は post-glow composite で見える)
+- **`glowF.glsl`** で `frag_color = vec4(0, 1, 0, 1);` にすれば blur loop を可視化
+- **`glowcombineF.glsl`** で `frag_color = emis;` だけ出すと glow only 表示 (diff が消えて halo だけ残る)、`frag_color = diff;` で逆。glow 寄与の比率を見たい時に便利
+
+deploy 先 (`project_shader_install_path.md`):
+- `~/ayastorm/app_settings/shaders/class1/effects/glowExtractF.glsl` 等
+- `~/ayastorm/app_settings/shaders/class1/interface/glowcombineF.glsl`
+
+cache clear (`project_ayastorm_shader_cache_path.md`):
+- `rm -rf ~/.ayastorm_x64/cache/shader_cache/`
+
+色割り当て推奨 (`feedback_diag_canary_design.md`):
+- glow extract → マゼンタ (1, 0, 1)
+- glow blur   → 緑 (0, 1, 0)
+- glow combine → シアン (0, 1, 1)
+
+---
+
+## 14. 関連ファイル
+
+### C++ (pipeline / pool)
+- `indra/newview/pipeline.h:993` — `LLRenderTarget mGlow[3]` 宣言
+- `indra/newview/pipeline.cpp:1745-1754` — `mGlow[]` allocate
+- `indra/newview/pipeline.cpp:1633-1636` — `mGlow[]` release
+- `indra/newview/pipeline.cpp:8947-9058` — `LLPipeline::generateGlow`
+- `indra/newview/pipeline.cpp:9472-9507` — `LLPipeline::combineGlow`
+- `indra/newview/pipeline.cpp:10113` — `generateGlow` 呼び出し点 (`renderFinalize`)
+- `indra/newview/pipeline.cpp:10136` — `combineGlow` 呼び出し点
+- `indra/newview/lldrawpoolsimple.cpp:45-71` — `LLDrawPoolGlow::renderPostDeferred`
+- `indra/newview/lldrawpoolpbropaque.cpp:76-94` — `LLDrawPoolGLTFPBR::renderPostDeferred` (PBR glow pass)
+- `indra/newview/lldrawpoolalpha.cpp:167-172` — alpha pool の emissive_shader / pbr_emissive_shader prep
+- `indra/newview/lldrawpoolalpha.cpp:686-758` — alpha pool の emissive dispatcher 群
+- `indra/newview/llvovolume.cpp:7273-7282` — `PASS_GLOW` / `PASS_GLTF_GLOW` の face 登録条件
+
+### Shader (effects / interface)
+- `indra/newview/app_settings/shaders/class1/effects/glowExtractV.glsl` — extract vertex (fullscreen triangle)
+- `indra/newview/app_settings/shaders/class1/effects/glowExtractF.glsl` — luminance/warmth gate
+- `indra/newview/app_settings/shaders/class1/effects/glowV.glsl` — 8 tap separable kernel texcoord
+- `indra/newview/app_settings/shaders/class1/effects/glowF.glsl` — 8 tap blur
+- `indra/newview/app_settings/shaders/class1/interface/glowcombineV.glsl` — composite vertex
+- `indra/newview/app_settings/shaders/class1/interface/glowcombineF.glsl` — composite + post FX
+
+### Shader (emissive writer / glow seed)
+- `indra/newview/app_settings/shaders/class1/deferred/emissiveV.glsl` / `emissiveF.glsl` — PASS_GLOW (legacy prim Glow スライダー)
+- `indra/newview/app_settings/shaders/class1/deferred/pbrglowV.glsl` / `pbrglowF.glsl` — PASS_GLTF_GLOW (GLTF emissive)
+- `indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl:131` — gbuffer3.rgb emissive write (PBR opaque)
+- `indra/newview/app_settings/shaders/class1/deferred/pbrterrainF.glsl:436` — gbuffer3.rgb emissive write (PBR terrain)
+- `indra/newview/app_settings/shaders/class3/deferred/materialF.glsl:440` — `frag_data[0].a = emissive` (legacy 用、softenLightF は読まない)
+- `indra/newview/app_settings/shaders/class1/deferred/fullbrightF.glsl` — fullbright forward (scene.a = final_alpha)
+- `indra/newview/app_settings/shaders/class3/deferred/fullbrightShinyF.glsl:93` — `color.a = 1.0` hardcode (scene.a 飽和点)
+
+### Settings
+- `indra/newview/app_settings/settings.xml` — RenderGlow* cvar default 群
+- `indra/newview/app_settings/settings_cinematic_bd.xml:62-92` — r30 Cinematic 上書き値 (BD parity)
+
+### 姉妹資料 (effect 軸 4 本)
+- `docs/specs/ayastorm-deferred-shader-routing.md` — object class 軸の routing 全体
+- `docs/specs/ayastorm-gbuffer3-trace.md` — gbuffer3 storage (emissiveRect) 仕様
+- `docs/specs/ayastorm-fullbright-rendering-routing.md` — FullBright effect 軸
+- `docs/ayastorm-sss-rendering-routing.md` — SSS effect 軸
+
+---
+
+## 15. 推測ベース / 未確認の項目 (本書の弱点)
+
+明示しておく:
+
+1. **`mGlow[3]` の `.a` channel の正確な物理利用**: `GL_RGBA / GL_RGBA16F` で alpha は real storage だが、`glowExtractF` で書き、`glowF` blur で kernel 重み付けして加算しているだけで、`glowcombineF` 側では `diff + emis` の vec4 加算でしか使われていない。出力 frag_color.a は post chain 後段でほぼ無視される (FXAA / vignette は diff.rgb のみ使う) ので、glow alpha は **生成と blur のためだけに存在し、最終出力ではほぼ使われない** 可能性が高い。明示確認はしていない。
+2. **`mGlow[1]` を `DEFERRED_EMISSIVE` slot で luminance 計算に bind する意図**: `generateLuminance` (`pipeline.cpp:8641-8645`) で `mGlow[1]` を読んでいるが、これが auto-exposure に glow を反映する意図か、Linden の uniform slot 再利用に過ぎないかは LL 側のコメントが薄く、本書では「auto-exposure に glow を反映する目的」と推定で書いた。
+3. **AYAstorm r30 Cinematic の glow tuning 値の根拠**: `settings_cinematic_bd.xml` の値は BD lineage と memo されているが、各値の最適性は本書では検証していない。tuning は別 phase 扱い (`project_r30_cinematic_control_tuning_deferred.md`)。
+4. **FullBright → SSS pink 漏れ bug の Glow 経路寄与**: §7 で構造的可能性は示したが、実機で「Glow を完全 OFF にすると SSS pink 漏れが消えるか」の実証はしていない。SSS doc 側で別途確認が必要。
+
+---
+
+## 16. 更新履歴
+
+- 2026-05-25 初版: effect 軸 4 本シリーズの 1 本として作成。`pipeline.cpp` / `lldrawpoolsimple.cpp` / `lldrawpoolpbropaque.cpp` / `lldrawpoolalpha.cpp` / `llvovolume.cpp` と各 emissive / glow / composite shader を上から下まで trace。SSS doc / FullBright doc / gbuffer3-trace / deferred-shader-routing と相互参照可能な粒度で確定マップ化

--- a/docs/specs/ayastorm-sss-rendering-routing.md
+++ b/docs/specs/ayastorm-sss-rendering-routing.md
@@ -1,0 +1,335 @@
+# AYAstorm SSS (Subsurface Scattering) Rendering Routing リファレンス
+
+**作成日**: 2026-05-25
+**作成経緯**: FullBright (FB) prim の後ろに SSS 設定アバターが居ると、SSS 色 (pink/salmon) の影が FB prim を**透けて見える**。AYAstorm 自作機能 `doSkinSSS` の routing がそもそも適切でない可能性を AYA さんが指摘。過去 2 回 3-4 時間ずつ shader 推論で潰そうとして両方失敗、機能軸 (effect 軸) で routing を地図化して構造原因を確定するための資料。
+**関連資料**:
+- `docs/ayastorm-deferred-shader-routing.md` (object class 軸の routing)
+- `docs/ayastorm-attachment-rendering-routing.md` (装着物 routing)
+- `docs/ayastorm-rez-object-rendering-routing.md` (rez object routing)
+- `docs/specs/ayastorm-gbuffer3-trace.md` (gbuffer3 storage 仕様)
+- `docs/specs/spec_avatar_skin_sss.md` (r20 SSS 機能仕様書)
+
+**ラベル**:
+- すべて **AYAstorm 固有** (`<FS:AYA r20 ...>` / `<FS:AYAstorm r30 ...>` で囲われた範囲)。
+- Firestorm 上流に SSS 機能は無い (本機能は r20 で AYAstorm が独自追加した screen-space SSS)。
+
+---
+
+## TL;DR — bleed の根本原因 3 候補 (最も疑わしい順)
+
+bug の症状「FB prim を透けて pink shadow が見える」を、コードトレースで物理的に再現可能な構造的原因として 3 つに絞った:
+
+1. **【最有力】 FullBright は deferred-opaque pass に参加せず `gbuffer3` に書かない → FB-covered pixel の `gbuffer3.a` は背後のアバターが先に書いた `aya_sss_skin_flag = 1` のまま残る。** SSS pass は `emissiveRect.a` を skin mask として読むが、それは「FB の背後にある avatar の skin bit」を読む。FB 自体が `vec4(0)` を `frag_data[3]` に書くチャンスが構造上ゼロ。FB を**深度 occluder としてしか登場させない** (post-deferred で `mRT->screen.rgb` だけ書く) ので、深度的に FB が手前でもマスクは avatar のものが透けて見える。
+   - 根拠: `lldrawpoolsimple.h:147` (FB は `getNumPostDeferredPasses()=1` のみ、`getNumDeferredPasses` override 無し)、`lldrawpoolsimple.cpp:156-182` (FB は post-deferred で `mRT->screen` だけ書く、gbuffer3 にはタッチしない)、`fullbrightF.glsl:28` (`out vec4 frag_color;` 単一 RT 出力)。
+
+2. **【次点】 SSS pass の入る位置が「post-water alpha 直前」= **post-deferred opaque + post-FullBright** より後。** `doSkinSSS()` のディスパッチ条件 `cur_type >= POOL_ALPHA_POST_WATER` (`pipeline.cpp:5242`) が走るのは、FullBright (POOL_FULLBRIGHT, POOL_FULLBRIGHT_ALPHA_MASK) のポスト・デファード描画**を含む** opaque/post-deferred 全部が終わった後。よって `diffuseRect` (mRT->screen) には FB の色がすでに焼き込まれていて、5-tap blur がそれを**サンプリング元**にしてしまう。skin mask が立っていなければ問題ないが (1) と組み合わさって stale な mask が立つので、FB の白色を pink-tinted weight でぼかして avatar 風の影に化けさせる。
+   - 根拠: `pipeline.cpp:5242-5265`, `pipeline.cpp:11758-11920` (`doSkinSSS` 実装)。
+
+3. **【補強】 gbuffer3 のクリア色が `(1, 0, 1, 1)` で、`.a = 1.0` が default 値。** 描画されない (=深度的に手前のものに完全に occlude された) 領域は **default で skin mask = 1.0** になる。sky 限定では skinSSSF が `d_raw >= 0.9999` で early return する safety net があるが (`skinSSSF.glsl:118`)、それは sky pixel のみで、**FB prim に隠れて何も書かれなかった avatar 領域には効かない** (depth は FB が書くので near-side、sky early-out 条件に該当しない)。
+   - 根拠: `llviewerdisplay.cpp:1093` (`glClearColor(1, 0, 1, 1)`), `skinSSSF.glsl:118-123` (sky safety net は depth==1.0 のみ)。
+
+**結論**: 場当たり的に「FB prim 用 if 文」を入れても潰せないのは、構造上 FB が **gbuffer3 に書く機会を持たない** から。fix の方向性は (a) FB prim を**深度 pre-pass で skin_flag=0 を gbuffer3.a に書かせて occlude する** (= FB 専用 frag_data[3] 出力経路を追加)、または (b) SSS pass で `gbuffer3.a` ではなく **`emissiveRect.a == aya_sss_skin_flag` AND depth match against the surface that wrote it** で二段検証する (depth が一致しない時は mask=0)、もしくは (c) skin bit を gbuffer3 から **stencil** に移して FB が深度書込み時に stencil clear させる、のいずれか。詳細は §F に。
+
+---
+
+## A. SSS 機能の入口 (cvar / uniform / 配線)
+
+### A.1 cvar (gSavedSettings)
+
+| Cvar | type | default | 役割 | 参照 |
+|------|------|---------|------|------|
+| `AYAVisualRealismEnabled` | U32 | 1 | View mode (0=Firestorm / 1=AYAstorm / 2=Cinematic)、`>0` で SSS dispatch 許可 | `pipeline.cpp:11771` `pipeline.cpp:5251` |
+| `AYAR20AvatarSkinSSSEnabled` | bool | true (出荷時 ON) | SSS master toggle、mode 1/2 共通 (r30 consolidation 後) | `pipeline.cpp:11772` `pipeline.cpp:5253` |
+| `AYAR20AvatarSkinSSSBlurRadius` | F32 | 1.0 | 1m 基準の pixel タップ間隔 (世界座標スケール、距離で逆比例) | `pipeline.cpp:11792` |
+| `AYAR20AvatarSkinSSSStrength` | F32 | 0.5 (出荷)、AYA 検証実用 0.7 | pass2 の blend 係数 (= mix factor) | `pipeline.cpp:11793` |
+| `AYAR20AvatarSkinSSSGlowGain` | F32 | 0.2 (出荷)、AYA 検証実用 3.0 | glow restore の強度 | `pipeline.cpp:11795` |
+| `AYAR20AvatarSkinSSSGlowColor` | Color4 | warm salmon | glow restore tint | `pipeline.cpp:11796` |
+| `AYAR20AvatarSkinSSSWhitelist` | String | (空) | mesh UUID newline-separated whitelist | `llayaskinsss.cpp:23` |
+| `RenderEnableEmissiveBuffer` | bool | **0 (default OFF)** | gbuffer3 の物理 attachment を制御。これが OFF だと SSS は実質効かない | `settings.xml:11924-29` `pipeline.cpp:499` |
+
+### A.2 GLSL uniforms (SSS shader 内)
+
+`indra/llrender/llshadermgr.{h,cpp}` の `LLShaderMgr::ReservedUniforms` に追加された AYAstorm reserved uniform:
+
+| Uniform 名 | type | 配線元 | 配線先 shader | 役割 |
+|------------|------|--------|---------------|------|
+| `aya_blur_dir` | vec2 | `pipeline.cpp:11806,11845,11897` | `skinSSSF.glsl:39` | (1,0) pass1 horizontal / (0,1) pass2 vertical |
+| `aya_strength` | float | `pipeline.cpp:11807,11846,11898` | `skinSSSF.glsl:40` | pass1=1.0 (scratch fill) / pass2=cvar strength |
+| `aya_blur_radius` | float | `pipeline.cpp:11808,11847,11899` | `skinSSSF.glsl:41` | 1m 基準 pixel |
+| `aya_glow_gain` | float | `pipeline.cpp:11809,11848,11900` | `skinSSSF.glsl:42` | glow restore gain |
+| `aya_glow_color` | vec3 | `pipeline.cpp:11810,11849,11901` | `skinSSSF.glsl:43` | glow restore tint (RGB) |
+| `AYA_VISUAL_REALISM_ENABLED` | int | `pipeline.cpp:11851,11903` | `skinSSSF.glsl:44` | master gate (現在は r20_active で gate 済のため常に 1) |
+| `AYA_R20_SKIN_SSS_ENABLED` | int | `pipeline.cpp:11852,11904` | `skinSSSF.glsl:45` | r20 gate (現在常に 1) |
+| `AYA_SSS_SKIN_FLAG` | float | `lldrawpool.cpp:1093-1097`, `lldrawpoolavatar.cpp:904,948`, `lldrawpoolmaterials.cpp:155-229` | `avatarF.glsl:37` `pbropaqueF.glsl:60` `materialF.glsl:209` | per-draw 0.0/1.0、gbuffer3.a に書く |
+
+### A.3 per-draw flag propagation (whitelist → GBuffer)
+
+```
+[ユーザー右クリック / cvar 編集]
+  ↓
+SkinSSSMatcher::instance().reloadAndReevaluate()           [llayaskinsss.cpp:184]
+  ↓
+LLCharacter::sInstances 全走査 → 各 avatar.attachment → setSSSTargetForAttachment
+  ↓
+apply_sss_flag()                                            [llayaskinsss.cpp:227]
+  └─ obj->setSSSTarget(match)                               [llviewerobject.h:208]
+  └─ gPipeline.markRebuild(REBUILD_GEOMETRY)                [llayaskinsss.cpp:234]
+  └─ group->setState(GEOM_DIRTY)                            [llayaskinsss.cpp:237]
+  ↓
+[次フレーム以降 LLVolumeGeometryManager::rebuildGeom]
+  ↓
+LLVOVolume::registerFace → LLDrawInfo 構築                  [llvovolume.cpp:5842]
+  └─ draw_info->mIsSSSTarget = vobj->isSSSTarget()
+  ↓
+[毎フレーム描画時 deferred opaque pass]
+  ↓
+LLDrawPoolMaterials::pushBatch (legacy material) 等
+  └─ glUniform1f(AYA_SSS_SKIN_FLAG, params.mIsSSSTarget ? 1.0 : 0.0)
+  ↓
+materialF / pbropaqueF / avatarF
+  └─ frag_data[3] = vec4(0, 0, 0, aya_sss_skin_flag)        [gbuffer3.a に書く]
+```
+
+---
+
+## B. SSS pass の挿入位置
+
+### B.1 dispatch site (pipeline.cpp)
+
+`LLPipeline::renderGeomPostDeferred` 内の **pool 反復ループ**で、`POOL_ALPHA_POST_WATER` (= `atmospherics_pass`) 境界に達した瞬間に `doSkinSSS()` を呼ぶ:
+
+| 位置 | コード | 注釈 |
+|------|--------|------|
+| `pipeline.cpp:5200` | `U32 atmospherics_pass = LLDrawPool::POOL_ALPHA_POST_WATER;` | dispatch 閾値 |
+| `pipeline.cpp:5242-5265` | `if (cur_type >= atmospherics_pass && !done_atmospherics) { doAtmospherics(); ...; if (dispatch_r20) doSkinSSS(); }` | 1 フレーム 1 回 |
+| `pipeline.cpp:5255` | `bool dispatch_r20 = (aya_view_mode() > 0) && aya_r20_enabled_disp;` | call-site gate |
+| `pipeline.cpp:11758` | `void LLPipeline::doSkinSSS()` | 本体 |
+| `pipeline.cpp:11762` | `if (sImpostorRender || gCubeSnapshot) return;` | impostor / cube map では走らない |
+| `pipeline.cpp:11774` | `if (!r20_active) return;` | self-gate (二重ガード) |
+
+### B.2 反復ループにおける順序
+
+`LLDrawPool` enum order (`lldrawpool.h:57-79`):
+
+```
+POOL_SKY (1)
+POOL_WATEREXCLUSION
+POOL_WL_SKY
+POOL_SIMPLE
+POOL_FULLBRIGHT       ← FullBright 通常 (post-deferred で render)
+POOL_BUMP
+POOL_MATERIALS        ← legacy material (deferred opaque、gbuffer3.a 書く)
+POOL_GLTF_PBR         ← GLTF PBR (deferred opaque、gbuffer3.a 書く)
+POOL_TERRAIN
+POOL_GRASS
+POOL_GLTF_PBR_ALPHA_MASK
+POOL_TREE
+POOL_ALPHA_MASK
+POOL_FULLBRIGHT_ALPHA_MASK
+POOL_AVATAR           ← Linden 標準 avatar (deferred opaque、gbuffer3.a 書く)
+POOL_CONTROL_AV       ← animesh
+POOL_GLOW
+POOL_ALPHA_PRE_WATER
+POOL_VOIDWATER
+POOL_WATER
+POOL_ALPHA_POST_WATER ← ★ ここで doSkinSSS() が dispatch される
+POOL_ALPHA
+```
+
+**重要**: ループは pool order で回るが、各 pool の `renderPostDeferred` は **同じループ内**で呼ばれる (`pipeline.cpp:5281-5295`)。よって POOL_SIMPLE / POOL_FULLBRIGHT / POOL_FULLBRIGHT_ALPHA_MASK の `renderPostDeferred` (= FB prim を `mRT->screen` に焼く処理) は **`doSkinSSS()` より前**に完了している。
+
+### B.3 段階的タイムライン (1 フレーム)
+
+| Phase | 何が起きるか | gbuffer3.a の状態 | mRT->screen.rgb の状態 |
+|-------|-------------|-------------------|------------------------|
+| 1. `deferredScreen.clear()` | `glClearColor(1, 0, 1, 1)` | **全 pixel = 1.0** | (まだ未使用) |
+| 2. `renderGeomDeferred` (opaque) | sky/material/PBR/avatar 等が gbuffer3 に書く | sky=0.0, material=0/1, avatar=0/1, **FB 領域はクリア値 1.0 のまま** | (まだ未使用) |
+| 3. `renderDeferredLighting` (`softenLightF`) | gbuffer → `mRT->screen` に lighting 解決 | (read-only) | sky+opaque lit color |
+| 4. `renderGeomPostDeferred` の前半 (POOL_SIMPLE 以降の `renderPostDeferred`) | FullBright / glow / alpha が `mRT->screen` に上書き、**gbuffer3 にはタッチしない** | (変化なし) | FB pixel が opaque lit の上に塗られる |
+| 5. `cur_type >= POOL_ALPHA_POST_WATER` → `doSkinSSS()` | SSS pass 1 (horizontal) / pass 2 (vertical)、`emissiveRect` (= gbuffer3) を skin mask、`diffuseRect` (= mRT->screen) を blur source | (read-only) | **FB pixel に対して、gbuffer3.a が 1.0 なら blur 結果を blend** ← bleed の発火点 |
+| 6. POOL_ALPHA_POST_WATER 以降の alpha 描画 | 透過物が `mRT->screen` に上書き | (変化なし) | alpha 透過物が上に乗る |
+
+---
+
+## C. どの shader が「SSS 計算」をするか
+
+### C.1 SSS pass 本体 (= screen-space blur)
+
+| Shader | 役割 | 入力 | 出力 | 参照 |
+|--------|------|------|------|------|
+| `class1/deferred/skinSSSV.glsl` | screen-triangle pass-through VS | screen quad | `vary_fragcoord` | (短いので省略) |
+| `class1/deferred/skinSSSF.glsl` | 5-tap separable blur + 波長依存重み + glow restore + skin mask | `diffuseRect` (scene), `emissiveRect` (gbuffer3, mask), `depthMap` (gbuffer-depth, eye_dist 計算), `inv_proj` (NDC→eye)、cvar uniform 群 | `frag_color = vec4(blurred_rgb, strength * skin_bit)` | `skinSSSF.glsl` 全体 |
+
+`skinSSSF.glsl` の構造:
+
+1. **Master gate** (`l.77-81`): `aya_visual_realism_enabled <= 0 || aya_r20_skin_sss_enabled <= 0` で pass-through (alpha=0、pass2 blend で no-op)。
+2. **Sky safety net** (`l.118-123`): `d_raw >= 0.9999` (far plane) で `frag_color = vec4(0)`、sky pixel の SSS 暴走を防止。
+3. **Eye distance reconstruction** (`l.125-127`): NDC depth → `inv_proj * vec4(0,0,ndc_z,1)` → `eye_dist = abs(vp.z/vp.w)`。
+4. **World-scale blur radius** (`l.128-130`): `r_eff = aya_blur_radius / max(eye_dist, 1.0)`、1m 以上は逆スケール。
+5. **5-tap separable blur** (`l.133-139`): weights 配列で R を広く / B を狭く配分、波長依存にじみを擬似的に作る。
+6. **Inner glow + glow restore** (`l.146-154`): blurred sum の輝度をベースに warm 加算と sRGB power curve で peak 増強。
+7. **Mask application** (`l.171-173`): `skin_bit = (gbuffer3.a >= 0.5) ? 1.0 : 0.0`、`frag_color.a = aya_strength * skin_bit`。
+
+### C.2 gbuffer3.a writer 一覧 (skin flag を書く shader)
+
+| Shader | gbuffer3.a write | 用途 | 参照 |
+|--------|------------------|------|------|
+| `class1/deferred/avatarF.glsl` | `aya_sss_skin_flag` | Linden 標準 avatar body (gDeferredAvatarProgram) | `avatarF.glsl:70` |
+| `class1/deferred/pbropaqueF.glsl` | `max(emissive, aya_sss_skin_flag).a` | GLTF PBR opaque (POOL_GLTF_PBR) | `pbropaqueF.glsl:131` |
+| `class3/deferred/materialF.glsl` | `aya_sss_skin_flag` | legacy material (PASS_MATERIAL*/SPECMAP*/NORMMAP*/NORMSPEC*) | `materialF.glsl:450` |
+| `class1/deferred/sky*F.glsl`、`cloudsF.glsl`、`sunDiscF.glsl`、`moonF.glsl`、`starsF.glsl` | `0.0` | sky/celestial が gbuffer3.a=0 にクリア | `skyF.glsl:131` 他 |
+| `class1/deferred/bumpF`、`diffuseF*`、`treeF`、`terrainF`、`impostorF`、`highlightF` | `0.0` | 旧 simple pass の opaque | gbuffer3-trace doc 参照 |
+| `class1/gltf/pbrmetallicroughnessF.glsl` | `max(emissive,0).a` = 通常 0 | GLTF scene manager (forward) | 該当 shader |
+
+**観測**: 上記 writer はすべて **deferred 描画パス** で動く。**FullBright (`fullbrightF.glsl`) は frag_data[3] を持たない** (single `out vec4 frag_color`)。
+
+### C.3 gbuffer3.a を書かない shader
+
+- `class1/deferred/fullbrightF.glsl` — single render target only (`out vec4 frag_color;`、`l.28`)。POOL_SIMPLE / POOL_FULLBRIGHT の post-deferred 経路で使われ、deferredScreen FBO は bind されていない。
+- `class1/deferred/fullbrightV.glsl` (VS、当然) — N/A
+- alpha pool 系の forward shader (`pbralphaF.glsl`, `alphaF.glsl`, `fullbrightF.glsl#IS_ALPHA` permutation 等) — alpha は alpha-pre/post-water pool で `mRT->screen` のみに書く。
+
+→ **これらの shader が描いた pixel の `gbuffer3.a` は、その背後の deferred-opaque pass が書いた値のまま残る**。これが §A.2 の bleed origin。
+
+---
+
+## D. SSS pass のサンプリング源 / depth gate
+
+### D.1 各 texture binding (両 pass)
+
+| Sampler | 内容 | bind 元 (pipeline.cpp) |
+|---------|------|------------------------|
+| `diffuseRect` (DEFERRED_DIFFUSE) | pass1: `mRT->screen` (deferred lit + post-deferred 焼込済) / pass2: `mWaterDis` (pass1 結果) | `pipeline.cpp:11828, 11880` |
+| `emissiveRect` (DEFERRED_EMISSIVE) | `deferred_target->bindTexture(3, ...)` = gbuffer3.a | `pipeline.cpp:11831-11837, 11883-11889` |
+| `depthMap` (DEFERRED_DEPTH) | deferredScreen.depth (eye_dist 計算用) | `pipeline.cpp:11841, 11893` |
+| `inv_proj` | LLRender reserved uniform (自動 bind) | (auto) |
+
+### D.2 offset 範囲
+
+`skinSSSF.glsl:130` の `step = aya_blur_dir * r_eff / screen_res`、5 タップ `t = -2..+2`。
+
+- pass1 (horizontal): `step = (r_eff/W, 0)`、両側 ±2 pixel × `r_eff`
+- pass2 (vertical): `step = (0, r_eff/H)`、両側 ±2 pixel × `r_eff`
+
+世界座標スケールで、近接 (eye_dist=1m, aya_blur_radius=1.0) なら半径 1 pixel × 2 = ±2 pixel、10m 先なら ±0.2 pixel = 実質 0。**近接時の最大ブリード幅は ±2 pixel × 2 pass = 最悪 ±4 pixel 程度**。
+
+### D.3 depth 境界処理
+
+**重要**: SSS pass は **per-tap depth comparison を行わない**。タップ毎の depth と中心 pixel の depth を比較してブリード範囲を制限するロジックは無い。`skinSSSF.glsl` には center pixel の `d_raw` を取って eye_dist を計算する処理しか無い (`l.103`)。
+
+| 境界ロジック | 有無 | コメント |
+|-------------|------|---------|
+| center pixel sky early-out (`d_raw >= 0.9999`) | あり | `skinSSSF.glsl:118-123` |
+| per-tap depth check (= bilateral blur) | **なし** | これが入っていれば FB との境界で blur が止まるが、現状は無条件サンプリング |
+| stencil test | **なし** | gbuffer3.a を mask に使う設計 |
+| skin_mask threshold (0.5) | あり | `skinSSSF.glsl:171-172`、binary 化 |
+
+→ 「FB の手前/avatar の奥」を区別する depth 検証は中央 pixel の sky 判定のみ。5-tap blur のサンプリング元 (`diffuseRect`) は **無条件** に近傍 4 pixel を読み込む。
+
+### D.4 stencil
+
+stencil bit は本機能では使われていない (`pipeline.cpp` の `doSkinSSS` で stencil 設定なし)。
+
+### D.5 depth test 設定
+
+`pipeline.cpp:11812`: `LLGLDepthTest depth(GL_FALSE, GL_FALSE)` — pass1/pass2 ともに depth test/write OFF。screen-quad なので当然だが、`gbuffer3.a` mask だけが gate。
+
+---
+
+## E. FullBright との交差点 (bleed の物理)
+
+### E.1 FullBright の routing
+
+| Shader | 経路 | render target | gbuffer3.a への書込 |
+|--------|------|---------------|---------------------|
+| `gDeferredFullbrightProgram` | POOL_FULLBRIGHT::renderPostDeferred (post-deferred) | `mRT->screen` | **無** |
+| `gDeferredFullbrightAlphaMaskProgram` | POOL_FULLBRIGHT_ALPHA_MASK::renderPostDeferred / POOL_ALPHA_*::render | `mRT->screen` | **無** |
+| `gDeferredFullbrightAlphaMaskAlphaProgram` | POOL_ALPHA_*::render (alpha-blend 経路) | `mRT->screen` | **無** |
+| `gHUDFullbrightProgram` | HUD パス | (HUD FBO) | **無** (IS_HUD permutation で対象外) |
+
+参照: `lldrawpoolsimple.cpp:163-181`、`lldrawpoolalpha.cpp:174-178`、`llviewershadermgr.cpp:2030-2031`。
+
+### E.2 FB-covered pixel の gbuffer3.a 由来 (場合分け)
+
+「FB prim の screen pixel P」における gbuffer3.a の最終値は以下の順で決まる:
+
+1. `deferredScreen.clear()` → `.a = 1.0` (`llviewerdisplay.cpp:1093`)
+2. deferred-opaque pass で P を覆う最後の writer が走る:
+   - もし P が **sky 領域 (FB の背後に何もない)** → skyF が `.a = 0` を書く → P.a = 0
+   - もし P が **avatar 領域 (FB の背後に avatar が居る)** → avatarF/pbropaqueF/materialF が `.a = aya_sss_skin_flag` を書く → P.a = 0 (whitelist 未登録) or **1.0 (登録済)**
+   - もし P が **GLTF PBR forward 領域** → pbrmetallicroughnessF が `.a = 0` を書く → P.a = 0
+3. post-deferred で FB が P を覆って `mRT->screen.rgb` に色を焼く。**gbuffer3.a は変化しない**。
+4. doSkinSSS が走る。P で `emissiveRect.a = 1.0` (avatar が登録済 SSS target だった場合) → `skin_bit = 1.0` → strength=0.7 で blur 結果を mix → **FB に avatar 色がぼかされて焼き付く**。
+
+### E.3 直接観測される現象との対応
+
+| AYA さん報告 | コード上の発火点 |
+|--------------|------------------|
+| 「SSS 色 (pink) の影が FB を透ける」 | E.2 の step 4。skin_bit=1 のまま FB pixel に対して blur がかかり、avatar 色 (lit skin = pink salmon 系) が ±2 pixel の 5-tap で持ち込まれる |
+| 「アバターの頭/体/衣類が pink shadow として漏れる」 | 衣類が SSS target に登録されていなくても、隣接する skin 部位 (頭/体) の lit 色を blur 結果に含む → 衣類覆い領域に隣の skin の pink がにじむ |
+| 「FB の輪郭に沿って漏れる」 | 5-tap separable blur のタップが ±2 pixel まで届くため、FB silhouette の縁 ±2-4 pixel 幅で skin color が滲む |
+
+---
+
+## F. 既知の bleed origin 候補 (fix 検討用、推測含む)
+
+| 候補 | 根拠 | 影響 | fix の方向性 |
+|------|------|------|--------------|
+| **F1. FullBright が gbuffer3.a を書かない (← 最有力)** | §C.3、§E | FB 背後の avatar の `aya_sss_skin_flag=1` が stale で残る | (a) FB shader に `frag_data[3] = vec4(0)` を書ける permutation を追加し、FB の deferred-pre-pass を作る / (b) skin mask に depth match を併用 (skin pixel の depth と中心 pixel depth が乖離してたら mask=0) / (c) skin bit を stencil に移行し FB depth 書込時に clear |
+| **F2. SSS pass が post-deferred + post-FB な位置にある** | §B.3 | FB の色が `mRT->screen` に焼かれた後で blur source として使われる | SSS pass を `renderDeferredLighting` 直後 (= softenLight 解決直後) に移動。POOL_SIMPLE / FB の post-deferred より前。ただし atmospherics/water ordering との競合確認要 (推測) |
+| **F3. SSS blur に depth-bilateral が無い** | §D.3 | ±2 pixel 範囲で無条件サンプル、depth 境界で stop しない | per-tap で `depthMap` を読み中心 depth との差 > 閾値なら weight=0 にする (Jimenez Separable SSS は元々 bilateral 込み)。実装コストは shader 5 行程度 |
+| **F4. gbuffer3.a の clear color が 1.0** | `llviewerdisplay.cpp:1093` | 何も書かれない領域が default で skin mask=1 になる (sky early-out で救うのは sky 限定) | `glClearColor(1, 0, 1, 0)` に変更 (sky 等の magenta canary は維持しつつ `.a` のみ 0)。広範囲影響あるので git grep `(1, 0, 1, 1)` で当たり確認要 |
+| **F5. avatar の per-prim mask 飛ばし**: rigged BLEND (透過服) の **alpha pool 描画** が gbuffer3.a を **クリアしない** | `lldrawpoolalpha.cpp` は alpha pool で `mRT->screen` のみ書く、gbuffer3 不変。透過服の背後の skin bit が露出 | 透過服越しの skin にも SSS blur が露出 (本来は隠れている skin 部位の色がにじむ) | 透過服に対しても deferred-pre-pass で `gbuffer3.a=0` を書く (= F1 と同根) |
+| **F6. blur radius が cvar で大きく振れる** | `pipeline.cpp:11792`, AYA 検証実用値 r=1.0 だが UI 上 max 32 | r が大きいと近接時 ±2*32 = ±64 pixel まで滲み、FB 越え bleed が視覚的に顕著化 | UI で max を絞る (例: max 4) / 強警告 — 推測、優先度低 |
+
+---
+
+## G. 追記事項 / 推測フラグ
+
+以下は**コードから物理的に確認できなかった**項目。`docs/specs/spec_avatar_skin_sss.md` の Phase D2 や git log 履歴と矛盾しない範囲で並べたが、確証は無い:
+
+- **F2 の修正で水面・大気との順序が壊れる可能性**: 上流 LL の `doAtmospherics` / `doWaterHaze` 順序を変更すると water 透過の歪みが入りうる。実機検証必須。(推測)
+- **F1 の (a) 案で FB shader に frag_data[3] を追加すると、`HAS_EMISSIVE` permutation との互換性**: 既存 FullBright が deferred FBO に bind されない設計なので、別 program を作る必要がある可能性あり (= 工数大)。(推測)
+- **stencil 移行 (F1-c) の VRAM/format コスト**: `deferredScreen` の depth attachment が stencil 込みかどうかは未確認。`addColorAttachment` 周辺で depth/stencil format を確認する必要あり (推測)。
+- **rigged BLEND alpha (clothing) の挙動**: 上記 F5 は構造的に成立するが、実際に SL の典型 BoM 装着で「透過服が skin pixel を覆っている」配置がどの程度頻発するかは不明。実機 repro 要 (推測)。
+
+---
+
+## H. 参考 file:line 索引
+
+### CPU 側
+- `indra/newview/llayaskinsss.h:35` — `SkinSSSMatcher` singleton 定義
+- `indra/newview/llayaskinsss.cpp:184-210` — `reloadAndReevaluate`、全 avatar 再評価
+- `indra/newview/llayaskinsss.cpp:227-241` — `apply_sss_flag`、`setSSSTarget` + REBUILD_GEOMETRY
+- `indra/newview/llviewerobject.h:207-208` — `isSSSTarget()` / `setSSSTarget()`
+- `indra/newview/llviewerobject.h:1082` — `mIsSSSTarget` (default false)
+- `indra/newview/llspatialpartition.h:156` — `LLDrawInfo::mIsSSSTarget`
+- `indra/newview/llvovolume.cpp:5842` — `draw_info->mIsSSSTarget = vobj->isSSSTarget()` (geometry rebuild 時の伝搬)
+- `indra/newview/llvoavatar.cpp:8605` — `attachObject` で `setSSSTargetForAttachment` 呼出
+- `indra/newview/pipeline.cpp:486-516` — `addDeferredAttachments`、gbuffer3 を RGBA16F に拡張 (Phase C)
+- `indra/newview/pipeline.cpp:5242-5265` — `doSkinSSS()` dispatch site (POOL_ALPHA_POST_WATER 境界)
+- `indra/newview/pipeline.cpp:11758-11920` — `doSkinSSS()` 本体 (pass1/pass2)
+- `indra/newview/llviewerdisplay.cpp:1085-1095` — `deferredScreen` clear (color=1,0,1,1)
+- `indra/newview/llviewerdisplay.cpp:1130` — `renderGeomDeferred` 呼出
+- `indra/newview/lldrawpoolsimple.h:134-156` — `LLDrawPoolFullbright` 定義 (post-deferred のみ)
+- `indra/newview/lldrawpoolsimple.cpp:156-182` — `LLDrawPoolFullbright::renderPostDeferred`
+- `indra/newview/lldrawpoolavatar.cpp:902-909, 945-953` — `aya_sss_skin_flag` を Linden body / eyeballs に push
+- `indra/newview/lldrawpoolmaterials.cpp:155-156, 229` — `aya_sss_skin_flag` を legacy material per-batch push
+- `indra/newview/lldrawpool.cpp:1090-1098` — GLTF PBR per-draw push
+- `indra/newview/llviewercontrol.cpp:1860-1887` — `AYAR20SSSEffective` の View mode 連動更新
+
+### GLSL 側
+- `indra/newview/app_settings/shaders/class1/deferred/skinSSSF.glsl` — SSS blur 本体 (全 175 行)
+- `indra/newview/app_settings/shaders/class1/deferred/skinSSSV.glsl` — pass-through VS
+- `indra/newview/app_settings/shaders/class1/deferred/avatarF.glsl:37,70` — Linden body の gbuffer3.a writer
+- `indra/newview/app_settings/shaders/class1/deferred/pbropaqueF.glsl:60,131` — GLTF PBR opaque の gbuffer3.a writer
+- `indra/newview/app_settings/shaders/class3/deferred/materialF.glsl:209,450` — legacy material の gbuffer3.a writer
+- `indra/newview/app_settings/shaders/class1/deferred/fullbrightF.glsl:28` — FB single-RT 出力 (= gbuffer3.a を書かない原因の一次資料)
+- `indra/newview/app_settings/shaders/class1/deferred/skyF.glsl:131`、`cloudsF.glsl:164`、`sunDiscF.glsl:57`、`moonF.glsl:66`、`starsF.glsl:70` — sky/celestial の gbuffer3.a=0 クリア
+- `indra/llrender/llshadermgr.h` / `llshadermgr.cpp` — `AYA_SSS_SKIN_FLAG` / `AYA_VISUAL_REALISM_ENABLED` / `AYA_R20_SKIN_SSS_ENABLED` reserved uniform 登録
+
+### Settings / UI
+- `indra/newview/app_settings/settings.xml:10121-10181` — `AYAR20AvatarSkinSSS*` cvar 群
+- `indra/newview/app_settings/settings.xml:11924-11929` — `RenderEnableEmissiveBuffer` (default 0)
+- `indra/newview/skins/default/xui/en/panel_preferences_sss.xml` — Preferences > Graphics > SSS タブ
+- `indra/newview/skins/default/xui/en/floater_aya_cinematic.xml:434-464` — Cinematic 用 SSS controls

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -5192,6 +5192,9 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
     bool done_atmospherics = LLPipeline::sRenderingHUDs; //skip atmospherics on huds
     bool done_water_haze = done_atmospherics;
     bool done_water_exclusion = false;
+    // <FS:AYAstorm bug fix> SSS dispatch を FB pool より前に動かすため独立 flag を導入。
+    bool done_sss = LLPipeline::sRenderingHUDs;
+    // </FS:AYAstorm>
 
     // do water exclusion just before water pass.
     U32 water_exclusion_pass = LLDrawPool::POOL_WATEREXCLUSION;
@@ -5206,6 +5209,12 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
 
     // do water haze just before pre water alpha
     U32 water_haze_pass = LLDrawPool::POOL_ALPHA_PRE_WATER;
+
+    // <FS:AYAstorm bug fix> SSS を FullBright/postDeferred より前で発火させて
+    //   FB prim 越しに SSS pink が透ける bug を解消。scene color が FB で
+    //   上書きされる前 (softenLight 直後の素 skin 色) を sample させる。
+    U32 sss_pass = LLDrawPool::POOL_FULLBRIGHT;
+    // </FS:AYAstorm>
 
     calcNearbyLights(camera);
     setupHWLights();
@@ -5225,6 +5234,11 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
     bool low_detail_probe = probe_level == 0 && gCubeSnapshot;
     done_atmospherics = done_atmospherics || low_detail_probe;
     done_water_haze   = done_water_haze || low_detail_probe;
+    // <FS:AYAstorm bug fix> 旧コードでは SSS が atmospherics と同 block にあったため
+    //   low_detail_probe の done_atmospherics 経由で skip されていた。独立 dispatch に
+    //   分離した本 fix でも cube snapshot 時の挙動を維持するため done_sss も同様に gate。
+    done_sss = done_sss || low_detail_probe;
+    // </FS:AYAstorm>
 
 
     while ( iter1 != mPools.end() )
@@ -5239,6 +5253,25 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
             done_water_exclusion = true;
         }
 
+        // <FS:AYAstorm bug fix> SSS を FullBright/postDeferred より前で発火。
+        //   旧: atmospherics と同 block (POOL_ALPHA_POST_WATER) で発火、mRT->screen が
+        //       FB で塗られた状態を sample → FB pixel に skin pink shadow が滲む bug。
+        //   新: POOL_FULLBRIGHT 到達直前で発火、scene color は softenLight 直後の素 skin 色のまま、
+        //       FB が後で覆い被さるので SSS は FB pixel に乗らない。
+        //   r20 SSS dispatch 条件は元と同じ (mode > 0 && AYAR20AvatarSkinSSSEnabled)。
+        if (cur_type >= sss_pass && !done_sss)
+        {
+            static LLCachedControl<U32>  aya_view_mode_sss(gSavedSettings, "AYAVisualRealismEnabled", 1);
+            static LLCachedControl<bool> aya_r20_enabled_sss(gSavedSettings, "AYAR20AvatarSkinSSSEnabled", false);
+            bool dispatch_r20 = (aya_view_mode_sss() > 0) && aya_r20_enabled_sss;
+            if (dispatch_r20)
+            {
+                doSkinSSS();
+            }
+            done_sss = true;
+        }
+        // </FS:AYAstorm>
+
         if (cur_type >= atmospherics_pass && !done_atmospherics)
         { // do atmospherics against depth buffer before rendering alpha
             doAtmospherics();
@@ -5246,20 +5279,14 @@ void LLPipeline::renderGeomPostDeferred(LLCamera& camera)
             // <FS:AYAstorm r30 BD改善> AYAstorm View は無条件、Cinematic は個別 InCinematic cvar で opt-in。
             //   各関数も自己 gate 済 (Phase 3.1 / r20 早期 return) だが call-site でも wrap して
             //   Cinematic OFF 時の関数 entry を無駄ゼロ化。
-            //   r20 SSS は consolidation 後 mode 1/2 共通の単一 cvar (AYAR20AvatarSkinSSSEnabled) で
-            //   dispatch されるため、call-site では mode > 0 と enabled のみで判定。
+            //   r15 Godrays は atmospherics 後の light scattering なので atmospherics ブロックに残置。
+            //   r20 SSS は本 fix で FB 前 dispatch に分離済 (上の sss_pass ブロック)。
             static LLCachedControl<U32>  aya_view_mode(gSavedSettings, "AYAVisualRealismEnabled", 1);
             static LLCachedControl<bool> aya_r15_in_cinematic(gSavedSettings, "AYAR15GodraysInCinematicEnabled", false);
-            static LLCachedControl<bool> aya_r20_enabled_disp(gSavedSettings, "AYAR20AvatarSkinSSSEnabled", false);
             bool dispatch_r15 = (aya_view_mode() == 1) || (aya_view_mode() == 2 && aya_r15_in_cinematic);
-            bool dispatch_r20 = (aya_view_mode() > 0) && aya_r20_enabled_disp;
             if (dispatch_r15)
             {
                 doGodrays();
-            }
-            if (dispatch_r20)
-            {
-                doSkinSSS();
             }
             // </FS:AYAstorm>
         }


### PR DESCRIPTION
## Summary

- **bug**: FullBright prim の後ろに SSS 設定アバターがいると、SSS の pink shadow が頭/体/衣類の形で FB prim を透けて見えていた (過去 2 回 3-4h ずつ調査して断念)
- **根本原因**: `POOL_FULLBRIGHT` 系 4 経路 (`fullbrightF.glsl` / `fullbrightShinyF.glsl`) は single-RT 出力で gbuffer3.a を触らない → 背後 avatar が opaque pass で書いた `aya_sss_skin_flag=1` が stale で残り、SSS pass (`skinSSSF.glsl`) が FB pixel を skin 判定して `mRT->screen` の FB 色を入力に blur → アバター形状で pink が滲む
- **fix**: SSS dispatch を `POOL_ALPHA_POST_WATER` 到達時 → `POOL_FULLBRIGHT` 到達直前に動かす。FB が scene color を上書きする前 (softenLight 直後の素 skin 色) を sample させる構造変更。`pipeline.cpp::renderGeomPostDeferred` の dispatch 1 ブロック移動 + `done_sss` / `sss_pass` 独立 flag/変数の新設のみ。FB shader 改修なし、可逆

## アプローチの転換

過去 2 回 if 文での場当たり対応で失敗していたので、本 PR では先に **effect 軸 routing 地図 4 本** を並列 agent で整備 (1894 行)。既存の object 軸 routing 資料 (deferred / attachment / rez-object / gbuffer3-trace) と相補的なリファレンスとして再利用可能。4 本独立に同じ仮説に到達したので根本原因の信頼度は高い。

- `docs/specs/ayastorm-sss-rendering-routing.md`
- `docs/specs/ayastorm-fullbright-rendering-routing.md` (§9.1 で案 A〜D 比較、本 PR は案 D 採用)
- `docs/specs/ayastorm-glow-rendering-routing.md`
- `docs/specs/ayastorm-environment-rendering-routing.md`

## Test plan

- [x] FB prim の後ろに SSS 設定アバターを配置 → 透け解消を実機確認
- [x] 通常時 (FB prim 無し) の SSS 表現に違和感無し (atmospherics 前 sample になった副作用なし)
- [x] cube snapshot (reflection probe) 時の SSS skip 挙動は `done_sss \|\| low_detail_probe` で旧挙動維持
- [ ] godrays / atmospherics 順序は不変 (atmospherics ブロック内に残置) — 撮影シーンで再確認推奨
- [ ] underwater 時 (`atmospherics_pass = POOL_WATER`) の見え方 — 機会あれば確認

## Risk

- 案 A (FB shader を MRT 化) ではなく案 D を採用。gbuffer3.a の構造的二重意味問題 (skin mask と emissive blend factor) はそのまま残るので、将来別 effect で同型 bug が出る可能性はある。本 PR は SSS 経路に限定した解決