### PR TITLE
fix(llrender): uniform4iv(U32 index, ...) で glUniform1iv → glUniform4iv (上流既存 bug、信管抜き fix)

### DIFF
--- a/indra/llrender/llglslshader.cpp
+++ b/indra/llrender/llglslshader.cpp
@@ -1477,7 +1477,7 @@ void LLGLSLShader::uniform4iv(U32 index, U32 count, const GLint* v)
             LLVector4 vec((F32)v[0], (F32)v[1], (F32)v[2], (F32)v[3]);
             if (iter == mValue.end() || shouldChange(iter->second, vec) || count != 1)
             {
-                glUniform1iv(mUniform[index], count, v);
+                glUniform4iv(mUniform[index], count, v);
                 mValue[mUniform[index]] = vec;
             }
         }


### PR DESCRIPTION
## 概要

`LLGLSLShader::uniform4iv(U32 index, U32 count, const GLint* v)` method (整数 index 経路) の中身が、method 名と矛盾する OpenGL API を呼んでいた **1 文字 typo 級の structural bug** を修正。**現状は dead code (call site 0 件) で実害なし**、将来 caller 追加で顕在化する地雷の信管抜き予防 fix。LL `secondlife/viewer` + Phoenix-Firestorm `phoenix-firestorm` 上流にも同型 bug 同居 (= ayastorm-release HEAD は両上流取込後の状態)。

## bug 内容

### 修正箇所

`indra/llrender/llglslshader.cpp:1480` (method body は line 1460-1485)

```diff
-                glUniform1iv(mUniform[index], count, v);
+                glUniform4iv(mUniform[index], count, v);
```

### 何が間違っていたか

| 観点 | 内容 |
|---|---|
| method 名 | `uniform4iv` = LL 慣例で「**ivec4** (= 4 component int) を count 個まとめて upload」用 |
| 内部処理 | `LLVector4 vec((F32)v[0], (F32)v[1], (F32)v[2], (F32)v[3]);` で 4 component 取り出して `mValue` cache に格納 = **4 component 前提** |
| 呼んでた API | `glUniform1iv` = OpenGL spec 上「**scalar int** を count 個 upload」用 = 1 component 前提 |
| 結果 | method 名・内部 cache (4 component) vs GPU upload (1 component) の **component 数不一致** |

### 顕在化したらどうなるか

- target uniform 型が `ivec4` で `glUniform1iv` 呼出 → OpenGL spec 上 `GL_INVALID_OPERATION` (driver 依存で silent fail もあり得る)
- 内部 cache (`mValue` = 4 component で保持) と GPU 実状態の乖離
- 4 component × N 個渡したつもりが 1 component × N 個しか upload されず、N×3 個の int が捨てられる (= **3/4 truncation**)

### なぜ現状実害ゼロか

- `grep -rn "uniform4iv" indra/ --include=\"*.cpp\" --include=\"*.h\"` 結果 = method 定義 4 件 + comment 3 件のみ、**外部呼出 0 件**
- 誰もこの整数 index 経路を呼んでないので 3/4 truncation も driver error も発生していない (= 完全 dead code)

### hashed 経路は正常

同 method 名の hashed 引数版 (`uniform4iv(const LLStaticHashedString&, ...)` line 1802-1820) は別実装で `glUniform4iv(location, count, v);` 正しく呼んでる。**整数 index 経路だけが書き間違い**。

## 上流 bug 同型 verify

| 上流 | 状態 |
|---|---|
| `secondlife/viewer` master HEAD `indra/llrender/llglslshader.cpp:1480` | 同型 bug 存在 |
| `FirestormViewer/phoenix-firestorm` master HEAD 同 file 同 line | 同型 bug 存在 |

→ **上流 (LL or Firestorm) への PR も別途価値あり** = 本 PR は AYAstorm fork 内 (a) 即時 fix path、(b) LL/Firestorm 上流 PR は別 work (= 後続独立 sub-task)。

## 経緯

AYAstorm r41 Vulkan migration milestone (Phase 1.B) で整数 index 経路を touch していた際に method 名と API call の不整合を発見。r41 milestone とは独立の上流既存 bug ゆえ、ayastorm-release 直接 fix path として本 PR 起案。

## 影響範囲

- **改変**: `indra/llrender/llglslshader.cpp` 1 file +1/-1 (`glUniform1iv` → `glUniform4iv` 1 文字)
- **C++ 他経路 / GLSL / settings.xml / cmake**: 改変 0
- **既存挙動**: 1 bit も変化なし (= dead code ゆえ動作差分ゼロ実証済)

## Test plan

- [x] AYA 実機 (Linux x86_64) full viewer build EXIT 0
- [x] viewer 起動 fail 0 件
- [x] viewer 終了 fail 0 件
- [x] `grep -rn "uniform4iv" indra/` で外部 call site 0 件 = dead code 状態確認
- [x] LL upstream + Phoenix-Firestorm 上流 raw fetch で line 1480 同型 bug 確認