### PR TITLE
docs(3dstream): rename r32 → r31.2 (3D Stream default OFF を r31-bugfix-2 で実施)

### DIFF
--- a/docs/specs/3dstream-user-guide.en.md
+++ b/docs/specs/3dstream-user-guide.en.md
@@ -2,7 +2,7 @@
 
 > **Language / 言語 / 语言**: **English** · [日本語](./3dstream-user-guide.ja.md) · [中文](./3dstream-user-guide.zh.md)
 
-**Available in**: AYAstorm r31 and later. In r32 and later, 3D Stream is disabled by default.
+**Available in**: AYAstorm r31 and later. In r31.2 and later, 3D Stream is disabled by default.
 
 **Audience**: Streamers, DJs, live venue owners, and builders of exhibition, cinema, or event spaces.
 

--- a/docs/specs/3dstream-user-guide.ja.md
+++ b/docs/specs/3dstream-user-guide.ja.md
@@ -2,7 +2,7 @@
 
 > **Language / 言語 / 语言**: [English](./3dstream-user-guide.en.md) · **日本語** · [中文](./3dstream-user-guide.zh.md)
 
-**搭載**: AYAstorm r31 以降。r32 以降では 3D Stream は初期状態で無効です。
+**搭載**: AYAstorm r31 以降。r31.2 以降では 3D Stream は初期状態で無効です。
 
 **対象**: 配信者、DJ、ライブ会場オーナー、展示・映画館・イベント会場を作る人。
 

--- a/docs/specs/3dstream-user-guide.zh.md
+++ b/docs/specs/3dstream-user-guide.zh.md
@@ -2,7 +2,7 @@
 
 > **Language / 言語 / 语言**: [English](./3dstream-user-guide.en.md) · [日本語](./3dstream-user-guide.ja.md) · **中文**
 
-**搭载版本**: AYAstorm r31 及以后。r32 以后，3D Stream 默认关闭。
+**搭载版本**: AYAstorm r31 及以后。r31.2 以后，3D Stream 默认关闭。
 
 **对象**: 直播者、DJ、现场会场所有者，以及展览、影院、活动空间的制作者。
 

--- a/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md
+++ b/docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md
@@ -1,4 +1,4 @@
-# AYAstorm r32 3D Stream URL Filter and UI Update 修正報告書
+# AYAstorm r31.2 3D Stream URL Filter and UI Update 修正報告書
 
 作成日: 2026-05-29
 更新日: 2026-05-30


### PR DESCRIPTION
## Summary

3D Stream default OFF を当初 r32 予定 → **r31-bugfix-2 (= r31.2)** で実施することにしたため、PR #125 の release docs 更新に呼応する spec 側 doc を rename。

### 変更内容

- **3dstream-user-guide (en/ja/zh)**: 「r32 以後 default OFF」表記を「r31.2 以後」に更新 (各 1 行)
- **spec report file rename**:
  - `docs/specs/ayastorm-r32-3dstream-url-filter-and-ui-update-report.ja.md`
  - → `docs/specs/ayastorm-r31-2-3dstream-url-filter-and-ui-update-report.ja.md`
  - タイトル行も r32 → r31.2

### 経緯

PR #125 で r31-bugfix-2 release docs を「2 大修正 + その他 3 件 (3DStream URL filter 含む)」framing に再構成。3D Stream default OFF も同 release に含めるため、spec 側 doc 表記を release content に合わせた。

## Test plan

- [ ] 3dstream-user-guide 3 言語の修正箇所が r31.2 表記になっていること
- [ ] spec report file が r31-2- prefix で参照可能なこと
- [ ] 旧 r32- file へのリンクが repo 内に残っていないこと