### PR TITLE
docs(release): r31-bugfix-2 release docs restructure (2 major fixes framing + #124)

### DIFF
--- a/docs/release/ayastorm-r31-bugfix-2-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-bugfix-2-github-release-page.en.md
@@ -1,6 +1,6 @@
 🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.zh.md)
 
-# AYAstorm r31-bugfix-2 — AO delete-behavior recovery + LSL Bridge collision defense
+# AYAstorm r31-bugfix-2 — AO recovery + Bridge defense + 3D Stream filter + alpha render-order + Cinematic glow + Underwater alpha
 
 > [!IMPORTANT]
 > **r31-bugfix-2 is a release that, on the AYAstorm side, stops two structural behaviors that exist across the entire Firestorm viewer family.**
@@ -14,11 +14,34 @@ These fixes address structural behaviors that exist across the Firestorm viewer 
 
 ## For users whose AO sets are already gone — AO re-setup procedure
 
-If you have already pressed "Delete" on an AO set in a Firestorm-family viewer (upstream Firestorm / older AYAstorm / other FS-derived), **the AO data itself cannot be brought back, either by the viewer or by the SL server**. The AO functionality itself, however, can be back in normal working order after a simple re-setup. Procedure is published in 3 languages:
+> [!IMPORTANT]
+> If your AO sets have already been erased by the deletion event described above, **the AO data itself cannot be brought back, either by the viewer or by the SL server**. The AO functionality itself, however, can be back in normal working order after a simple re-setup. **Step-by-step recovery guides are published in 3 languages — please use the one matching your environment:**
+>
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+>
+> Installing r31-bugfix-2 itself **stops the same event from recurring on the AYAstorm side**. Recurrence on upstream Firestorm / other FS-derived viewers needs each viewer to be patched on its own — workarounds for that case are spelled out inside the recovery guide.
 
