### PR TITLE
fix(glow): Cinematic mode blank+colored prim 誤発火 bloom 矯正

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10263,6 +10263,17 @@ Change of this parameter will affect the layout of buttons in notification toast
       <key>Value</key>
       <integer>0</integer>
     </map>
+    <key>AYAR31GlowMinLuminanceMigrationVersion</key>
+    <map>
+      <key>Comment</key>
+      <string>Cinematic overlay RenderGlowMinLuminance 値の bugfix one-shot migration version sentinel。BD 由来の 0.0 が「blank texture + 色付きプリム」で意図しない bloom 発火を起こす副作用に対し、0.5 へ強制上書きする。0=未適用 (起動時に強制 0.5 上書き)、1=適用済 (no-op)。手動で 0 に戻すと再 migration が走る</string>
+      <key>Persist</key>
+      <integer>1</integer>
+      <key>Type</key>
+      <string>S32</string>
+      <key>Value</key>
+      <integer>0</integer>
+    </map>
     <key>AYAR16AerialPerspectiveStrength</key>
     <map>
       <key>Comment</key>

--- a/indra/newview/app_settings/settings_cinematic_bd.xml
+++ b/indra/newview/app_settings/settings_cinematic_bd.xml
@@ -75,7 +75,7 @@
     <real>0.03</real>
 
     <key>RenderGlowMinLuminance</key>
-    <real>0.0</real>
+    <real>0.5</real>
 
     <key>RenderGlowLumWeights</key>
     <array>

--- a/indra/newview/llappviewer.cpp
+++ b/indra/newview/llappviewer.cpp
@@ -3288,6 +3288,13 @@ bool LLAppViewer::initConfiguration()
     LLCinematicOverlay::applyR15GodraysCinematicMigrationIfNeeded();
     // </FS:AYAstorm>
 
+    // <FS:AYAstorm> r31.2 Cinematic overlay RenderGlowMinLuminance bugfix migration.
+    // One-shot; safe in every startup path (no-op once
+    // AYAR31GlowMinLuminanceMigrationVersion >= 1). 既存 r31.0 / r31.1 ユーザーの
+    // persist 値 0.0 を 0.5 に強制矯正。
+    LLCinematicOverlay::applyR31GlowMinLuminanceMigrationIfNeeded();
+    // </FS:AYAstorm>
+
     // <FS:Ansariel> Debug setting to disable log throttle
     nd::logging::setThrottleEnabled(gSavedSettings.getBOOL("FSEnableLogThrottle"));
 

--- a/indra/newview/llcinematicoverlay.cpp
+++ b/indra/newview/llcinematicoverlay.cpp
@@ -208,3 +208,47 @@ void LLCinematicOverlay::applyR15GodraysCinematicMigrationIfNeeded()
         << ENABLED_CONTROL << " " << (old_value ? "true" : "false") << " -> true" << LL_ENDL;
 }
 // </FS:AYAstorm>
+
+// <FS:AYAstorm> r31.2 Cinematic overlay RenderGlowMinLuminance bugfix migration.
+// BD parity port で持ち込まれた RenderGlowMinLuminance=0.0 が、blank texture +
+// 色付きプリム (装着物 / SIM rez object 両方) で意図しない bloom 発火を起こす。
+// shader (glowExtractF.glsl) は smoothstep(minLuminance, minLuminance+1.0, x)
+// で bloom 寄与を計算するため、0.0 では HDR linear 空間 0〜1.0 の中間 lit でも
+// 発火し、`warmth = max(r*0.75, g*0.6, b*0.712)` 経路で色付きが優位に光る。
+// 0.5 に上げると HDR > 0.5 (sky lit / 強い反射 / 強い emissive) だけ拾い、
+// 装着物クラスの中間 lit は切れる。空 / 街灯 / 強い反射などの Cinematic
+// 表現は維持される。
+// Persist 値が r31.0 / r31.1 で 0.0 に焼かれているユーザーを一度だけ強制矯正。
+void LLCinematicOverlay::applyR31GlowMinLuminanceMigrationIfNeeded()
+{
+    static const char VERSION_CONTROL[] = "AYAR31GlowMinLuminanceMigrationVersion";
+    static const char CVAR_CONTROL[]    = "RenderGlowMinLuminance";
+    static const char MODE_CONTROL[]    = "AYAVisualRealismEnabled";
+    static const F32  NEW_VALUE         = 0.5f;
+
+    const S32 ver = gSavedSettings.getS32(VERSION_CONTROL);
+    if (ver >= 1)
+    {
+        return;
+    }
+
+    // RenderGlowMinLuminance は LL 標準 cvar で全 mode 共通。BD overlay の不正値
+    // (0.0) が焼かれているのは Cinematic mode で起動した経験のあるユーザーだけ。
+    // Firestorm mode のみ使うユーザーは LL default 1.0 で問題なく動作しているので
+    // 上書きしない (skip し、version も bump せず次回起動で再検査)。Cinematic mode
+    // に初めて切り替えて再起動した時に migration が走る。
+    const U32 mode = gSavedSettings.getU32(MODE_CONTROL);
+    if (mode != 2)
+    {
+        return;
+    }
+
+    const F32 old_value = gSavedSettings.getF32(CVAR_CONTROL);
+    gSavedSettings.setF32(CVAR_CONTROL, NEW_VALUE);
+    gSavedSettings.setS32(VERSION_CONTROL, 1);
+
+    LL_INFOS("CinematicOverlay")
+        << "r31.2 glow min luminance migration v0->v1: "
+        << CVAR_CONTROL << " " << old_value << " -> " << NEW_VALUE << LL_ENDL;
+}
+// </FS:AYAstorm>

