### PR TITLE
r20: SSS Whitelist Comment を Phase C 実装現状に追従 (spec lag fix)

### DIFF
--- a/indra/newview/app_settings/settings.xml
+++ b/indra/newview/app_settings/settings.xml
@@ -10181,7 +10181,7 @@ Change of this parameter will affect the layout of buttons in notification toast
     <key>AYAR20AvatarSkinSSSWhitelist</key>
     <map>
       <key>Comment</key>
-      <string>r20 SSS 対象 mesh asset UUID whitelist。改行区切り、各行が 1 件の mesh UUID (36 文字 dash 区切り、完全一致)。装着物を右クリック > Add to SSS whitelist で自動追加されるのが基本ルート。手書きで paste も可。空行/無効な行は無視。Phase B/E 装着時照合済み、Phase A (本 build) の rendering は全画面 SSS のままで Phase C で per-pixel mask に切替予定</string>
+      <string>r20 SSS 対象 mesh asset UUID whitelist。改行区切り、各行が 1 件の mesh UUID (36 文字 dash 区切り、完全一致)。装着物を右クリック > Add to SSS whitelist で自動追加されるのが基本ルート。手書きで paste も可。空行/無効な行は無視。Phase C (per-pixel mask gate) 実装済 — 本 whitelist が空のとき SSS は全 mesh で発火しない (= isSSSTarget()==false → gbuffer3.a=0 → skinSSSF.glsl skin_bit=0 → Pass 2 alpha=0)。AYAR20AvatarSkinSSSEnabled=1 master ON にしても効果を見るには対象装着物を右クリック > Add to SSS whitelist で追加必須</string>
       <key>Persist</key>
       <integer>1</integer>
       <key>Type</key>


### PR DESCRIPTION
## 概要

`AYAR20AvatarSkinSSSWhitelist` の Comment 文言が Phase A 時代のまま残っていた spec lag を修正。実装は既に Phase C (per-pixel mask gate) で正常動作しており **code 改変は無し**、Comment 1 行のみの修正。

## 背景

r41 milestone 作業 (Phase 1.B 完了直後) に AYA さん主観で「SSS が効かなくなった気がする」報告。verify (Z) sub-step で以下を確認:

- master `AYAR20AvatarSkinSSSEnabled=1` ON 済
- `AYAR20AvatarSkinSSSWhitelist` override 無 = default 空
- shader 経路 trace 6 段で chain 確定: whitelist 空 → `isSSSTarget()==false` → `gbuffer3.a=0` → `skinSSSF` Pass 2 alpha=0 → 完全に無変化
- AYA 実機 live A/B: 自 avatar 肌 mesh を右クリック → Add to SSS whitelist → SSS 視認 PASS

→ **実装は仕様通り。Comment が Phase A 時代の「全画面 SSS のまま、Phase C で per-pixel mask に切替予定」のまま残っていたため、AYA さんが master ON のみで効くと誤解しやすい状態だった**。

## 修正内容

`indra/newview/app_settings/settings.xml` line 10184 の Comment 文字列 1 件 (+1/-1):

### 修正前
> Phase B/E 装着時照合済み、Phase A (本 build) の rendering は全画面 SSS のままで Phase C で per-pixel mask に切替予定

### 修正後
> Phase C (per-pixel mask gate) 実装済 — 本 whitelist が空のとき SSS は全 mesh で発火しない (= isSSSTarget()==false → gbuffer3.a=0 → skinSSSF.glsl skin_bit=0 → Pass 2 alpha=0)。AYAR20AvatarSkinSSSEnabled=1 master ON にしても効果を見るには対象装着物を右クリック > Add to SSS whitelist で追加必須

## 影響範囲

- **改変**: `indra/newview/app_settings/settings.xml` 1 file +1/-1 (Comment string のみ)
- **C++ / GLSL 改変**: 無し
- **cvar 種別/型/default 値/Persist**: 不変
- **既存挙動**: 1 bit も変化なし (純粋に文言修正)

## Test plan

- [x] AYA 実機 live A/B PASS (2026-06-04)
- [x] settings.xml debug settings ダイアログで Comment 表示確認
- [x] AYAR20AvatarSkinSSSWhitelist 既定 (空) → master ON 単独では SSS 不発火を確認
- [x] mesh を右クリック → Add to SSS whitelist で SSS 発火を確認