### PR TITLE
release: r31-bugfix-1 Downloads 3 OS 実 URL 記入 + macOS 復活反映

### DIFF
--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.en.md
@@ -35,11 +35,9 @@ Venue IRs bundled in r11 (and still shipping) are from OpenAIR (CC-BY 4.0). Sour
 
 ## Downloads
 
-_To be filled in by @mayatonton after the 2 OS (Linux / Windows) build completes._
-
-- Linux Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX.tar.xz`
-- Windows Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX_Setup.exe`
-- macOS Installer: **Not provided in this release.** Bundled in the upcoming r32 chapter (per r10.x precedent: bugfix-N releases ship Linux/Windows only)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261441503_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261442337.tar.xz)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.ja.md
@@ -35,11 +35,9 @@ r11 で同梱し以降も出荷中の venue IR は OpenAIR (CC-BY 4.0) 由来で
 
 ## Downloads
 
-_2 OS (Linux / Windows) build 完了後に @mayatonton が記入予定。_
-
-- Linux Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX.tar.xz`
-- Windows Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX_Setup.exe`
-- macOS Installer: **本リリースでは非提供。** 次の r32 章でまとめて同梱予定です (r10.x の前例どおり、bugfix-N リリースは Linux/Windows のみ)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261441503_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261442337.tar.xz)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.zh.md
@@ -35,11 +35,9 @@ r11 同捆并持续出货的 venue IR 来自 OpenAIR(CC-BY 4.0)。来源: [`app_
 
 ## Downloads
 
-_2 OS(Linux / Windows)构建完成后由 @mayatonton 填写。_
-
-- Linux Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX.tar.xz`
-- Windows Installer: _TBD_ — `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-XXXXXX_Setup.exe`
-- macOS Installer: **本次发布不提供。** 将在即将到来的 r32 章一并同捆(按 r10.x 先例,bugfix-N 版本仅提供 Linux/Windows)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261441503_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-1/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261442337.tar.xz)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.en.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.en.md
@@ -59,7 +59,6 @@ The four routing maps (1894 lines total) ship in this release as a permanent reu
 
 - The structural double meaning of `gbuffer3.a` (SSS skin mask **and** emissive MRT blend factor) is not resolved by this fix. The same class of bug may surface again for a future effect that reads `gbuffer3.a` after a single-RT pass
 - A more structural fix (case A: MRT-ize the FB shaders so they write a clean `gbuffer3.a`) remains open as future work. For SSS, the present fix is complete
-- **macOS build is bundled in the r32 chapter** (per the r10.x precedent: bugfix-N releases ship Linux/Windows only)
 
 ### Implementation summary
 

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.ja.md
@@ -59,7 +59,6 @@ SSS dispatch 位置を移動しました:
 
 - `gbuffer3.a` の構造的二重意味 (SSS skin mask と emissive MRT blend factor) は本 fix では解消していません。single-RT pass 後に `gbuffer3.a` を読む将来の effect で同型のバグが再発する可能性があります
 - より構造的な fix (案 A: FB shader を MRT 化してクリーンな `gbuffer3.a` を書かせる) は将来課題として残っています。SSS については本 fix で完了です
-- **macOS build は r32 章で同梱予定**です (r10.x の前例どおり、bugfix-N リリースは Linux/Windows のみ提供)
 
 ### Implementation summary
 

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.zh.md
@@ -59,7 +59,6 @@
 
 - `gbuffer3.a` 在结构上的双重含义(SSS skin mask 与 emissive MRT blend factor)本次未解决。今后若有 effect 在 single-RT pass 之后读取 `gbuffer3.a`,同类 bug 仍可能复发
 - 更根本的结构修复(案 A: 将 FB shader MRT 化,使其写入干净的 `gbuffer3.a`)仍是开放课题。就 SSS 而言本次已完整修复
-- **macOS 构建将在 r32 章一同提供**(按 r10.x 先例,bugfix-N 版本仅提供 Linux/Windows)
 
 ### 实现概要
 