--- a/indra/newview/llcinematicoverlay.h
+++ b/indra/newview/llcinematicoverlay.h
@@ -61,6 +61,18 @@ namespace LLCinematicOverlay
     // 既存ユーザーが live A/B 期間中 false 持ちで放置していたケースを救済する。
     void applyR15GodraysCinematicMigrationIfNeeded();
     // </FS:AYAstorm>
+
+    // <FS:AYAstorm> r31.2 Cinematic overlay RenderGlowMinLuminance bugfix.
+    // Pre: 0.0 (BD parity port から持ち込み、blank texture + 色付きプリムで
+    //            意図しない bloom 発火が起きる)
+    // Post: 0.5 (HDR linear 空間で中間 lit を切る現実的な threshold)
+    // Runs once per Cinematic-mode startup: when AYAR31GlowMinLuminanceMigrationVersion < 1
+    // AND AYAVisualRealismEnabled == 2, forces the cvar to 0.5 regardless of
+    // persisted value, then bumps the version. Firestorm mode 起動時はスキップし
+    // 次回 Cinematic 起動まで持ち越し (Firestorm mode のみ使うユーザーは LL default
+    // 1.0 のままで影響を受けない)。
+    void applyR31GlowMinLuminanceMigrationIfNeeded();
+    // </FS:AYAstorm>
 }
 
 #endif // LL_CINEMATIC_OVERLAY_H


### PR DESCRIPTION
## Summary

BD parity port で持ち込まれた `RenderGlowMinLuminance=0.0` が、blank texture + 色付きプリム (装着物 / SIM rez object 両方) で意図しない bloom を発火させていた。shader (`glowExtractF.glsl`) は `smoothstep(min, min+1.0, x)` で bloom 寄与を計算するため、`min=0.0` だと HDR linear 0〜1.0 の中間 lit でも発火し、`warmth = max(r*0.75, g*0.6, b*0.712)` 経路で色付き面が優位に光る。

- `settings_cinematic_bd.xml`: `RenderGlowMinLuminance` `0.0` → `0.5`
- `settings.xml`: `AYAR31GlowMinLuminanceMigrationVersion` sentinel 追加
- `llcinematicoverlay.{h,cpp}`: `applyR31GlowMinLuminanceMigrationIfNeeded()` 実装
- `llappviewer.cpp`: 起動 sequence に migration 呼び出し追加

`0.5` に上げると HDR > 0.5 (sky / 強い反射 / 強い emissive) だけ拾い、装着物クラスの中間 lit は切れる。空 / 街灯 / 強い反射などの Cinematic 表現は維持。

## Migration policy

`AYAVisualRealismEnabled==2` (Cinematic mode) 起動時のみ既存 `0.0` 焼き持ちユーザーを `0.5` に強制矯正。Firestorm mode 起動時は skip し version も bump せず、次回 Cinematic 起動まで持ち越し (Firestorm mode のみ使うユーザーは LL default `1.0` のままで影響を受けない)。

## Test plan

- [x] AYA Linux 実機検証 PASS (2026-05-30)
- [x] Cinematic mode 起動 → `RenderGlowMinLuminance` = `0.5`
- [x] blank texture + 色付きプリム glow バグ消失 (装着物 / SIM rez object 両方)
- [x] Cinematic 表現維持 (空 / 街灯 / 強い反射 bloom)
- [ ] Win build → AYA verify
- [ ] Mac build → @t-noami verify

r31-bugfix-2 同梱予定。