### PR TITLE
docs(release): r31-bugfix-1 Credits/Contributors に @t-noami さん追記、対等並列に

### DIFF
--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.en.md
@@ -41,4 +41,4 @@ Venue IRs bundled in r11 (and still shipping) are from OpenAIR (CC-BY 4.0). Sour
 
 ## Contributors
 
-@mayatonton
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.ja.md
@@ -41,4 +41,4 @@ r11 で同梱し以降も出荷中の venue IR は OpenAIR (CC-BY 4.0) 由来で
 
 ## Contributors
 
-@mayatonton
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-bugfix-1-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-1-github-release-page.zh.md
@@ -41,4 +41,4 @@ r11 同捆并持续出货的 venue IR 来自 OpenAIR(CC-BY 4.0)。来源: [`app_
 
 ## Contributors
 
-@mayatonton
+@t-noami @mayatonton

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.en.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.en.md
@@ -71,7 +71,8 @@ The four routing maps (1894 lines total) ship in this release as a permanent reu
 
 ### Credits
 
-[@mayatonton](https://github.com/mayatonton) — implementation, routing-map authoring, bug analysis.
+- [@t-noami](https://github.com/t-noami) — macOS build for r31-bugfix-1, alongside ongoing implementation contributions across AYAstorm (r24 Dullahan audio callback, r25 Ogg Vorbis codec, r26 3D Stream media ring, r27 macOS branding, and more).
+- [@mayatonton](https://github.com/mayatonton) — r31-bugfix-1 SSS pink-shadow fix implementation, routing-map authoring, bug analysis.
 
 ### Documentation
 

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.ja.md
@@ -71,7 +71,8 @@ SSS dispatch 位置を移動しました:
 
 ### Credits
 
-[@mayatonton](https://github.com/mayatonton) — 実装、routing 地図整備、バグ解析。
+- [@t-noami](https://github.com/t-noami) — r31-bugfix-1 の macOS ビルドに加え、AYAstorm 全体への継続的な実装貢献 (r24 Dullahan audio callback / r25 Ogg Vorbis codec / r26 3D Stream media ring / r27 macOS branding ほか)。
+- [@mayatonton](https://github.com/mayatonton) — r31-bugfix-1 SSS pink-shadow 修正の実装、routing 地図整備、バグ解析。
 
 ### Documentation
 

--- a/docs/release/ayastorm-r31-bugfix-1-release-note.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-1-release-note.zh.md
@@ -71,7 +71,8 @@
 
 ### 致谢
 
-[@mayatonton](https://github.com/mayatonton) — 实现、routing 地图编写、bug 分析。
+- [@t-noami](https://github.com/t-noami) — r31-bugfix-1 的 macOS 构建,以及 AYAstorm 全局的持续实装贡献 (r24 Dullahan audio callback / r25 Ogg Vorbis codec / r26 3D Stream media ring / r27 macOS branding 等)。
+- [@mayatonton](https://github.com/mayatonton) — r31-bugfix-1 SSS pink-shadow 修复实装、routing 地图编写、bug 分析。
 
 ### 文档
 


### PR DESCRIPTION
## Summary

- r31-bugfix-1 の release-note (en/ja/zh) と github-release-page (en/ja/zh) 計 6 ファイルの Credits/Contributors を更新
- @t-noami さんの貢献を macOS build に留まらず、r24 Dullahan audio callback / r25 Ogg Vorbis codec / r26 3D Stream media ring / r27 macOS branding など継続的な実装貢献として記述
- 過去 r24-r30 release と揃え、`@t-noami @mayatonton` の対等並列順序

## Why

bugfix-1 の初版 Credits が `[@mayatonton] — implementation, ...` 単独 + `macOS installer build is by @t-noami` という従属的な書き方になっており、t-noami さんの本来の継続貢献規模と乖離していた。AYA レビュー指摘により対等並列に修正。

## Test plan

- [x] release-note 3 言語版で Credits が箇条書き 2 名並列 (t-noami → mayatonton 順)
- [x] github-release-page 3 言語版で Contributors が `@t-noami @mayatonton`
- [ ] merge 後、GitHub Release body (v7.2.4-ayastorm-r31-bugfix-1) も同内容に同期更新