--- a/docs/release/ayastorm-r31-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-github-release-page.en.md
@@ -85,11 +85,11 @@ The AYAstorm View pipeline draws extensively from NiranV Dean's Black Dragon vie
 
 ## Downloads
 
-> **Linux / Windows: please use [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) instead.** r31-bugfix-1 fixes a structural SSS pink-shadow leak through FullBright prims that was present in r31. macOS remains on this r31 build until r32 bundles the fix (per r10.x precedent: bugfix-N releases ship Linux/Windows only).
+> **Please use [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) instead.** r31-bugfix-1 fixes a structural SSS pink-shadow leak through FullBright prims that was present in r31, and ships installers for all 3 OS (Linux / Windows / macOS).
 
 - Linux Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 - Windows Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31+bundle-fs.80646/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81208.dmg) — current macOS build; r32 will bundle the SSS leak fix
+- macOS Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-github-release-page.ja.md
@@ -85,11 +85,11 @@ AYAstorm View pipeline は NiranV Dean 氏の Black Dragon viewer (LGPL-2.1、vi
 
 ## Downloads
 
-> **Linux / Windows ユーザーの方は [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) をご利用ください。** r31 に存在していた FullBright prim 越し SSS pink-shadow 透けの構造バグを r31-bugfix-1 で修正済みです。macOS は r32 で fix を同梱するまで本 r31 ビルドのままです (r10.x の前例どおり、bugfix-N リリースは Linux/Windows のみ提供)。
+> **[AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) をご利用ください。** r31 に存在していた FullBright prim 越し SSS pink-shadow 透けの構造バグを r31-bugfix-1 で修正済みで、3 OS (Linux / Windows / macOS) すべてのインストーラーを同梱しています。
 
 - Linux Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 - Windows Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31+bundle-fs.80646/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81208.dmg) — 現行 macOS ビルド (r32 で SSS leak fix を同梱予定)
+- macOS Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-github-release-page.zh.md
@@ -85,11 +85,11 @@ AYAstorm View pipeline 大量借鉴自 NiranV Dean 的 Black Dragon viewer (LGPL
 
 ## Downloads
 
-> **Linux / Windows 用户请改用 [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)。** r31 中存在的 FullBright prim 透过 SSS pink-shadow 渗漏的结构性 bug 已在 r31-bugfix-1 中修复。macOS 在 r32 同捆该修复前继续使用本 r31 构建(按 r10.x 先例,bugfix-N 版本仅提供 Linux/Windows)。
+> **请改用 [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)。** r31 中存在的 FullBright prim 透过 SSS pink-shadow 渗漏的结构性 bug 已在 r31-bugfix-1 中修复,并同捆全部 3 个 OS(Linux / Windows / macOS)的安装包。
 
 - Linux Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 - Windows Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31+bundle-fs.80646/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81208.dmg) — 当前 macOS 构建(r32 将同捆 SSS leak 修复)
+- macOS Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

- **bugfix-1 github-release-page.{en,ja,zh}.md** の Downloads セクションに 3 OS 実 URL を記入 (Linux + Windows + macOS、tag `v7.2.4-ayastorm-r31-bugfix-1` 配下)
- **bugfix-1 release-note.{en,ja,zh}.md** から「macOS は r32 で bundle」記述を削除 (macOS も bugfix-1 で同梱されるため)
- **r31 github-release-page.{en,ja,zh}.md** Downloads: macOS も bugfix-1 release ページへ誘導に統一 (Linux/Win と同パターン、3 OS とも redirect)

## Files

| OS | Installer |
|---|---|
| Windows | `Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261441503_Setup.exe` |
| macOS | `Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg` (t-noami さん build) |
| Linux | `Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261442337.tar.xz` |

## Test plan

- [ ] PR merge 後、`gh release create v7.2.4-ayastorm-r31-bugfix-1` で 3 installer attach + body = github-release-page.en.md
- [ ] r31 release ページから bugfix-1 への redirect リンクが 3 OS とも生きている