### PR TITLE
fix(alpha): 水中で alpha plate redirect skip = underwater black 解消

### DIFF
--- a/indra/newview/lldrawpoolalpha.cpp
+++ b/indra/newview/lldrawpoolalpha.cpp
@@ -217,6 +217,26 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
     // here the alpha plate gets filled but never composited back over the
     // DoF result — alpha BLEND surfaces vanish from the screen while edit
     // tool is open. Keep the redirect gate aligned with renderDoF()'s gate.
+    // <AYAstorm r31.2 underwater alpha plate fix 2026-05-30>
+    // Underwater gate: when LLPipeline::sUnderWaterRender is true, the main
+    // RT (mRT->screen) already contains water-fog-tinted opaque scene, but the
+    // alpha plate (mAYAAlphaColor) is cleared to (0,0,0,0) and forward alpha
+    // shaders write into it. The pre-tonemap composite uses
+    // GL_ONE / GL_ONE_MINUS_SRC_ALPHA, so where forward alpha writes pixels
+    // with high src.a the plate over-blends and overrides the underwater-
+    // tinted main RT — alpha BLEND surfaces (eyelash attachments, particles)
+    // render visually black underwater. Same break also surfaces transiently
+    // when the camera crosses from below the water plane back to above: the
+    // first frame above water is fine (plate redirect off), then plate state
+    // resyncs and the black bleed reappears for a few frames as the depth /
+    // fragment-level water-fog sampling settles.
+    // Drop the plate redirect entirely while sUnderWaterRender is true so the
+    // alpha BLEND writes go straight to mRT->screen exactly like upstream
+    // Firestorm, restoring underwater fog continuity. The transparent-DoF
+    // C-(a) bg-blur effect is lost while underwater, but underwater scenes
+    // are already a fog-saturated wash where DoF bokeh is structurally
+    // invisible — the visual cost is near zero, and water-fog correctness
+    // beats it.
     const bool use_alpha_rt =
         !LLPipeline::sImpostorRender && !LLPipeline::sRenderingHUDs &&
         !gCubeSnapshot && LLPipeline::RenderDepthOfField &&
@@ -224,7 +244,9 @@ void LLDrawPoolAlpha::renderPostDeferred(S32 pass)
          !LLToolMgr::getInstance()->inBuildMode()) &&
         getType() == LLDrawPool::POOL_ALPHA_POST_WATER &&
         gPipeline.mRT == &gPipeline.mMainRT &&
+        !LLPipeline::sUnderWaterRender &&
         gPipeline.mAYAAlphaColor.isComplete();
+    // </AYAstorm r31.2 underwater alpha plate fix>
 
     // <AYAstorm r30 P5 plate-clear unconditional 2026-05-23>
     // Clear mAYAAlphaColor every frame regardless of use_alpha_rt. When


### PR DESCRIPTION
## 概要
r30 Cinematic 章以降、水中でアバター顔・髪周辺の alpha BLEND prim (まつ毛 / 装着 alpha) と SIM particle の透過部分が**真っ黒**で描画されるバグの修正。水上→水中→水上の遷移後にも数フレーム再発していた。

## 原因
r30 P5 transparent-DoF C-(a) で導入した forward alpha BLEND の独立 RT (`mAYAAlphaColor`) redirect が水中 (`LLPipeline::sUnderWaterRender`) に対応していなかった。water 上下の対称破れ:

- **水上**: main RT (opaque) + plate (alpha BLEND) の合成、双方 fog なし → 正常
- **水中**: main RT に **underwater fog 着色済 opaque scene**、plate は (0,0,0,0) で clear → forward alpha 書き込み後 composite (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) で **plate が underwater 着色 main RT を覆い隠す** → 黒く露出

## 修正
`use_alpha_rt` 条件に `!LLPipeline::sUnderWaterRender` を追加。水中時は plate redirect を完全に skip、forward alpha は main RT に直書き = upstream FS 互換挙動。

## 影響範囲 (trace 済)

| 連動箇所 | 旧 (水中) | 新 (水中) |
|---|---|---|
| `mForwardToAlphaRT` フラグ | true | false (upstream FS 互換) |
| forward alpha blend factor (lldrawpoolalpha.cpp:441-450) | (ONE, 1-Sa) plate モード | (ZERO, 1-Sa) glow suppression |
| emissive routing (lldrawpoolalpha.cpp:1107) | plate pop/push | main RT 直書き |
| pipeline.cpp:10075 plate composite | plate が水中色を上書き | plate=(0,0,0,0) で完全 no-op |
| 3-pass dispatch (PR #122) | 動作 | 動作 (独立、未変化) |

水上時は条件不変、振る舞い完全に旧と同一 = 水上 0 影響。

## 副作用
- 水中時の transparent-DoF C-(a) plate composite 効果は無効化
- 水中は元々全画面 fog で bokeh 構造的に不可視、実視覚差ほぼなし

## 検証 (Linux 2026-05-30)
- 水中でアバター顔・髪周辺の黒 解消
- 水中ログイン時 particle 透過部分の黒 解消
- 水中→水上 遷移後 black 再発しない
- 水上の装着物 alpha / SIM 窓ガラス / DoF 正常

## 同梱予定
r31-bugfix-2 に同梱 (4 fix → 5 fix へ拡張)。