-- 🇺🇸 [English Recovery Guide](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
-- 🇯🇵 [日本語復旧手順](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
-- 🇨🇳 [繁體中文復原指南](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+## Attachment alpha render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+This is the **second major fix** bundled in r31-bugfix-2 alongside the AO recovery work. The previously shipped "rigged hair / SIM N-BL render-order swap" (r30 §5) resolved sky-bleed through hair, but caused attachment N-BL prims (eyelash prims, etc.) to be drawn before rigged hair and then over-blended away — a clearly visible regression on certain avatars (eyes / brows / eyelashes appearing washed out or missing on heads that use attachment alpha prims).
+
+The POST_WATER forward pass is now split into three sub-passes (SIM N-BL → all R-BL → attachment N-BL) using `LLDrawInfo::mAttachedToAvatar` as the per-draw discriminator. This restores correct front-most ordering for attachment prims while keeping the §5 swap fix for sky-bleed through hair. Applies automatically — no setting change needed.
+
+See [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md) for the structural compare against the falsified A/B/C alternatives.
+
+### Special thanks (PR #122 — attachment alpha render-order)
+
+**neria (neriamm)** helped enormously on this fix. Reproduction setups across multiple SL avatars and hands-on verification of the candidate approaches meaningfully shortened the structural compare and the final implementation choice. neria is a Second Life resident contributor (not a GitHub account).
+
+## Other bundled fixes
+
+r31-bugfix-2 also rolls up three additional fixes that landed after r31-bugfix-1:
+
+- **3D Stream URL filter + UI update** (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121)): the 3D Stream feature now ships disabled by default; the prompts that ask viewers whether to play a stream URL now display the source identity (object name + owner) so each viewer can decide based on who is sending the URL, and unintended auto-play from rezzed objects is blocked at the source-of-truth level. See [`docs/specs/3dstream-user-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.en.md) for the user-facing guide
+- **Cinematic glow min-luminance bugfix** (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123)): the BD-parity port carried `RenderGlowMinLuminance = 0.0` into Cinematic mode, which let blank-texture color-tinted prims (both attachments and SIM rez objects) fire post-process bloom even with Glow set to zero on the prim. The threshold is raised to `0.5`, and a one-shot migration force-corrects users who have the bad value persisted from r31.0 / r31.1 the next time they boot into Cinematic mode. Firestorm mode is unaffected (LL default `1.0` stays in place; the migration is skipped and re-checked on the next Cinematic boot)
+- **Underwater alpha plate fix** (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124)): the r30 P5 transparent-DoF C-(a) `mAYAAlphaColor` redirect did not gate on `LLPipeline::sUnderWaterRender`. Underwater, the main RT carried the underwater fog-tinted opaque scene while the separated alpha plate was cleared to `(0,0,0,0)`; the pre-tonemap composite (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) then let the plate paint over the underwater-tinted main RT — eyelash / brow attachment alpha prims and SIM particle transparent regions rendered as solid black underwater, and the same break transiently reappeared for a few frames after surfacing. The redirect is now skipped while `sUnderWaterRender` is true so forward alpha goes straight to the main RT (upstream FS-compatible behavior underwater). The above-water path is unchanged
 
 ## Release notes
 
@@ -28,8 +51,12 @@ If you have already pressed "Delete" on an AO set in a Firestorm-family viewer (
 
 ## Key documents (tag pinned)
 
-- Technical spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
-- User recovery guide (3 languages): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- AO + Bridge technical spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
+- AO user recovery guide (3 languages): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- 3D Stream URL filter report (日本語): [docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- 3D Stream user guide (3 languages): [docs/specs/3dstream-user-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/specs)
+- Alpha render-order extension report: [docs/specs/ayastorm-double-alpha-c-plan-extension.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- Six-category render order trace: [docs/specs/ayastorm-six-category-render-order-trace.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
 
 ## Compatibility with existing setups
 
@@ -37,6 +64,10 @@ Ships without disturbing r31 / r31-bugfix-1 environments:
 
 - **AO delete-behavior fix**: applies automatically. No setting change required. Users on r31 / r31-bugfix-1 install r31-bugfix-2 on top and normal AO-set delete becomes non-destructive Hide
 - **LSL Bridge collision defense**: applies automatically. Prevents AYAstorm-side Bridges from being destroyed when upstream Firestorm bumps the Bridge minor version (not yet firing today, defensive for the future)
+- **3D Stream default-off + URL filter**: existing streamers who were already running with 3D Stream enabled keep their `Stream3DEnabled = true` setting. Fresh installs land on default OFF
+- **Alpha render-order 3-pass dispatch**: applies automatically to all avatars. Attachment N-BL prims (eyelash prims, etc.) now sit in front of rigged hair as expected, while the original §5 swap fix for sky-bleed through hair is preserved
+- **Cinematic glow min-luminance**: one-shot migration runs only on the next Cinematic-mode boot for users whose persisted value was `0.0`. Firestorm-mode-only users are not touched (LL default `1.0` stays in place)
+- **Underwater alpha plate**: applies automatically. Underwater alpha BLEND now writes straight to the main RT instead of the separated plate, so the underwater fog tint is preserved through compositing. Side effect: the transparent-DoF C-(a) plate composite is disabled while underwater (visually inert — underwater is already a fog-saturated wash where DoF bokeh is structurally invisible). Above water is unchanged
 - **All r31 / r31-bugfix-1 features** (3D Stream unified tag / AYAstorm View / parcel music Vorbis fix / MOAP audio routing / macOS branding / GPU other-rigged picker / chat tab split / venue reverb / SSS pink-shadow fix, etc.): preserved unchanged
 - **Users who don't edit or delete AO sets**: almost no visible change. The AO-set trash icon becomes a visibility-off icon, and the dialog wording changes to Hide
 - **Users who want to clean up AO inventory**: the Hidden manager has `Delete selected`, which permanently deletes the selected hidden inventory folder after confirmation. This cannot be undone
@@ -48,10 +79,12 @@ Venue IRs bundled since r11 (and still shipping) are from OpenAIR (CC-BY 4.0). S
 
 ## Downloads
 
-- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261481144_Setup.exe)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
-- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261481144.tar.xz)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261492019_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81339.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261500427.tar.xz)
 
 ## Contributors
 
 @t-noami @mayatonton
+
+(See the Special thanks callout in the "Attachment alpha render-order" section for neria (neriamm)'s contribution to PR #122.)

--- a/docs/release/ayastorm-r31-bugfix-2-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-2-github-release-page.ja.md
@@ -1,6 +1,6 @@
 🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.zh.md)
 
-# AYAstorm r31-bugfix-2 — AO 削除事象救済 + LSL Bridge 衝突防御
+# AYAstorm r31-bugfix-2 — AO 削除事象救済 + LSL Bridge 衝突防御 + 3D Stream URL filter + 装着物アルファ順序 + Cinematic glow + 水中アルファ
 
 > [!IMPORTANT]
 > **r31-bugfix-2 は Firestorm 系 viewer 全体に存在する 2 件の構造的な振る舞いを AYAstorm 側で食い止めるリリースです。**
@@ -12,13 +12,36 @@
 
 修正は Firestorm 系 viewer 全体に存在する構造的振る舞いへの対応です。AYAstorm 側では通常の AO 削除から `#Firestorm` root への破壊的操作を外します。Firestorm 本家 / 他派生 viewer での再発はそれぞれの viewer が patch される必要があります (推奨運用と回避策は recovery guide に明記)。
 
-## すでに AO セットが消えてしまった方へ — AO 機能の再セットアップ手順
+## すでに AO セットが消えてしまった方 — AO 再セットアップ手順
 
-Firestorm 系 viewer (Firestorm 本家 / 旧版 AYAstorm / 他 FS 派生) ですでに AO セットを「削除」してしまった方の **AO データそのものは viewer 側でも SL サーバ側でも取り戻せません**。ただし AO 機能自体は再セットアップで普通に使えるようになります。手順を 3 言語で公開しています:
+> [!IMPORTANT]
+> 上に書いた事象によりすでに AO セットが消えてしまった方の **AO データそのものは viewer 側でも SL サーバ側でも取り戻せません**。ただし AO 機能自体は簡単な再セットアップで普通に使える状態に戻せます。**手順を 3 言語で公開していますので、ご自身の環境に合うものをご利用ください:**
+>
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+>
+> r31-bugfix-2 を install していただくと **以降 AYAstorm 側では同じ事象は起きません**。Firestorm 本家 / 他 FS 派生 viewer での再発は各 viewer 側で patch される必要がありますが、その場合の回避策も復旧 guide 内に明記されています。
 
-- 🇯🇵 [日本語復旧手順](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
-- 🇺🇸 [English Recovery Guide](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
-- 🇨🇳 [繁體中文復原指南](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+## 装着物アルファ render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+これは r31-bugfix-2 の **AO 救済と並ぶ 2 大修正項目** の 1 つです。r30 §5 で出荷した「rigged hair / SIM N-BL render-order swap」は髪越し空抜けを解消しましたが、副作用として装着物 N-BL prim (まつ毛 prim 等) が rigged hair の前ではなく後ろに描かれ、その後 over-blend で潰される regression を出していました — 装着物 alpha prim を使う avatar (目 / 眉 / まつ毛が prim 構成のヘッド) で「眉まつ毛が薄い / 欠ける」として可視化される regression でした。
+
+POST_WATER の forward pass を 3 sub-pass (SIM N-BL → 全 R-BL → 装着物 N-BL) に分割し、`LLDrawInfo::mAttachedToAvatar` を per-draw discriminator として両立。§5 swap fix を維持しつつ装着物 prim の前面整列を回復します。自動適用 — 設定変更は不要です。
+
+falsified 案 A/B/C との構造的比較は [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md) を参照。
+
+### Special thanks (PR #122 — 装着物アルファ render-order)
+
+この修正には **neria (neriamm)** さんに多大なご協力をいただきました。複数の SL avatar での再現環境構築と候補修正の hands-on 検証により、構造的比較と最終的な実装選択の絞り込みが大きく短縮されました。neria さんは Second Life のレジデント貢献者で (GitHub アカウントではありません)、SL 名で表記しています。
+
+## その他の同梱修正
+
+r31-bugfix-2 では r31-bugfix-1 以降に着地した次の 3 件の修正も同梱しています:
+
+- **3D Stream URL filter + UI 更新** (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121)): 3D Stream 機能を初期状態で OFF にしました。プロンプトの URL 再生確認ダイアログには送信元の object 名 / owner を表示し、誰が送ってきた URL なのかを各 viewer が判断できるようにします。rezz されたオブジェクト経由の意図しない自動再生は source-of-truth の段階でブロックします。ユーザー向け解説は [`docs/specs/3dstream-user-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.ja.md) を参照
+- **Cinematic glow min-luminance 修正** (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123)): BD parity port で持ち込まれた `RenderGlowMinLuminance = 0.0` が、blank texture + 色付きプリム (装着物 / SIM rez object 両方) で prim 側 Glow=0 設定でも post-process bloom を誤発火させていました。閾値を `0.5` に引き上げ、r31.0 / r31.1 で `0.0` を persist 焼きしてしまったユーザーは次回 Cinematic mode 起動時に one-shot migration で強制矯正します。Firestorm mode は影響なし (LL default `1.0` のまま、migration は skip され次回 Cinematic 起動で再検査)
+- **水中アルファ plate 修正** (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124)): r30 P5 transparent-DoF C-(a) で導入した `mAYAAlphaColor` redirect が `LLPipeline::sUnderWaterRender` に対応していませんでした。水中では main RT に underwater fog 着色済みの opaque scene があるのに、独立 plate は `(0,0,0,0)` で clear → forward alpha が plate に書き込み、pre-tonemap composite (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) で plate が underwater 着色 main RT を上書きしてしまい、まつ毛 / 眉などの装着物アルファプリムと SIM particle の透過部分が **水中で真っ黒** で描画されていました。水上に出た後にも数フレーム再発する症状あり。`use_alpha_rt` 条件に `!sUnderWaterRender` を追加して水中時は plate redirect を skip、forward alpha は main RT に直書き = upstream FS 互換挙動。水上時の振る舞いは旧と完全一致
 
 ## Release notes
 
@@ -28,8 +51,12 @@ Firestorm 系 viewer (Firestorm 本家 / 旧版 AYAstorm / 他 FS 派生) です
 
 ## Key documents (tag pinned)
 
-- 技術 spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
-- ユーザー復旧手順 (3 言語): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- AO + Bridge 技術 spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
+- AO ユーザー復旧手順 (3 言語): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- 3D Stream URL filter 報告書 (日本語): [docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- 3D Stream ユーザーガイド (3 言語): [docs/specs/3dstream-user-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/specs)
+- アルファ render-order 拡張報告書: [docs/specs/ayastorm-double-alpha-c-plan-extension.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- 6 カテゴリ render order trace: [docs/specs/ayastorm-six-category-render-order-trace.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
 
 ## 既存環境との互換性
 
@@ -37,6 +64,10 @@ r31 / r31-bugfix-1 環境を乱さずに出荷:
 
 - **AO 削除事象 fix**: 自動適用。設定変更不要。r31 / r31-bugfix-1 install 済の方は r31-bugfix-2 を上書き install するだけで、通常の AO セット削除は非破壊の Hide になります
 - **LSL Bridge 衝突防御**: 自動適用。Firestorm 本家のマイナーバンプ時に AYAstorm Bridge が削除される事象を防止 (現状未発火、将来防御)
+- **3D Stream 初期 OFF + URL filter**: すでに 3D Stream 有効で運用中の配信者は `Stream3DEnabled = true` の設定を持ち越します。新規 install では初期 OFF からの開始です
+- **アルファ render-order 3-pass dispatch**: 全 avatar に自動適用。装着物 N-BL prim (まつ毛 prim 等) が rigged hair の前面に正しく整列するようになり、§5 swap による髪越し空抜け修正は維持されます
+- **Cinematic glow min-luminance**: `0.0` を persist 焼きしていたユーザーの **次回 Cinematic mode 起動時** に one-shot migration が走ります。Firestorm mode 専用ユーザーは影響なし (LL default `1.0` のまま)
+- **水中アルファ plate**: 自動適用。水中時は alpha BLEND が独立 plate を経由せず main RT に直書きされ、underwater fog 着色が composite 越しに保持されます。副作用: 水中での transparent-DoF C-(a) plate composite 効果は無効化されますが、水中はそもそも全画面 fog で bokeh 構造的に不可視のため視覚差ほぼなし。水上時は変更なし
 - **r31 / r31-bugfix-1 の全機能** (3D Stream unified tag / AYAstorm View / parcel music Vorbis fix / MOAP audio routing / macOS branding / GPU other-rigged picker / chat tab split / venue reverb / SSS pink-shadow 修正等): そのまま保持されます
 - **AO を編集 / 削除しない方**: 見た目の変化はほぼありません。AO set の Trash icon は非表示 icon になり、Dialog 文言が Hide 前提に変わります
 - **AO を整理したい方**: Hidden 管理画面の「選択を削除」 (`Delete selected`) から、確認後に選択済み hidden set の実 inventory folder を完全削除できます。これは元に戻せません
@@ -48,10 +79,12 @@ r11 で同梱し以降も出荷中の venue IR は OpenAIR (CC-BY 4.0) 由来で
 
 ## Downloads
 
-- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261481144_Setup.exe)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
-- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261481144.tar.xz)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261492019_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81339.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261500427.tar.xz)
 
 ## Contributors
 
 @t-noami @mayatonton
+
+(PR #122 への neria (neriamm) さんのご協力については、上記「装着物アルファ render-order」セクション内の「Special thanks」を参照)

--- a/docs/release/ayastorm-r31-bugfix-2-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-2-github-release-page.zh.md
@@ -1,6 +1,6 @@
 🌐 Language: [🇺🇸 English](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.en.md) | [🇯🇵 日本語](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.ja.md) | [🇨🇳 中文](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/release/ayastorm-r31-bugfix-2-github-release-page.zh.md)
 
-# AYAstorm r31-bugfix-2 — AO 刪除事象救濟 + LSL Bridge 衝突防禦
+# AYAstorm r31-bugfix-2 — AO 刪除事象救濟 + LSL Bridge 衝突防禦 + 3D Stream URL filter + 裝著物 alpha 順序 + Cinematic glow + 水中 alpha
 
 > [!IMPORTANT]
 > **r31-bugfix-2 是在 AYAstorm 側阻止 Firestorm 系列 viewer 整體存在的 2 件結構性行為的版本。**
@@ -12,13 +12,36 @@
 
 修正是對 Firestorm 系列 viewer 全體所存在的結構性行為的對應。AYAstorm 側會從一般 AO 刪除路徑移除對 `#Firestorm` root 的破壞性操作，Firestorm 本家 / 其他衍生 viewer 中的再發各別 viewer 需另行 patch (推薦運用與規避手段在 recovery guide 中明示)。
 
-## 已有 AO 集合消失的使用者 — AO 機能再次設置手順
+## AO 集合已消失的使用者 — AO 再設置手順
 
-在 Firestorm 系列 viewer (Firestorm 本家 / 舊版 AYAstorm / 其他 FS 衍生) 中已按下「刪除」的 AO 集合的 **AO 資料本身在 viewer 側或 SL 伺服器側均無法找回**。不過 AO 機能本身可以透過簡單的再設置回到正常使用狀態。手順以 3 種語言公開:
+> [!IMPORTANT]
+> 已被上述事象抹去的 AO 集合的 **AO 資料本身在 viewer 側或 SL 伺服器側均無法找回**。不過 AO 機能本身可以透過簡單的再設置回到正常使用狀態。**手順以 3 種語言公開，請使用符合您環境的版本:**
+>
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+>
+> 安裝 r31-bugfix-2 本身 **可在 AYAstorm 側阻止相同事象再次發生**。Firestorm 本家 / 其他 FS 衍生 viewer 中的再發各別需要 viewer 端 patch，相應的規避手段在復原指南內亦有明示。
 
-- 🇨🇳 [繁體中文復原指南](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
-- 🇺🇸 [English Recovery Guide](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
-- 🇯🇵 [日本語復旧手順](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+## 裝著物 alpha render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+這是 r31-bugfix-2 的 **與 AO 救濟並列的 2 大修正項目** 之一。r30 §5 出貨的「rigged hair / SIM N-BL render-order swap」雖然解消了透過頭髮的天空空抜，但副作用是裝著物 N-BL prim (睫毛 prim 等) 反而被繪在 rigged hair 之前，然後被 over-blend 蓋掉，形成可見的 regression — 在使用裝著物 alpha prim 的 avatar (眼 / 眉 / 睫毛由 prim 構成的 head) 上顯現為「眉與睫毛變淡 / 缺失」的 regression。
+
+將 POST_WATER 的 forward pass 切分為 3 sub-pass (SIM N-BL → 全 R-BL → 裝著物 N-BL)，使用 `LLDrawInfo::mAttachedToAvatar` 作為 per-draw discriminator 兩立。§5 swap fix 維持的同時恢復裝著物 prim 的前面整列。自動套用 — 不需變更設定。
+
+與被 falsify 的 A/B/C 案的結構性比較請參照 [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)。
+
+### Special thanks (PR #122 — 裝著物 alpha render-order)
+
+此修正得到 **neria (neriamm)** 的大力協助。在多個 SL avatar 上的再現環境構築與候補修正的 hands-on 檢證，大幅縮短了結構性比較與最終實作選擇的範圍。neria 是 Second Life 的居民貢獻者 (並非 GitHub 帳號)，以 SL 名稱記載。
+
+## 其他同捆修正
+
+r31-bugfix-2 也同捆了在 r31-bugfix-1 之後著陸的以下 3 件修正:
+
+- **3D Stream URL filter + UI 更新** (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121)): 3D Stream 機能改為初期狀態 OFF。URL 播放確認 dialog 改為顯示送來方的 object 名稱 / owner，讓各 viewer 能依據送來方判斷是否播放。透過 rezz 物件導致的非預期自動播放於 source-of-truth 階段就被擋住。使用者向解說請參照 [`docs/specs/3dstream-user-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.zh.md)
+- **Cinematic glow min-luminance 修正** (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123)): BD parity port 帶入的 `RenderGlowMinLuminance = 0.0` 使 blank texture + 著色 prim (裝著物 / SIM rez object 兩者皆然) 即使 prim 側 Glow=0 也會誤發 post-process bloom。將閾值提升到 `0.5`，r31.0 / r31.1 中已被 persist 為 `0.0` 的使用者在下次 Cinematic mode 起動時透過 one-shot migration 強制矯正。Firestorm mode 不受影響 (LL default `1.0` 保持，migration 跳過並於下次 Cinematic 起動時再檢查)
+- **水中 alpha plate 修正** (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124)): r30 P5 transparent-DoF C-(a) 導入的 `mAYAAlphaColor` redirect 並未對應 `LLPipeline::sUnderWaterRender`。水中時 main RT 已含 underwater fog 著色的 opaque scene，獨立 plate 卻被 clear 為 `(0,0,0,0)` → forward alpha 寫入 plate，pre-tonemap composite (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) 讓 plate 覆蓋 underwater 著色的 main RT，導致睫毛 / 眉等裝著物 alpha prim 與 SIM particle 透明區域在水中顯示為純黑。上浮到水面後也會數 frame 再發。`use_alpha_rt` 條件加上 `!sUnderWaterRender`，水中時跳過 plate redirect，forward alpha 直接寫入 main RT = upstream FS 互換動作。水面以上路徑與舊版完全一致
 
 ## Release notes
 
@@ -28,8 +51,12 @@
 
 ## Key documents (tag pinned)
 
-- 技術 spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
-- 使用者復原手順 (3 種語言): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- AO + Bridge 技術 spec: [docs/specs/ayastorm-r31-2-ao-bridge-recovery.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-ao-bridge-recovery.md)
+- AO 使用者復原手順 (3 種語言): [docs/guides/ao-data-recovery-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/guides)
+- 3D Stream URL filter 報告書 (日語): [docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- 3D Stream 使用者指南 (3 種語言): [docs/specs/3dstream-user-guide.{en,ja,zh}.md](https://github.com/mayatonton/phoenix-firestorm/tree/v7.2.4-ayastorm-r31-bugfix-2/docs/specs)
+- Alpha render-order 擴充報告書: [docs/specs/ayastorm-double-alpha-c-plan-extension.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- 6 類別 render order trace: [docs/specs/ayastorm-six-category-render-order-trace.md](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
 
 ## 與既有環境的相容性
 
@@ -37,6 +64,10 @@
 
 - **AO 刪除事象 fix**: 自動套用。不需變更設定。已安裝 r31 / r31-bugfix-1 者，僅需在上層覆蓋安裝 r31-bugfix-2，一般 AO 集合刪除就會變成非破壞性 Hide
 - **LSL Bridge 衝突防禦**: 自動套用。防止 Firestorm 本家對 Bridge 進行 minor bump 時 AYAstorm 側 Bridge 被刪除的事象 (目前尚未發火，為將來防禦)
+- **3D Stream 初期 OFF + URL filter**: 已在 3D Stream 啟用狀態下運用中的配信者會保留 `Stream3DEnabled = true` 設定。新安裝會從初期 OFF 開始
+- **Alpha render-order 3-pass dispatch**: 對全 avatar 自動套用。裝著物 N-BL prim (睫毛 prim 等) 會正確排在 rigged hair 之前，§5 swap 對透過頭髮的天空空抜修正仍然維持
+- **Cinematic glow min-luminance**: 對於將 `0.0` 持久化的使用者，**下次 Cinematic mode 起動時** 會執行 one-shot migration。Firestorm mode 專用使用者不受影響 (LL default `1.0` 維持)
+- **水中 alpha plate**: 自動套用。水中時 alpha BLEND 直接寫入 main RT 而非獨立 plate，underwater fog 著色得以透過 composite 保持。副作用: 水中時 transparent-DoF C-(a) plate composite 效果停用，但水中本來就是全畫面 fog，bokeh 結構性上看不見，視覺差幾乎為零。水面以上路徑不變
 - **r31 / r31-bugfix-1 的全部機能** (3D Stream unified tag / AYAstorm View / parcel music Vorbis fix / MOAP audio routing / macOS branding / GPU other-rigged picker / chat tab split / venue reverb / SSS pink-shadow 修正等): 原樣保持
 - **不編輯 / 刪除 AO 的使用者**: 幾乎沒有可見變化。AO set 的 trash icon 會變成非顯示 icon，Dialog 文字改為 Hide 前提
 - **需要整理 AO inventory 的使用者**: Hidden 管理畫面提供「刪除所選」 (`Delete selected`)，確認後會永久刪除所選 hidden inventory folder。此操作無法復原
@@ -48,10 +79,12 @@ r11 起同捆並持續出貨的 venue IR 來自 OpenAIR (CC-BY 4.0)。出處: [`
 
 ## Downloads
 
-- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261481144_Setup.exe)
-- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81209.dmg)
-- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261481144.tar.xz)
+- [Windows Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_AVX2-7-2-4-261492019_Setup.exe)
+- [macOS Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-81339.dmg)
+- [Linux Installer](https://github.com/mayatonton/phoenix-firestorm/releases/download/v7.2.4-ayastorm-r31-bugfix-2/Phoenix-FirestormOS-AYAstorm-release_LEGACY-7-2-4-261500427.tar.xz)
 
 ## Contributors
 
 @t-noami @mayatonton
+
+(關於 neria (neriamm) 對 PR #122 的協助，請參照上方「裝著物 alpha render-order」章節中的「Special thanks」說明)

--- a/docs/release/ayastorm-r31-bugfix-2-release-note.en.md
+++ b/docs/release/ayastorm-r31-bugfix-2-release-note.en.md
@@ -5,6 +5,8 @@
 >
 > These are not AYAstorm-specific issues; they originate from the shared `#Firestorm` inventory root used by all Firestorm-derived viewers (whether they count as bugs or by-design is upstream's call to make).
 
+Alongside the AO + Bridge fix, r31-bugfix-2 also delivers a **second major fix** — attachment N-BL prim alpha render-order via 3-pass dispatch (PR #122) — plus three other bundled fixes that landed after r31-bugfix-1: 3D Stream URL filter + UI update (PR #121), a Cinematic-mode glow min-luminance bugfix (PR #123), and an underwater alpha plate redirect fix (PR #124). See the per-feature sections below.
+
 Implementation details, scope analysis, and the recovery procedure live permanently under `docs/specs/` and `docs/guides/`. This note is the entry point and highlight summary.
 
 ---
@@ -91,3 +93,128 @@ This behavior was not introduced in r31. It has been structurally present in the
 - User recovery guide (English): [`docs/guides/ao-data-recovery-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
 - User recovery guide (Japanese): [`docs/guides/ao-data-recovery-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
 - User recovery guide (Traditional Chinese): [`docs/guides/ao-data-recovery-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+
+---
+
+## For users whose AO sets are already gone — AO re-setup procedure
+
+> [!IMPORTANT]
+> If your AO sets have already been erased by the deletion event described above, **the AO data itself cannot be brought back, either by the viewer or by the SL server**. The AO functionality itself, however, can be back in normal working order after a simple re-setup. **Step-by-step recovery guides are published in 3 languages — please use the one matching your environment:**
+>
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+>
+> Installing r31-bugfix-2 itself **stops the same event from recurring on the AYAstorm side**. Recurrence on upstream Firestorm / other FS-derived viewers needs each viewer to be patched on its own — workarounds for that case are spelled out inside the recovery guide.
+
+---
+
+## Attachment N-BL prim alpha render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+### Headline: Second major fix in r31-bugfix-2 — POST_WATER forward pass split into SIM N-BL → R-BL → attachment N-BL using per-draw discriminator
+
+This is the **second major fix** bundled in r31-bugfix-2 alongside the AO + Bridge recovery work. The r30 §5 render-order swap (POST_WATER all non-rigged → all rigged) resolved sky-bleed through rigged hair, but caused attachment N-BL prims (eyelash prims, etc.) to be drawn before rigged hair and then over-blended away, producing a visible regression on certain avatars (S1 / S2 in the spec terminology). The POST_WATER forward pass is now split into three sub-passes:
+
+- **pass 1**: `forwardRender(false, ATTACHMENT_NONE)` — SIM rezz N-BL only
+- **pass 2**: `forwardRender(true)` — all R-BL (rigged hair, etc.)
+- **pass 3**: `forwardRender(false, ATTACHMENT_ONLY)` — attachment N-BL prims only
+
+The per-draw discriminator is `LLDrawInfo::mAttachedToAvatar.notNull()`. Moving pass 3 after rigged places attachment prims in front of hair, while pass 1 still draws SIM-side N-BL before rigged so the original §5 swap fix (sky-bleed through hair) is preserved. PRE_WATER stays rigged-first for water-fog coherence. HUD uses a single forwardRender call and is out of scope.
+
+The falsified alternatives (independent depth on the alpha plate, etc.) and the structural-compare argument for the 3-pass approach are recorded in `docs/specs/ayastorm-double-alpha-c-plan-extension.md §3`.
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` / `lldrawpoolalpha.h` — `AttachmentFilter` enum and `forwardRender(rigged, filter)` overload; POST_WATER split into 3 sub-passes; per-draw `LLDrawInfo::mAttachedToAvatar` discriminator
+- `docs/specs/ayastorm-double-alpha-c-plan-extension.md` — structural compare against falsified A/B/C alternatives (new)
+- `docs/specs/ayastorm-six-category-render-order-trace.md` — full 6-category render order trace used to derive the 3-pass boundary (new)
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3-pass dispatch design, implementation, falsification analysis (A/B/C alternatives), and spec authoring.
+
+### Special thanks
+
+- neria (neriamm) — alpha render-order issue investigation and verification help. Reproduction setups across multiple SL avatars and hands-on verification of the candidate fixes meaningfully shortened the structural compare and the final implementation choice. neria is a Second Life resident contributor (not a GitHub account).
+
+### Documentation
+
+- Structural compare (extension report): [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- 6-category render order trace: [`docs/specs/ayastorm-six-category-render-order-trace.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
+
+---
+
+## 3D Stream URL filter and UI update (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121))
+
+### Headline: 3D Stream ships disabled by default; URL-play prompts now show the sending object's identity
+
+The 3D Stream feature (introduced in r26 / formalised under unified tag in r31) is shipped with `Stream3DEnabled = false` from r31.2 onward. Users who were already running with 3D Stream enabled keep their persisted setting; only fresh installs land on default OFF. The URL-play confirmation prompt that opens when an in-world object sends a stream URL now displays the source object name and owner, so each viewer can decide whether to accept the URL based on who is sending it. Unintended auto-play from rezzed objects is also blocked at the source-of-truth level, not after-the-fact in the UI.
+
+### How the fix works
+
+- `settings.xml` ships `Stream3DEnabled` default `false`. Existing users keep their persisted value
+- The URL-play confirmation dialog text now includes the source object name + owner (3 languages)
+- Source-of-truth enforcement: when 3D Stream is disabled, rezzed-object URL emit is dropped before reaching the auto-play path, not after
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3D Stream URL filter and UI update implementation, plus 3-language prompt localization.
+
+### Documentation
+
+- Technical report (Japanese): [`docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- User guide (English): [`docs/specs/3dstream-user-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.en.md)
+- User guide (Japanese): [`docs/specs/3dstream-user-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.ja.md)
+- User guide (Traditional Chinese): [`docs/specs/3dstream-user-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.zh.md)
+
+---
+
+## Cinematic glow min-luminance bugfix (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123))
+
+### Headline: Raise Cinematic-mode `RenderGlowMinLuminance` from 0.0 to 0.5; one-shot migration force-corrects shipped users
+
+The BD-parity overlay used in Cinematic mode carried `RenderGlowMinLuminance = 0.0`, which lowered the bloom-extract threshold in HDR linear space. `glowExtractF.glsl` computes bloom contribution via `smoothstep(min, min+1.0, x)`, so with `min = 0.0` the middle-lit pixels in the HDR `0..1.0` range fire bloom, and the `warmth = max(r*0.75, g*0.6, b*0.712)` branch lets color-tinted prims (blank texture + color picker) light up even with Glow set to zero on the prim. Symptoms were reported on both attachment and SIM rez objects, while textured prims and white-colored prims were not affected.
+
+The threshold is raised to `0.5`. Strong Cinematic bloom sources (sky, intense reflections, strong emissives — anything above HDR `0.5`) still fire; the unintended middle-lit prim bloom is cut. A one-shot migration (sentinel `AYAR31GlowMinLuminanceMigrationVersion`) force-corrects users who have the `0.0` value persisted from r31.0 / r31.1, but only on the next Cinematic-mode boot — Firestorm-mode-only users are not touched (LL default `1.0` stays in place; the migration is skipped and re-checked on the next Cinematic boot).
+
+### How the fix works
+
+- `settings_cinematic_bd.xml`: `RenderGlowMinLuminance` `0.0` → `0.5`
+- `settings.xml`: `AYAR31GlowMinLuminanceMigrationVersion` sentinel (S32, Persist=1, default 0) added
+- `llcinematicoverlay.{h,cpp}`: `applyR31GlowMinLuminanceMigrationIfNeeded()` implemented. Guard: if `AYAVisualRealismEnabled != 2` (Firestorm mode), skip without bumping the version, so the next Cinematic boot re-checks
+- `llappviewer.cpp`: migration call added to the startup sequence after the existing `applyR15GodraysCinematicMigrationIfNeeded()` call
+
+### Implementation summary
+
+- `indra/newview/app_settings/settings_cinematic_bd.xml` — `RenderGlowMinLuminance` threshold raise
+- `indra/newview/app_settings/settings.xml` — migration sentinel
+- `indra/newview/llcinematicoverlay.cpp` / `llcinematicoverlay.h` — `applyR31GlowMinLuminanceMigrationIfNeeded()` with mode==2 guard
+- `indra/newview/llappviewer.cpp` — startup-sequence integration
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — bloom threshold investigation, fix design, and one-shot migration implementation.
+
+---
+
+## Underwater alpha plate redirect fix (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124))
+
+### Headline: Gate `mAYAAlphaColor` redirect on `!sUnderWaterRender`; underwater forward alpha goes straight to main RT (FS-compatible)
+
+The r30 P5 transparent-DoF C-(a) work introduced an `mAYAAlphaColor` redirect that routes forward alpha BLEND writes to a separate alpha plate, then composites the plate over the main RT before tonemapping (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`). The condition that enables this redirect (`use_alpha_rt`) did not gate on `LLPipeline::sUnderWaterRender`. Underwater, the main RT carries the underwater fog-tinted opaque scene while the separated alpha plate is cleared to `(0,0,0,0)`; the pre-tonemap composite then lets the plate paint over the underwater-tinted main RT. Eyelash / brow attachment alpha prims and SIM particle transparent regions rendered as solid black underwater, and the same break transiently reappeared for a few frames after surfacing (the camera ascends, the redirect briefly returns to its above-water state, then drifts back into the broken underwater path until the next surface event).
+
+The fix is a single-condition gate: `use_alpha_rt` now additionally requires `!LLPipeline::sUnderWaterRender`. Underwater, the redirect is skipped and forward alpha writes directly to the main RT — matching upstream FS behavior underwater. Above water, behavior is identical to before.
+
+### How the fix works
+
+- `indra/newview/lldrawpoolalpha.cpp`: `use_alpha_rt` condition adds `!LLPipeline::sUnderWaterRender &&` immediately before the existing `gPipeline.mAYAAlphaColor.isComplete()` check
+- When the gate suppresses the redirect, the alpha plate stays at its cleared `(0,0,0,0)`. The pre-tonemap composite is then a no-op against the main RT (`A_plate * 1 + RT * 1 = RT`), so no underwater-specific composite path is needed
+- The above-water transparent-DoF C-(a) plate composite is unchanged. Underwater bokeh is structurally invisible (full-frame fog), so dropping the plate composite underwater has no perceptible cost
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` — `use_alpha_rt` gated on `!LLPipeline::sUnderWaterRender`; inline comment documents the underwater no-op composite reasoning
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — underwater symptom investigation, single-gate fix, side-effect trace across the 5 connection points (`mForwardToAlphaRT`, alpha blend factors, emissive routing, plate clear, plate composite).

--- a/docs/release/ayastorm-r31-bugfix-2-release-note.ja.md
+++ b/docs/release/ayastorm-r31-bugfix-2-release-note.ja.md
@@ -5,6 +5,8 @@
 >
 > AYAstorm 固有の問題ではなく、Firestorm 派生 viewer 全体で共有される inventory root に起因する構造的な振る舞いへの対応です (バグか仕様かの判断は upstream にあります)。
 
+AO + Bridge 修正と並ぶ **2 大修正項目** として、装着物 N-BL prim アルファ render-order の 3-pass dispatch (PR #122) も本リリースに同梱します。それに加え r31-bugfix-1 以降に着地した次の 3 件の修正も含んでいます: 3D Stream URL filter + UI 更新 (PR #121)、Cinematic mode glow min-luminance bugfix (PR #123)、水中アルファ plate redirect 修正 (PR #124)。各 feature 別の section は本ノート下部を参照。
+
 実装詳細、影響範囲、復旧手順は `docs/specs/` および `docs/guides/` 配下に常設しています。本ノートは入口と差分ハイライトです。
 
 ---
@@ -91,3 +93,128 @@ r31-bugfix-2 では通常の AO セット「削除」を実 inventory 削除で�
 - ユーザー復旧手順 (日本語): [`docs/guides/ao-data-recovery-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
 - ユーザー復旧手順 (English): [`docs/guides/ao-data-recovery-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
 - ユーザー復旧手順 (繁體中文): [`docs/guides/ao-data-recovery-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+
+---
+
+## すでに AO セットが消えてしまった方 — AO 再セットアップ手順
+
+> [!IMPORTANT]
+> 上に書いた事象によりすでに AO セットが消えてしまった方の **AO データそのものは viewer 側でも SL サーバ側でも取り戻せません**。ただし AO 機能自体は簡単な再セットアップで普通に使える状態に戻せます。**手順を 3 言語で公開していますので、ご自身の環境に合うものをご利用ください:**
+>
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+>
+> r31-bugfix-2 を install していただくと **以降 AYAstorm 側では同じ事象は起きません**。Firestorm 本家 / 他 FS 派生 viewer での再発は各 viewer 側で patch される必要がありますが、その場合の回避策も復旧 guide 内に明記されています。
+
+---
+
+## 装着物 N-BL prim アルファ render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+### 見出し: r31-bugfix-2 の 2 大修正項目その 2 — POST_WATER forward pass を SIM N-BL → R-BL → 装着物 N-BL の 3 段に分割し per-draw discriminator で振り分け
+
+これは AO + Bridge 救済と **並ぶ 2 大修正項目** の 1 つです。r30 §5 の render-order swap (POST_WATER 全 non-rigged → 全 rigged) は rigged hair 越しの空抜けを解消しましたが、副作用として装着物 N-BL prim (まつ毛 prim 等) が rigged hair の前ではなく後に描かれて over-blend で潰される regression (spec 用語で S1 / S2) を出していました。POST_WATER の forward pass を以下 3 sub-pass に分割します:
+
+- **pass 1**: `forwardRender(false, ATTACHMENT_NONE)` — SIM rezz N-BL のみ
+- **pass 2**: `forwardRender(true)` — 全 R-BL (rigged hair 等)
+- **pass 3**: `forwardRender(false, ATTACHMENT_ONLY)` — 装着物 N-BL prim のみ
+
+per-draw discriminator は `LLDrawInfo::mAttachedToAvatar.notNull()`。pass 3 を rigged の後にずらすことで装着物 prim が hair の前面に整列し、同時に pass 1 で SIM 側 N-BL を rigged 前に描いて §5 swap fix (髪越し空抜け解消) は維持します。PRE_WATER は water fog 整合性のため rigged-first 維持。HUD は forwardRender 1 回のみで対象外。
+
+falsified した代替案 (alpha plate の独立 depth など) と 3-pass 採用の構造的比較は `docs/specs/ayastorm-double-alpha-c-plan-extension.md §3` に記録。
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` / `lldrawpoolalpha.h` — `AttachmentFilter` enum と `forwardRender(rigged, filter)` overload、POST_WATER の 3 sub-pass 分割、per-draw `LLDrawInfo::mAttachedToAvatar` discriminator
+- `docs/specs/ayastorm-double-alpha-c-plan-extension.md` — falsified 案 A/B/C との構造的比較 (新規)
+- `docs/specs/ayastorm-six-category-render-order-trace.md` — 3-pass 境界の根拠となった 6 カテゴリ render order trace 全文 (新規)
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3-pass dispatch の設計・実装、falsification analysis (A/B/C 案)、spec 整備。
+
+### Special thanks
+
+- neria (neriamm) — アルファ render-order 問題の調査と検証協力。複数の SL avatar での再現環境構築と候補修正の hands-on 検証が、構造的比較と最終的な実装選択の絞り込みに大きく貢献しました。neria さんは Second Life のレジデント貢献者です (GitHub アカウントではありません)。
+
+### Documentation
+
+- 構造的比較 (拡張報告書): [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- 6 カテゴリ render order trace: [`docs/specs/ayastorm-six-category-render-order-trace.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
+
+---
+
+## 3D Stream URL filter + UI 更新 (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121))
+
+### 見出し: 3D Stream を初期 OFF に。URL 再生確認に送信元の object 名 / owner を表示
+
+3D Stream 機能 (r26 で導入、r31 で unified tag として整理) を r31.2 以降は `Stream3DEnabled = false` 初期値で出荷します。すでに 3D Stream を有効で運用していたユーザーは persist 値を引き継ぎます。新規 install のみ初期 OFF からの開始です。in-world オブジェクトから stream URL が送られたときの再生確認 dialog には送信元の object 名 / owner を表示し、誰が送ってきた URL なのかを各 viewer が判断できるようにします。rezz されたオブジェクト経由の意図しない自動再生は UI で後追いブロックするのではなく source-of-truth の段階で落とします。
+
+### 修正の仕組み
+
+- `settings.xml` で `Stream3DEnabled` 初期値を `false` に。既存ユーザーの persist 値は保持
+- URL 再生確認 dialog 文言に送信元の object 名 / owner を含める (3 言語)
+- source-of-truth 強制: 3D Stream が disabled のとき、rezz されたオブジェクトからの URL emit は auto-play 経路に届く前に落とす (UI 後追いではない)
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3D Stream URL filter + UI 更新の実装、3 言語プロンプトローカライズ。
+
+### Documentation
+
+- 技術報告 (日本語): [`docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- ユーザーガイド (English): [`docs/specs/3dstream-user-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.en.md)
+- ユーザーガイド (日本語): [`docs/specs/3dstream-user-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.ja.md)
+- ユーザーガイド (繁體中文): [`docs/specs/3dstream-user-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.zh.md)
+
+---
+
+## Cinematic glow min-luminance bugfix (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123))
+
+### 見出し: Cinematic mode `RenderGlowMinLuminance` を 0.0 → 0.5 に。既出荷ユーザーは one-shot migration で強制矯正
+
+Cinematic mode で適用される BD parity overlay が `RenderGlowMinLuminance = 0.0` を持ち込み、HDR linear 空間の bloom-extract 閾値を下げていました。`glowExtractF.glsl` は bloom 寄与を `smoothstep(min, min+1.0, x)` で計算するため、`min = 0.0` だと HDR `0..1.0` の中間 lit でも発火し、`warmth = max(r*0.75, g*0.6, b*0.712)` 経路で色付きプリム (blank texture + color picker) が prim 側 Glow=0 設定でも光ってしまいます。装着物と SIM rez object の両方で症状が報告され、texture 適用プリムや白色プリムでは発火しないという観測でした。
+
+閾値を `0.5` に引き上げます。Cinematic の強い bloom 表現 (空 / 強い反射 / 強い emissive — HDR `0.5` 以上) は引き続き発火し、装着物クラスの中間 lit による意図しない bloom だけを切ります。r31.0 / r31.1 で `0.0` を persist 焼きしてしまったユーザーは one-shot migration (sentinel `AYAR31GlowMinLuminanceMigrationVersion`) で強制矯正しますが、**次回 Cinematic mode 起動時に限ります** — Firestorm mode 専用ユーザーは影響なし (LL default `1.0` のまま、migration は skip し version も bump せず、次回 Cinematic 起動で再検査)。
+
+### 修正の仕組み
+
+- `settings_cinematic_bd.xml`: `RenderGlowMinLuminance` `0.0` → `0.5`
+- `settings.xml`: `AYAR31GlowMinLuminanceMigrationVersion` sentinel (S32, Persist=1, default 0) 追加
+- `llcinematicoverlay.{h,cpp}`: `applyR31GlowMinLuminanceMigrationIfNeeded()` 実装。`AYAVisualRealismEnabled != 2` (Firestorm mode) の場合は version を bump せず skip、次回 Cinematic 起動で再検査
+- `llappviewer.cpp`: 起動 sequence の既存 `applyR15GodraysCinematicMigrationIfNeeded()` 呼出後に migration 呼出を追加
+
+### Implementation summary
+
+- `indra/newview/app_settings/settings_cinematic_bd.xml` — `RenderGlowMinLuminance` 閾値引き上げ
+- `indra/newview/app_settings/settings.xml` — migration sentinel
+- `indra/newview/llcinematicoverlay.cpp` / `llcinematicoverlay.h` — `applyR31GlowMinLuminanceMigrationIfNeeded()` (mode==2 ガード付き)
+- `indra/newview/llappviewer.cpp` — 起動 sequence への組込み
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — bloom 閾値の調査、修正設計、one-shot migration 実装。
+
+---
+
+## 水中アルファ plate redirect 修正 (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124))
+
+### 見出し: `mAYAAlphaColor` redirect を `!sUnderWaterRender` で gate、水中は forward alpha を main RT へ直書き (FS 互換挙動)
+
+r30 P5 transparent-DoF C-(a) で導入した `mAYAAlphaColor` redirect は、forward alpha BLEND を独立 alpha plate に書かせて tonemap 前に main RT に over-blend (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) composite します。この redirect 有効化条件 (`use_alpha_rt`) が `LLPipeline::sUnderWaterRender` に対応していませんでした。水中時は main RT に underwater fog 着色済みの opaque scene があるのに、独立 plate は `(0,0,0,0)` で clear → forward alpha が plate に書き込み、pre-tonemap composite で plate が underwater 着色 main RT を上書きし、まつ毛 / 眉などの装着物アルファプリムと SIM particle の透過部分が **水中で真っ黒** で描画されていました。水上に出た後にも数フレーム再発する症状あり (カメラ上昇に伴い redirect が一旦水上状態に戻り、その後また水中状態に drift する)。
+
+修正は単一条件 gate: `use_alpha_rt` に `!LLPipeline::sUnderWaterRender` を追加します。水中時は redirect を skip して forward alpha を main RT に直書き — 水中での upstream FS 互換挙動。水上時の振る舞いは旧と完全一致。
+
+### 修正の仕組み
+
+- `indra/newview/lldrawpoolalpha.cpp`: `use_alpha_rt` 条件の既存 `gPipeline.mAYAAlphaColor.isComplete()` 直前に `!LLPipeline::sUnderWaterRender &&` を追加
+- gate が redirect を抑えると alpha plate は clear 済の `(0,0,0,0)` のまま。pre-tonemap composite は main RT に対して no-op (`A_plate * 1 + RT * 1 = RT`) となるため、水中専用 composite 経路は不要
+- 水上時の transparent-DoF C-(a) plate composite 効果は変更なし。水中は全画面 fog で bokeh 構造的に不可視のため、水中で plate composite を落としても知覚的差はない
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` — `use_alpha_rt` 条件に `!LLPipeline::sUnderWaterRender` を追加、inline コメントで水中時 no-op composite の根拠を明記
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 水中症状の調査、単一 gate 修正、5 connection point (`mForwardToAlphaRT` / alpha blend factors / emissive routing / plate clear / plate composite) の影響範囲トレース。

--- a/docs/release/ayastorm-r31-bugfix-2-release-note.zh.md
+++ b/docs/release/ayastorm-r31-bugfix-2-release-note.zh.md
@@ -5,6 +5,8 @@
 >
 > 並非 AYAstorm 特有的問題，而是對 Firestorm 衍生 viewer 全體共用的 inventory root 所衍生之結構性行為的對應 (屬於 bug 或仕樣的判斷由 upstream 決定)。
 
+與 AO + Bridge 修正並列的 **2 大修正項目** — 裝著物 N-BL prim alpha render-order 之 3-pass dispatch (PR #122) 也同捆於本版。此外還收錄了在 r31-bugfix-1 之後著陸的以下 3 件修正: 3D Stream URL filter + UI 更新 (PR #121)、Cinematic mode glow min-luminance bugfix (PR #123)、水中 alpha plate redirect 修正 (PR #124)。各 feature 別 section 請見本通知下方。
+
 實作細節、影響範圍、復原手順常設於 `docs/specs/` 與 `docs/guides/` 之下。本通知為入口與差異重點。
 
 ---
@@ -91,3 +93,128 @@ r31-bugfix-2 將一般 AO 集合「刪除」改為不刪除實際 inventory，�
 - 使用者復原手順 (繁體中文): [`docs/guides/ao-data-recovery-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
 - 使用者復原手順 (English): [`docs/guides/ao-data-recovery-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
 - 使用者復原手順 (日本語): [`docs/guides/ao-data-recovery-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+
+---
+
+## AO 集合已消失的使用者 — AO 再設置手順
+
+> [!IMPORTANT]
+> 已被上述事象抹去的 AO 集合的 **AO 資料本身在 viewer 側或 SL 伺服器側均無法找回**。不過 AO 機能本身可以透過簡單的再設置回到正常使用狀態。**手順以 3 種語言公開，請使用符合您環境的版本:**
+>
+> - 🇨🇳 [**繁體中文復原指南**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.zh.md)
+> - 🇺🇸 [**English Recovery Guide**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.en.md)
+> - 🇯🇵 [**日本語復旧手順**](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/guides/ao-data-recovery-guide.ja.md)
+>
+> 安裝 r31-bugfix-2 本身 **可在 AYAstorm 側阻止相同事象再次發生**。Firestorm 本家 / 其他 FS 衍生 viewer 中的再發各別需要 viewer 端 patch，相應的規避手段在復原指南內亦有明示。
+
+---
+
+## 裝著物 N-BL prim alpha render-order — 3-pass dispatch (PR [#122](https://github.com/mayatonton/phoenix-firestorm/pull/122))
+
+### 標題: r31-bugfix-2 之 2 大修正項目 其二 — POST_WATER forward pass 切分為 SIM N-BL → R-BL → 裝著物 N-BL 三段並以 per-draw discriminator 分流
+
+這是 AO + Bridge 救濟 **並列的 2 大修正項目** 之一。r30 §5 的 render-order swap (POST_WATER 全 non-rigged → 全 rigged) 解消了 rigged hair 越過的天空空抜，但副作用是裝著物 N-BL prim (睫毛 prim 等) 反而被繪在 rigged hair 之前然後被 over-blend 蓋掉的 regression (spec 用語為 S1 / S2)。將 POST_WATER 的 forward pass 切分為以下 3 sub-pass:
+
+- **pass 1**: `forwardRender(false, ATTACHMENT_NONE)` — 僅 SIM rezz N-BL
+- **pass 2**: `forwardRender(true)` — 全 R-BL (rigged hair 等)
+- **pass 3**: `forwardRender(false, ATTACHMENT_ONLY)` — 僅裝著物 N-BL prim
+
+per-draw discriminator 為 `LLDrawInfo::mAttachedToAvatar.notNull()`。將 pass 3 移到 rigged 之後使裝著物 prim 整列於 hair 前面，同時 pass 1 仍將 SIM 側 N-BL 繪於 rigged 之前以維持 §5 swap fix (透過頭髮的天空空抜解消)。PRE_WATER 為了 water fog 整合性維持 rigged-first。HUD 僅一次 forwardRender，不在範圍內。
+
+被 falsify 的替代案 (alpha plate 獨立 depth 等) 與採用 3-pass 的結構性比較記錄於 `docs/specs/ayastorm-double-alpha-c-plan-extension.md §3`。
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` / `lldrawpoolalpha.h` — `AttachmentFilter` enum 與 `forwardRender(rigged, filter)` overload、POST_WATER 切分為 3 sub-pass、per-draw `LLDrawInfo::mAttachedToAvatar` discriminator
+- `docs/specs/ayastorm-double-alpha-c-plan-extension.md` — 與 falsified A/B/C 案的結構性比較 (新增)
+- `docs/specs/ayastorm-six-category-render-order-trace.md` — 推導 3-pass 邊界所依據的 6 類別 render order trace 全文 (新增)
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3-pass dispatch 的設計、實作、falsification analysis (A/B/C 案)、spec 整備。
+
+### Special thanks
+
+- neria (neriamm) — alpha render-order 問題的調查與檢證協助。在多個 SL avatar 上的再現環境構築與候補修正的 hands-on 檢證，對結構性比較與最終實作選擇的縮小範圍有重大貢獻。neria 是 Second Life 的居民貢獻者 (並非 GitHub 帳號)。
+
+### Documentation
+
+- 結構性比較 (擴充報告書): [`docs/specs/ayastorm-double-alpha-c-plan-extension.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-double-alpha-c-plan-extension.md)
+- 6 類別 render order trace: [`docs/specs/ayastorm-six-category-render-order-trace.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-six-category-render-order-trace.md)
+
+---
+
+## 3D Stream URL filter + UI 更新 (PR [#121](https://github.com/mayatonton/phoenix-firestorm/pull/121))
+
+### 標題: 將 3D Stream 改為初期 OFF；URL 播放確認顯示送來方 object 名稱 / owner
+
+3D Stream 機能 (r26 導入、r31 以 unified tag 整理) 自 r31.2 起以 `Stream3DEnabled = false` 為初期值出貨。已在 3D Stream 啟用狀態下運用中的使用者會保留 persist 值，只有新安裝才從初期 OFF 開始。in-world 物件送來 stream URL 時的播放確認 dialog 改為顯示送來方的 object 名稱 / owner，讓各 viewer 能根據送來方判斷是否接受 URL。透過 rezz 物件導致的非預期自動播放不再以 UI 後追擋下，而是於 source-of-truth 階段就被擋住。
+
+### 修正的原理
+
+- `settings.xml` 中 `Stream3DEnabled` 初期值改為 `false`，既有使用者的 persist 值保留
+- URL 播放確認 dialog 文字加入送來方 object 名稱 / owner (3 語言)
+- source-of-truth 強制: 3D Stream 為 disabled 時，rezz 物件送出的 URL 在抵達 auto-play 路徑前就被丟棄 (非 UI 後追)
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 3D Stream URL filter + UI 更新的實作、3 語言提示在地化。
+
+### Documentation
+
+- 技術報告 (日語): [`docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md)
+- 使用者指南 (English): [`docs/specs/3dstream-user-guide.en.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.en.md)
+- 使用者指南 (日語): [`docs/specs/3dstream-user-guide.ja.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.ja.md)
+- 使用者指南 (繁體中文): [`docs/specs/3dstream-user-guide.zh.md`](https://github.com/mayatonton/phoenix-firestorm/blob/v7.2.4-ayastorm-r31-bugfix-2/docs/specs/3dstream-user-guide.zh.md)
+
+---
+
+## Cinematic glow min-luminance bugfix (PR [#123](https://github.com/mayatonton/phoenix-firestorm/pull/123))
+
+### 標題: 將 Cinematic mode 的 `RenderGlowMinLuminance` 從 0.0 提升到 0.5；既出貨使用者以 one-shot migration 強制矯正
+
+Cinematic mode 套用的 BD parity overlay 帶入了 `RenderGlowMinLuminance = 0.0`，降低了 HDR linear 空間的 bloom-extract 閾值。`glowExtractF.glsl` 以 `smoothstep(min, min+1.0, x)` 計算 bloom 寄與，故 `min = 0.0` 時連 HDR `0..1.0` 的中間 lit 都會發火，且 `warmth = max(r*0.75, g*0.6, b*0.712)` 路徑會讓著色 prim (blank texture + color picker) 即使 prim 側 Glow=0 也會發光。裝著物與 SIM rez object 兩者皆有症狀回報，而 texture 套用 prim 或白色 prim 不會發火。
+
+將閾值提升到 `0.5`。Cinematic 的強力 bloom 表現 (空 / 強反射 / 強 emissive — HDR `0.5` 以上) 仍會發火，只切掉裝著物等級的中間 lit 所致非預期 bloom。對於在 r31.0 / r31.1 已將 `0.0` 持久化的使用者，以 one-shot migration (sentinel `AYAR31GlowMinLuminanceMigrationVersion`) 強制矯正，但 **僅在下次 Cinematic mode 起動時** — Firestorm mode 專用使用者不受影響 (LL default `1.0` 維持，migration 跳過且不 bump version，於下次 Cinematic 起動時再檢查)。
+
+### 修正的原理
+
+- `settings_cinematic_bd.xml`: `RenderGlowMinLuminance` `0.0` → `0.5`
+- `settings.xml`: 加入 `AYAR31GlowMinLuminanceMigrationVersion` sentinel (S32, Persist=1, default 0)
+- `llcinematicoverlay.{h,cpp}`: 實作 `applyR31GlowMinLuminanceMigrationIfNeeded()`。當 `AYAVisualRealismEnabled != 2` (Firestorm mode) 時不 bump version 而 skip，下次 Cinematic 起動再檢查
+- `llappviewer.cpp`: 起動 sequence 中在既有 `applyR15GodraysCinematicMigrationIfNeeded()` 呼叫後追加 migration 呼叫
+
+### Implementation summary
+
+- `indra/newview/app_settings/settings_cinematic_bd.xml` — `RenderGlowMinLuminance` 閾值提升
+- `indra/newview/app_settings/settings.xml` — migration sentinel
+- `indra/newview/llcinematicoverlay.cpp` / `llcinematicoverlay.h` — `applyR31GlowMinLuminanceMigrationIfNeeded()` (帶 mode==2 保護)
+- `indra/newview/llappviewer.cpp` — 起動 sequence 中的整合
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — bloom 閾值調查、修正設計、one-shot migration 實作。
+
+---
+
+## 水中 alpha plate redirect 修正 (PR [#124](https://github.com/mayatonton/phoenix-firestorm/pull/124))
+
+### 標題: 將 `mAYAAlphaColor` redirect 以 `!sUnderWaterRender` 進行 gate；水中時 forward alpha 直接寫入 main RT (FS 互換動作)
+
+r30 P5 transparent-DoF C-(a) 導入的 `mAYAAlphaColor` redirect 會將 forward alpha BLEND 寫入獨立 alpha plate，然後在 tonemap 前以 (`GL_ONE / GL_ONE_MINUS_SRC_ALPHA`) over-blend composite 至 main RT。此 redirect 的啟用條件 (`use_alpha_rt`) 並未對應 `LLPipeline::sUnderWaterRender`。水中時 main RT 已含 underwater fog 著色的 opaque scene，獨立 plate 卻被 clear 為 `(0,0,0,0)` → forward alpha 寫入 plate，pre-tonemap composite 讓 plate 覆蓋 underwater 著色的 main RT，導致睫毛 / 眉等裝著物 alpha prim 與 SIM particle 透明區域 **在水中顯示為純黑**。上浮到水面後也會數 frame 再發 (camera 上升時 redirect 一度回到水面狀態，之後又漂回水中狀態)。
+
+修正為單一條件 gate: 在 `use_alpha_rt` 加上 `!LLPipeline::sUnderWaterRender`。水中時跳過 redirect，forward alpha 直接寫入 main RT — 水中時與 upstream FS 互換的動作。水面以上路徑與舊版完全一致。
+
+### 修正的原理
+
+- `indra/newview/lldrawpoolalpha.cpp`: 在 `use_alpha_rt` 條件既有的 `gPipeline.mAYAAlphaColor.isComplete()` 前加上 `!LLPipeline::sUnderWaterRender &&`
+- gate 抑制 redirect 時，alpha plate 維持 clear 狀態的 `(0,0,0,0)`。pre-tonemap composite 對 main RT 變為 no-op (`A_plate * 1 + RT * 1 = RT`)，因此不需要水中專用的 composite 路徑
+- 水面以上的 transparent-DoF C-(a) plate composite 效果無變化。水中是全畫面 fog 使 bokeh 結構性不可見，故水中放棄 plate composite 在知覺上無差異
+
+### Implementation summary
+
+- `indra/newview/lldrawpoolalpha.cpp` — `use_alpha_rt` 條件加上 `!LLPipeline::sUnderWaterRender`，並以 inline 註解記錄水中 no-op composite 的依據
+
+### Credits
+
+- [@mayatonton](https://github.com/mayatonton) — 水中症狀調查、單一 gate 修正、5 連線點 (`mForwardToAlphaRT` / alpha blend factors / emissive routing / plate clear / plate composite) 的影響範圍追蹤。

--- a/docs/release/ayastorm-r31-github-release-page.en.md
+++ b/docs/release/ayastorm-r31-github-release-page.en.md
@@ -85,11 +85,11 @@ The AYAstorm View pipeline draws extensively from NiranV Dean's Black Dragon vie
 
 ## Downloads
 
-> **Please use [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) instead.** r31-bugfix-1 fixes a structural SSS pink-shadow leak through FullBright prims that was present in r31, and ships installers for all 3 OS (Linux / Windows / macOS).
+> **Please use [AYAstorm r31-bugfix-2](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2) instead.** r31-bugfix-2 bundles the AO delete-event recovery, LSL Bridge collision defense, attachment alpha render-order (3-pass dispatch), 3D Stream URL filter, Cinematic glow min-luminance fix, underwater alpha plate fix, and the earlier r31-bugfix-1 SSS pink-shadow fix. Installers for all 3 OS (Linux / Windows / macOS) are bundled.
 
-- Linux Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- Windows Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- macOS Installer → [use r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
+- Linux Installer → [use r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- Windows Installer → [use r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- macOS Installer → [use r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-github-release-page.ja.md
+++ b/docs/release/ayastorm-r31-github-release-page.ja.md
@@ -85,11 +85,11 @@ AYAstorm View pipeline は NiranV Dean 氏の Black Dragon viewer (LGPL-2.1、vi
 
 ## Downloads
 
-> **[AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1) をご利用ください。** r31 に存在していた FullBright prim 越し SSS pink-shadow 透けの構造バグを r31-bugfix-1 で修正済みで、3 OS (Linux / Windows / macOS) すべてのインストーラーを同梱しています。
+> **[AYAstorm r31-bugfix-2](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2) をご利用ください。** r31-bugfix-2 は AO 削除事象救済 + LSL Bridge 衝突防御、装着物アルファ render-order の 3-pass dispatch、3D Stream URL filter、Cinematic glow min-luminance 修正、水中アルファ plate 修正、および r31-bugfix-1 の SSS pink-shadow 修正をすべて同梱しています。3 OS (Linux / Windows / macOS) すべてのインストーラーを同梱しています。
 
-- Linux Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- Windows Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- macOS Installer → [r31-bugfix-1 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
+- Linux Installer → [r31-bugfix-2 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- Windows Installer → [r31-bugfix-2 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- macOS Installer → [r31-bugfix-2 release を使用](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
 
 ## Contributors
 

--- a/docs/release/ayastorm-r31-github-release-page.zh.md
+++ b/docs/release/ayastorm-r31-github-release-page.zh.md
@@ -85,11 +85,11 @@ AYAstorm View pipeline 大量借鉴自 NiranV Dean 的 Black Dragon viewer (LGPL
 
 ## Downloads
 
-> **请改用 [AYAstorm r31-bugfix-1](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)。** r31 中存在的 FullBright prim 透过 SSS pink-shadow 渗漏的结构性 bug 已在 r31-bugfix-1 中修复,并同捆全部 3 个 OS(Linux / Windows / macOS)的安装包。
+> **请改用 [AYAstorm r31-bugfix-2](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)。** r31-bugfix-2 同捆了 AO 删除事象救济 + LSL Bridge 冲突防御、装着物 alpha render-order 之 3-pass dispatch、3D Stream URL filter、Cinematic glow min-luminance 修正、水中 alpha plate 修正,以及 r31-bugfix-1 的 SSS pink-shadow 修正。并同捆全部 3 个 OS(Linux / Windows / macOS)的安装包。
 
-- Linux Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- Windows Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
-- macOS Installer → [使用 r31-bugfix-1 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-1)
+- Linux Installer → [使用 r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- Windows Installer → [使用 r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
+- macOS Installer → [使用 r31-bugfix-2 release](https://github.com/mayatonton/phoenix-firestorm/releases/tag/v7.2.4-ayastorm-r31-bugfix-2)
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

r31-bugfix-2 release docs を「2 大修正項目 + その他同梱 3 件」framing に再構成し、実 installer URL を反映。

### 変更内容

- **release page (en/ja/zh)**: AO 再セットアップ手順 + 装着物 alpha render-order (PR #122) を「2 大修正項目」として明示、Special thanks (neria) を装着物 α section に配置
- **release note (en/ja/zh)**: intro 更新、PR #122 section を AO+Bridge 直後に reorder、AO 再セットアップ `[!IMPORTANT]` callout 挿入、PR #124 水中 α plate fix section 新規追加
- **r31 release page Downloads (en/ja/zh)**: r31-bugfix-1 → r31-bugfix-2 に redirect、説明文を r31-bugfix-2 同梱 fix 一式に更新
- **r31-bugfix-2 Downloads URL**: 実 installer 3 OS に差し替え
  - Windows: build 261492019
  - macOS: build 81339
  - Linux: build 261500427

### 同梱 PR (参考)

- #118 AO/Bridge recovery
- #121 3D Stream URL filter
- #122 装着物アルファ 3-pass dispatch
- #123 Cinematic glow min-luminance fix
- #124 underwater alpha plate fix

## Test plan

- [ ] release page (en/ja/zh) を GitHub Release ページに転載して表示崩れがないこと
- [ ] Downloads link 3 OS 全てがダウンロード可能なこと
- [ ] release note (en/ja/zh) の `[!IMPORTANT]` callout が GitHub で正しくレンダリングされること
- [ ] r31 release page から r31-bugfix-2 への redirect が機能していること