### PR TITLE
macOS MoltenVK: device lost診断とRetinaログイン画面修正

### DIFF
--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -115,7 +115,16 @@ rg '#VkPerf#|FRAMETIME ms:|recreateSwapchain|WARNING|ERROR|VUID|device lost' "$L
 確認したもの。スクリーンショットは有り（この task に添付された
 `codex-clipboard-5ef5d7d3-9b79-401b-a0ae-faaae31d421e.png`）。再現場所、ワールド時刻、
 カメラ位置・回転操作の詳細は未記録であるため、修正確認時はこれらを採取して同一条件で
-再試験する。この NG により、視覚受入は **FAIL** とする。
+再試験する。この時点では、この NG により視覚受入を **FAIL** とした。
+
+### 再確認結果 — 2026-08-10
+
+半透明オブジェクトの影が点描（dither）状に出ることを、検証者の目視で **OK** と確認した。
+したがって同項目の現時点の結果は **OK** とし、2026-08-02 の NG は過去の再現記録として残す。
+
+この PR には `pbrShadowAlphaBlendF.glsl` 等の半透明 shadow shader 差分を含めていないため、
+今回の OK をこの PR の device lost 修正による効果とは断定しない。再発防止のため、同一の透明度
+段階・light・カメラ条件で screenshot と log を採取する再試験は引き続き推奨する。
 
 ### 追加視覚事象: メッシュボディ alpha の再有効化 — 2026-08-02
 
@@ -136,10 +145,11 @@ rg '#VkPerf#|FRAMETIME ms:|recreateSwapchain|WARNING|ERROR|VUID|device lost' "$L
   テレポートせずに反映されること。操作開始・終了時刻、COF version、`Stale appearance` の
   有無を併記すること。
 
-## 6. 半透明 dither shadow NG の修正方針（未実装）
+## 6. 半透明 dither shadow: 過去の NG と修正候補（PR 対象外）
 
-この節は §5 の半透明オブジェクト shadow NG に対する**修正方針**であり、shader の修正が
-この branch に含まれることを示すものではない。現時点の視覚受入は NG のままである。
+この節は §5 で過去に記録した半透明オブジェクト shadow NG に対する**修正候補**であり、shader の
+修正がこの branch に含まれることを示すものではない。2026-08-10 の目視再確認では dither shadow は
+OK であり、ここに記載する候補は再発時に検討するものとする。
 
 ### 現状の確認結果
 
@@ -172,7 +182,7 @@ cutout shadow は対象外とし、輪郭を保つ既存経路を変更しない
 この shader は `LL_VULKAN_GLSL` 経路で共有されるため、修正時は macOS MoltenVK だけでなく
 Linux Vulkan と Windows Vulkan を同一 scope とする。
 
-### 修正後の受入条件
+### 再発時の受入条件
 
 同じ light、地面、カメラ距離で、次の4行を別々に比較する。
 

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -415,3 +415,81 @@ Viewer log 上の起動時刻は `15:30:17Z`、device lost は約 42 秒後の `
 小規模テクスチャ upload / mipmap 作成経路である。次の診断では image handle、幅・高さ、format、
 mip 数および texture asset ID を submit 履歴へ加え、対象リソースを確定してから layout と
 GPU 完了前の寿命管理を修正する。
+
+## 11. image upload / mip blit の調査と修正方針 — 2026-08-10
+
+### 結論
+
+`image-upload-2d` と `image-mip-blit` が交互に記録されたこと自体は、device lost の原因確定を
+意味しない。Present Engine は one-shot job に単調な timeline 値を振り、単一 graphics queue へ
+FIFO で submit するため、通常の `upload -> mip blit` の順序は維持される。
+
+今回の履歴は、先行 texture の mip blit の後に次 texture の upload が続く形であり、timeline
+`17119` の `image-upload-2d` が `VK_ERROR_DEVICE_LOST` を返した。Vulkan / MoltenVK では先行する
+GPU command の異常が後続 submit で表面化し得るため、最後の upload だけを原因とは断定しない。
+
+### VERIFIED: 修正すべき仕様不備
+
+`LLVKLoader::generateMipChainBlitVk()` は `VK_FILTER_LINEAR` 用に
+`VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT` だけを検査している。しかし
+`vkCmdBlitImage` には source の `VK_FORMAT_FEATURE_BLIT_SRC_BIT` と destination の
+`VK_FORMAT_FEATURE_BLIT_DST_BIT` も必要である。
+
+従って次の修正を行う。
+
+1. mip generation 可否を format ごとに `BLIT_SRC`、`BLIT_DST`、および linear filter の全条件で
+   判定する。
+2. 非対応 format は mip blit command を一切記録せず、最初から 1 mip の texture として確保し、
+   non-mip sampler を使う fallback にする。複数 mip を確保したまま未初期化の level を sample
+   してはならない。
+3. 失敗時の診断には image handle、幅・高さ、format、mip 数、および format feature bits を残す。
+
+これは log の 4 KiB texture が当該非対応 format だったことをまだ示すものではないが、現行コードの
+`vkCmdBlitImage` 発行条件が不十分であることは source と Vulkan の valid usage から確認済みである。
+
+### VERIFIED: bindless descriptor の寿命上の危険
+
+Vulkan + bindless が有効な run で、`LLImageGL::updateVkHeapSlot()` は image view または sampler が
+変わると、既存 bindless slot を `vkUpdateDescriptorSets()` で即時上書きする。descriptor binding は
+`UPDATE_AFTER_BIND` と `UPDATE_UNUSED_WHILE_PENDING` を付けているが、pending command buffer が実際に
+その slot を sample する場合、その descriptor を更新してよいことにはならない。
+
+修正は、view または sampler が変わるたびに新しい bindless slot を取得し、旧 slot は既存の
+`bindlessReleaseSlotDeferred()` 経路で GPU 完了後に解放することとする。これにより既に submit 済みの
+frame は旧 slot と旧 image view を維持し、以後 record する frame だけが新 slot を参照する。
+
+これは device lost の直接原因としては未確定だが、今回の run では bindless heap が有効であり、texture
+streaming 中にこの更新が起きるため、format feature 修正と同じ優先度で是正する。
+
+### 構造改善: upload と mip chain を一つの one-shot に統合する
+
+現状は `syncVulkanMip0Image()` が base level upload を submit した直後、別 command buffer / 別
+one-shot job として mip chain blit を submit する。FIFO により通常は順序を保てるものの、mip family の
+layout 遷移を呼び手内で閉じる規約に対して不必要な中間状態を作る。
+
+auto-generated mip の経路は、次を一つの command buffer に記録して一度だけ submit する。
+
+```text
+UNDEFINED -> TRANSFER_DST (mip 0)
+copy staging buffer -> mip 0
+TRANSFER_DST / TRANSFER_SRC を使った mip 1..N の blit
+全 mip -> SHADER_READ_ONLY
+```
+
+submit 発生元は `image-upload-mips-2d` として診断に残す。asset 側が既に全 mip を持つ upload、cube /
+3D image、readback などは対象外とし、挙動を変えない。
+
+### 補助的な是正と検証
+
+- one-shot の staging byte 上限は、通常の `image-upload-2d` で回収キューに `0` が渡されるため、
+  256 MiB の byte 上限が実効していない。今回の直接原因とは未確定だが、実バイト数を保持して
+  backpressure を有効化する。
+- `sCommandPool` は one-shot と frame command buffer で共有している。Vulkan の command pool は
+  host access の外部同期が必要である。現行の静的確認では PE thread は submit 専任であり、この共有が
+  本件の race である証拠はない。ただし one-shot を将来 worker から記録する経路がないかを確認し、
+  必要なら専用 pool または pool mutex を導入する。
+
+修正順序は、(1) format feature gate と 1 mip fallback、(2) bindless slot の世代分離、(3) upload + mip
+統合、(4) staging backpressure と command pool 監査とする。各段階で cache を消去した状態から
+`AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` で複数回起動し、device lost / VUID の不在、`#VkPerf#`、
+`FRAMETIME ms:`、および通常の texture・shadow 表示を記録する。

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -122,9 +122,12 @@ rg '#VkPerf#|FRAMETIME ms:|recreateSwapchain|WARNING|ERROR|VUID|device lost' "$L
 半透明オブジェクトの影が点描（dither）状に出ることを、検証者の目視で **OK** と確認した。
 したがって同項目の現時点の結果は **OK** とし、2026-08-02 の NG は過去の再現記録として残す。
 
-この PR には `pbrShadowAlphaBlendF.glsl` 等の半透明 shadow shader 差分を含めていないため、
-今回の OK をこの PR の device lost 修正による効果とは断定しない。再発防止のため、同一の透明度
-段階・light・カメラ条件で screenshot と log を採取する再試験は引き続き推奨する。
+解消元は、最新 `feature/ayastorm-r42-phase2` の `54e8559fba`
+（`fix: 透明影 flicker 根治(MDI テンプレ per-draw 内容 stale)+ F1 timeline hang 退行修正 + 診断計器撤去`）
+である。この PR の先頭コミット `1bfa09760d` は同 commit を親にしており、device lost 修正が
+dither shadow を解消したものではない。今回の目視は、更新済み base の透明 shadow 修正が有効で
+あることの確認として扱う。再発防止のため、同一の透明度段階・light・カメラ条件で screenshot と
+log を採取する再試験は引き続き推奨する。
 
 ### 追加視覚事象: メッシュボディ alpha の再有効化 — 2026-08-02
 

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -493,3 +493,56 @@ submit 発生元は `image-upload-mips-2d` として診断に残す。asset 側�
 統合、(4) staging backpressure と command pool 監査とする。各段階で cache を消去した状態から
 `AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` で複数回起動し、device lost / VUID の不在、`#VkPerf#`、
 `FRAMETIME ms:`、および通常の texture・shadow 表示を記録する。
+
+## 12. device lost 修正実装と初回実用検証 — 2026-08-09
+
+### 実装済みの変更
+
+`feature/ayastorm-r42-macos-device-lost-repair-wip` で、§11 のうち command pool 監査を除く
+修正を次の 3 コミットに分離して実装した。この branch はローカル検証用であり、既存 PR には
+まだ含めていない。
+
+| コミット | 内容 |
+| --- | --- |
+| `5ced502490` | auto-generated mip の base level upload、全 mip の layout 遷移、blit、shader-read 遷移を単一 one-shot command buffer / submit に統合。format feature は `BLIT_SRC`、`BLIT_DST`、linear filter の全条件を確認し、非対応 format は 1 mip に制限する。 |
+| `f247b52742` | one-shot deferred-free queue に実際の staging byte 数を引き渡し、256 MiB の backpressure を再び実効させる。byte 数の型を `U64` に揃える。 |
+| `d9da0126e9` | image view / sampler の変更時に bindless descriptor を in-place 更新せず、新 slot を取得して旧 slot を GPU 完了後に解放する。 |
+
+この変更により、旧来の `image-upload-2d` と `image-mip-blit` の別 submit は、auto-generated mip
+対象では `image-upload-mips-2d` の単一 submit に置き換わる。asset が既に mip を持つ upload、cube / 3D
+image、readback は変更対象外である。
+
+### 初回実用検証の記録
+
+同一ソースから arm64 開発 app を build し、shader cache と `pipeline_cache.bin` を削除してから、
+次で起動した。
+
+```bash
+AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
+```
+
+原本 log は次にある。
+
+```text
+~/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log
+```
+
+| 確認項目 | 実測結果 |
+| --- | --- |
+| Vulkan 起動 | `initialized device=Apple M2 Pro`、`Vulkan presentation surface initialized`、`Initializing Login Screen` を順に確認。 |
+| 実行時間 | `Run time: 1069.259 seconds`（約 17 分 49 秒）。ユーザー操作による終了後に `status: stopped`。 |
+| device lost / VUID | `device lost`、`VK_ERROR_DEVICE_LOST`、`VUID` は検出なし。 |
+| GPU shadow 経路 | `#VkPerf#` に `shsite mv.am=...` を確認。観測した同一行に `rest.am` および `fb.*` はなく、alpha-mask の multiview 経路は維持された。 |
+| P0 | 終盤は負荷により `FRAMETIME ms:` の p95 が約 190--290 ms、p99 が約 262--308 ms。安定性通過と性能受入を混同しない。 |
+| 警告 | HTTP 403 等の asset/network 系 WARNING は継続。今回の log に device lost、VUID、ログレベル ERROR はない。 |
+
+この run は、従来 42--271 秒で再現していた `VK_ERROR_DEVICE_LOST` がこの操作範囲では再現せず、
+修正コードを**実用検証へ進める候補として採用できる**根拠である。一方で、単一 run が GPU/driver
+問題の恒久解決を証明するものではない。安定性の最終受入は次を満たすまで **OPEN** とする。
+
+1. shader cache / pipeline cache を毎回消去した cache-cold run を少なくとも 3 回行う。
+2. 各 run を 10--30 分以上継続し、login、teleport、texture streaming、カメラ回転を含める。
+3. 各 run の log 全体から `device lost` / `VK_ERROR_DEVICE_LOST` / `VUID` / ERROR の有無、`#VkPerf#`、
+   `FRAMETIME ms:`、`recreateSwapchain` を記録する。
+4. macOS の結果を Linux / Windows の実行証拠とみなさず、共有 Vulkan TU に触れる本修正は各
+   プラットフォーム担当者が build と Vulkan run を別途確認する。

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -307,3 +307,111 @@ shsite mv.op=850 mv.opR=374 mv.am=102 mv.ab=646 mv.gm=102 mv.gmR=8874 mv.gaR=34 
 - 視覚確認は [§5](#5-視覚確認チェックリスト) に記録済み。髪、植生・木の葉、金網、草、
   カメラ回転、spot light は OK だが、半透明 dither shadow は NG のため、視覚受入は
   **FAIL** である。
+
+## 10. device lost 再現・submit 診断記録 — 2026-08-09
+
+`feature/ayastorm-r42-macos-device-lost-diagnostics` の開発 app で、次の環境変数を付けて
+実行した run で device lost を再現した。この branch には Retina でのログイン画面 1/4 表示を
+防ぐ修正 (`1bfa09760d`) と、Darwin 限定の submit 履歴診断
+(`c43f8d4320`) を含む。
+
+```bash
+AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
+```
+
+この run については shader cache / pipeline cache を起動直前に消去した記録がない。そのため
+shadow の視覚受入結果には使わず、device lost の診断 run としてだけ扱う。
+
+### 結果
+
+- 起動から約 271 秒後の `2026-08-09T14:41:02Z` に `VK_ERROR_DEVICE_LOST` を再現した。
+- 直接失敗したのは `queue-submit` の timeline `57962`、`result=-4`
+  (`VK_ERROR_DEVICE_LOST`) である。
+- 新設した `VKC-DEVLOST` 診断では、失敗 submit を含む直近 16 件が**すべて
+  `one-shot`**だった。timeline `57947`--`57961` は成功、`57962` だけが失敗した。
+- `PresentEngine submit failed` の後、Viewer は `requestQuit` を呼び、logout / cleanup を
+  完走して `status: stopped` へ到達した。OS による即時 abort ではなく、device lost を検出した
+  Viewer の graceful shutdown である。
+- 終了直前の P0 は `FRAMETIME ms: avg 101.81, p95 275.99, p99 319.35, max 319.35, n 99`。
+  この run の安定性判定は **FAIL**。
+
+`VKC-DEVLOST` の原本は次の Viewer log に残る。
+
+```text
+~/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log
+```
+
+要点は次のとおり。
+
+```text
+VKC-DEVLOST trigger=queue-submit submit_history=16
+VKC-DEVLOST submit[14]: type=one-shot result=0  timeline=57961 ...
+VKC-DEVLOST submit[15]: type=one-shot result=-4 timeline=57962 ...
+PresentEngine: device lost — all further submits skipped (first skipped: is_frame=0 is_oneshot=1)
+GPU device lost (VK_ERROR_DEVICE_LOST) — requesting graceful shutdown.
+```
+
+### shader / pipeline cache が空の状態での再現 — 2026-08-09
+
+同じ開発用 profile で、起動前に次の 2 項目を確認した。両方とも既に存在せず、profile 内に
+別位置の同名項目もなかったため、cache が空の状態であることを確認してから起動した。
+
+```text
+~/Library/Application Support/AYAstorm-dev/cache/shader_cache/
+~/Library/Application Support/AYAstorm-dev/cache/pipeline_cache.bin
+```
+
+起動には再び `AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` を用いた。`15:12:02Z` に Vulkan
+presentation surface / `2560x1387` swapchain の成立を確認したが、run time 約 68 秒後の
+`15:13:10Z` に再度 `VK_ERROR_DEVICE_LOST` が発生した。
+
+- `VKC-DEVLOST trigger=queue-submit`、失敗は one-shot timeline `16606` (`result=-4`)。
+- 直前 15 件 (`16591`--`16605`) もすべて one-shot で、成功していた。
+- 最終 P0 行は `15:13:01Z`: `FRAMETIME ms: avg 106.80, p95 237.44, p99 310.23,
+  max 310.23, n 75`。
+- この場合も `requestQuit` を経由して `status: stopped` まで cleanup した。
+
+したがって shader cache / pipeline cache の残存は、この device lost の必要条件ではない。
+ただし cache を消しても device lost を防げないことを示すだけで、one-shot command buffer 内の
+どの操作が GPU 異常を引き起こしたかは未確定である。
+
+### 現時点の切り分け
+
+device lost を返した submit と直前 15 件が one-shot であるため、通常 frame submit、swapchain
+present、shadow multiview 経路ではなく、one-shot のリソース転送・画像レイアウト遷移・mipmap /
+cubemap 処理のいずれかが関与する可能性が高い。ただし GPU の異常は先行コマンドに起因して
+後続 submit で検出され得るため、timeline `57962` の command buffer 自体を原因とは断定しない。
+
+MoltenVK / Apple GPU のこの run では GPU breadcrumb と `VK_EXT_device_fault` がともに
+`enabled=0` であり、driver 側 fault 情報は取得できない。HTTP 403・asset retry・network timeout
+は同時期に出ているが、device lost への因果を示すログはない。
+
+次の再現では one-shot submit ごとに呼び出し元種別（buffer upload / image upload / mipmap /
+cubemap / layout transition）と staging bytes を記録し、timeline `57962` / `16606` のような
+失敗 submit に対応する操作まで特定する。
+
+### one-shot 発生元を特定した再現 — 2026-08-09
+
+Darwin 限定の発生元・staging byte 診断 (`7f8b2cfd83`) を含む開発 app を、同じ環境変数で起動した。
+Viewer log 上の起動時刻は `15:30:17Z`、device lost は約 42 秒後の `15:30:59Z` だった。
+
+- 失敗した submit は timeline `17119`、`type=one-shot`、
+  `oneshot_source=image-upload-2d`、`staging_bytes=4096`、`result=-4`
+  (`VK_ERROR_DEVICE_LOST`) である。
+- 直前 15 件もすべて one-shot で、`image-upload-2d`（各 4,096 bytes）と
+  `image-mip-blit` が交互に並んだ。`17104`--`17118` は成功し、`17119` だけが失敗した。
+- `image-upload-2d` は静的な呼び出し元として
+  `LLImageGL::syncVulkanMip0Image()` から `LLVKLoader::uploadImageDataVk()` へ入る一般的な
+  テクスチャ upload 経路である。今回の診断は texture asset ID、画像寸法、format、mip 数を
+  出していないため、対象テクスチャ自体は未確定である。
+- `image-mip-blit` は `LLVKLoader::generateMipChainBlitVk()` の経路である。最後に
+  `image-upload-2d` が失敗を返したことは、当該 upload 自体が原因である証拠にはならない。
+  先行 upload / mip blit の GPU 異常が後続 submit で検出される可能性を残す。
+- 終了直前の P0 は `15:30:57Z`: `FRAMETIME ms: avg 66.77, p95 171.10, p99 188.98,
+  max 342.55, n 121`。この run も `requestQuit` を経由して終了し、安定性判定は **FAIL**。
+
+従って、次の修正・診断対象は swapchain や shadow multiview ではなく、
+`LLImageGL::syncVulkanMip0Image()` -- `uploadImageDataVk()` -- `generateMipChainBlitVk()` の
+小規模テクスチャ upload / mipmap 作成経路である。次の診断では image handle、幅・高さ、format、
+mip 数および texture asset ID を submit 履歴へ加え、対象リソースを確定してから layout と
+GPU 完了前の寿命管理を修正する。

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -1432,9 +1432,17 @@ void LLImageGL::updateVkHeapSlot()
 
     if (mVkHeapSlotView != mVkImageView || mVkHeapSlotSampler != smp)
     {
-        LLVKLoader::bindlessUpdateSlot(mVkHeapSlot, mVkImageView, smp);
-        mVkHeapSlotView    = mVkImageView;
-        mVkHeapSlotSampler = smp;
+        // Descriptors referenced by already submitted command buffers must
+        // remain immutable until those submissions complete.  Publish a new
+        // slot and retire the old one instead of overwriting it in place.
+        const U32 old_slot = mVkHeapSlot;
+        const U32 new_slot = LLVKLoader::bindlessAcquireSlot(mVkImageView, smp);
+        LLVKLoader::bindlessReleaseSlotDeferred(old_slot);
+        mVkHeapSlot        = new_slot;
+        mVkHeapSlotView    = (new_slot != LLVKLoader::BINDLESS_INVALID_SLOT)
+                             ? mVkImageView : VK_NULL_HANDLE;
+        mVkHeapSlotSampler = (new_slot != LLVKLoader::BINDLESS_INVALID_SLOT)
+                             ? smp : VK_NULL_HANDLE;
     }
 }
 
@@ -2609,4 +2617,3 @@ void LLImageGLThread::run()
     gGL.shutdown();
     mWindow->destroySharedContext(mContext);
 }
-

--- a/indra/llrender/llimagegl.cpp
+++ b/indra/llrender/llimagegl.cpp
@@ -879,11 +879,8 @@ bool LLImageGL::setImage(const U8* data_in, bool data_hasmips /* = false */)
                         S32 dim = llmax(w, h);
                         while (dim > 1) { dim >>= 1; ++vk_mip_count; }
                     }
-                    vk_ok &= syncVulkanMip0Image((U32)mFormatInternal, (U32)mFormatPrimary, (U32)mFormatType, w, h, data_in, false, 0, vk_mip_count);
-                    if (vk_ok && mVkImage != VK_NULL_HANDLE && mVkImageMipLevels > 1)
-                    {
-                        LLVKLoader::generateMipChainBlitVk(mVkImage, (U32)w, (U32)h, mVkImageMipLevels, mVkImageFormat);
-                    }
+                    vk_ok &= syncVulkanMip0Image((U32)mFormatInternal, (U32)mFormatPrimary, (U32)mFormatType,
+                                                  w, h, data_in, false, 0, vk_mip_count, true);
 
                     updatePickMask(w, h, data_in);
                 }
@@ -1072,7 +1069,7 @@ namespace
 
 bool LLImageGL::syncVulkanMip0Image(U32 intformat, U32 primary, U32 type,
                                     S32 w, S32 h, const void* data, bool is_compressed,
-                                    S32 mip_level, S32 mip_count)
+                                    S32 mip_level, S32 mip_count, bool generate_mip_chain)
 {
     if (!LLVKLoader::shouldUseVulkanRender())
     {
@@ -1104,7 +1101,15 @@ bool LLImageGL::syncVulkanMip0Image(U32 intformat, U32 primary, U32 type,
 
     if (mip_level == 0)
     {
-        const U32 want_mips = (mip_count > 0) ? (U32)mip_count : 1u;
+        U32 want_mips = (mip_count > 0) ? (U32)mip_count : 1u;
+        if (generate_mip_chain && want_mips > 1
+            && !LLVKLoader::canGenerateMipChainBlitVk(vk_format))
+        {
+            // A view restricted to one level is safe to sample; leaving an
+            // unsupported mip chain allocated would leave its lower levels
+            // uninitialized and make the first texture sample undefined.
+            want_mips = 1;
+        }
 
         const bool can_reuse = (mVkImage != VK_NULL_HANDLE)
                                && (mVkImageView != VK_NULL_HANDLE)
@@ -1241,8 +1246,12 @@ bool LLImageGL::syncVulkanMip0Image(U32 intformat, U32 primary, U32 type,
     bool ok = true;
     if (upload_size > 0)
     {
-        const bool upload_ok = LLVKLoader::uploadImageDataVk(
-            mVkImage, (U32)w, (U32)h, upload_data, upload_size, (U32)mip_level);
+        const bool upload_ok = (generate_mip_chain && mip_level == 0 && mVkImageMipLevels > 1)
+            ? LLVKLoader::uploadImageDataAndGenerateMipChainVk(
+                mVkImage, (U32)w, (U32)h, upload_data, upload_size,
+                mVkImageMipLevels, mVkImageFormat)
+            : LLVKLoader::uploadImageDataVk(
+                mVkImage, (U32)w, (U32)h, upload_data, upload_size, (U32)mip_level);
 
         if (!upload_ok)
         {

--- a/indra/llrender/llimagegl.h
+++ b/indra/llrender/llimagegl.h
@@ -146,7 +146,7 @@ public:
     bool syncVulkan3DImage(U32 intformat, U32 primary, U32 type, S32 w, S32 h, S32 depth, const void* data);
 
     bool syncVulkanMip0Image(U32 intformat, U32 primary, U32 type, S32 w, S32 h, const void* data, bool is_compressed,
-                             S32 mip_level = 0, S32 mip_count = 1);
+                             S32 mip_level = 0, S32 mip_count = 1, bool generate_mip_chain = false);
 
     static bool computeIsMask(const void* data_in, U32 w, U32 h, S8 alpha_stride, S8 alpha_offset);
     static U8* buildPickMask(S32 width, S32 height, const U8* data_in, U16& out_width, U16& out_height);

--- a/indra/llrender/llvkloader.cpp
+++ b/indra/llrender/llvkloader.cpp
@@ -10269,12 +10269,29 @@ bool createTextureImageVk(U32          width,
     return created;
 }
 
-bool uploadImageDataVk(VkImage     image,
-                       U32         width,
-                       U32         height,
-                       const void* data,
-                       U32         data_size_bytes,
-                       U32         mip_level)
+bool canGenerateMipChainBlitVk(VkFormat format)
+{
+    if (sPhysicalDevice == VK_NULL_HANDLE || format == VK_FORMAT_UNDEFINED)
+    {
+        return false;
+    }
+
+    VkFormatProperties fp = {};
+    vkGetPhysicalDeviceFormatProperties(sPhysicalDevice, format, &fp);
+    const VkFormatFeatureFlags required = VK_FORMAT_FEATURE_BLIT_SRC_BIT
+                                        | VK_FORMAT_FEATURE_BLIT_DST_BIT
+                                        | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+    return (fp.optimalTilingFeatures & required) == required;
+}
+
+static bool uploadImageDataVkImpl(VkImage     image,
+                                  U32         width,
+                                  U32         height,
+                                  const void* data,
+                                  U32         data_size_bytes,
+                                  U32         mip_level,
+                                  U32         generate_mip_count,
+                                  VkFormat    generate_mip_format)
 {
     if (image == VK_NULL_HANDLE || data == nullptr || data_size_bytes == 0)
     {
@@ -10282,6 +10299,12 @@ bool uploadImageDataVk(VkImage     image,
     }
     if (sDevice == VK_NULL_HANDLE || sAllocator == VK_NULL_HANDLE ||
         sCommandPool == VK_NULL_HANDLE || sGraphicsQueue == VK_NULL_HANDLE)
+    {
+        return false;
+    }
+    const bool generate_mip_chain = generate_mip_count > 1;
+    if (generate_mip_chain
+        && (mip_level != 0 || !canGenerateMipChainBlitVk(generate_mip_format)))
     {
         return false;
     }
@@ -10362,6 +10385,7 @@ bool uploadImageDataVk(VkImage     image,
                                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
     }
 
+    if (!generate_mip_chain)
     {
         VkImageMemoryBarrier b = {};
         b.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -10382,11 +10406,103 @@ bool uploadImageDataVk(VkImage     image,
                              VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &b);
     }
+    else
+    {
+        auto mip_barrier = [&](U32 level, VkImageLayout old_layout, VkImageLayout new_layout,
+                               VkAccessFlags src_access, VkAccessFlags dst_access,
+                               VkPipelineStageFlags src_stage, VkPipelineStageFlags dst_stage)
+        {
+            VkImageMemoryBarrier b = {};
+            b.sType                           = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+            b.srcAccessMask                   = src_access;
+            b.dstAccessMask                   = dst_access;
+            b.oldLayout                       = old_layout;
+            b.newLayout                       = new_layout;
+            b.srcQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            b.dstQueueFamilyIndex             = VK_QUEUE_FAMILY_IGNORED;
+            b.image                           = image;
+            b.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            b.subresourceRange.baseMipLevel   = level;
+            b.subresourceRange.levelCount     = 1;
+            b.subresourceRange.baseArrayLayer = 0;
+            b.subresourceRange.layerCount     = 1;
+            vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &b);
+        };
+
+        S32 mip_w = (S32)width;
+        S32 mip_h = (S32)height;
+        for (U32 i = 1; i < generate_mip_count; ++i)
+        {
+            const S32 dst_w = (mip_w > 1) ? (mip_w / 2) : 1;
+            const S32 dst_h = (mip_h > 1) ? (mip_h / 2) : 1;
+
+            mip_barrier(i - 1,
+                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                        VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT,
+                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+            mip_barrier(i,
+                        VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                        0, VK_ACCESS_TRANSFER_WRITE_BIT,
+                        VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+            VkImageBlit blit = {};
+            blit.srcSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.srcSubresource.mipLevel       = i - 1;
+            blit.srcSubresource.baseArrayLayer = 0;
+            blit.srcSubresource.layerCount     = 1;
+            blit.srcOffsets[1]                 = { mip_w, mip_h, 1 };
+            blit.dstSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+            blit.dstSubresource.mipLevel       = i;
+            blit.dstSubresource.baseArrayLayer = 0;
+            blit.dstSubresource.layerCount     = 1;
+            blit.dstOffsets[1]                 = { dst_w, dst_h, 1 };
+            vkCmdBlitImage(cmd,
+                           image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           1, &blit, VK_FILTER_LINEAR);
+
+            mip_barrier(i - 1,
+                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                        VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_SHADER_READ_BIT,
+                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+            mip_w = dst_w;
+            mip_h = dst_h;
+        }
+
+        mip_barrier(generate_mip_count - 1,
+                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                    VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT,
+                    VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    }
 
     vkEndCommandBuffer(cmd);
 
     return submitOneShotVk(cmd, staging_buffer, staging_allocation,
-                           "image-upload-2d", data_size_bytes);
+                           generate_mip_chain ? "image-upload-mips-2d" : "image-upload-2d",
+                           data_size_bytes);
+}
+
+bool uploadImageDataVk(VkImage     image,
+                       U32         width,
+                       U32         height,
+                       const void* data,
+                       U32         data_size_bytes,
+                       U32         mip_level)
+{
+    return uploadImageDataVkImpl(image, width, height, data, data_size_bytes,
+                                 mip_level, 1, VK_FORMAT_UNDEFINED);
+}
+
+bool uploadImageDataAndGenerateMipChainVk(VkImage     image,
+                                          U32         width,
+                                          U32         height,
+                                          const void* data,
+                                          U32         data_size_bytes,
+                                          U32         mip_count,
+                                          VkFormat    format)
+{
+    return uploadImageDataVkImpl(image, width, height, data, data_size_bytes,
+                                 0, mip_count, format);
 }
 
 bool generateMipChainBlitVk(VkImage image, U32 base_w, U32 base_h, U32 mip_count, VkFormat format)
@@ -10400,9 +10516,7 @@ bool generateMipChainBlitVk(VkImage image, U32 base_w, U32 base_h, U32 mip_count
         return false;
     }
 
-    VkFormatProperties fp = {};
-    vkGetPhysicalDeviceFormatProperties(sPhysicalDevice, format, &fp);
-    if (!(fp.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT))
+    if (!canGenerateMipChainBlitVk(format))
     {
         return false;
     }
@@ -10709,9 +10823,7 @@ bool generateMipChainInFrameVk(VkImage        image,
         return false;
     }
 
-    VkFormatProperties fp = {};
-    vkGetPhysicalDeviceFormatProperties(sPhysicalDevice, format, &fp);
-    if (!(fp.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT))
+    if (!canGenerateMipChainBlitVk(format))
     {
         return false;
     }

--- a/indra/llrender/llvkloader.cpp
+++ b/indra/llrender/llvkloader.cpp
@@ -911,6 +911,11 @@ namespace
         U32             slot              = 0;
         PESyncPoint*    sync              = nullptr;
         uint64_t        timeline_value    = 0;   // この submit が signal する GPU タイムライン値
+#if LL_DARWIN
+        // Host-side attribution for the MoltenVK device-lost submit trace.
+        const char*     oneshot_source    = nullptr;
+        U64             oneshot_staging_bytes = 0;
+#endif
     };
 
     std::atomic<U32>        sPESlotState[FRAMES_IN_FLIGHT] = {};
@@ -942,6 +947,7 @@ namespace
     struct PEDarwinSubmitTrace
     {
         const char* type             = "unknown";
+        const char* oneshot_source   = "-";
         VkResult    result           = VK_ERROR_UNKNOWN;
         U64         command_buffer   = 0;
         U64         fence            = 0;
@@ -951,6 +957,7 @@ namespace
         U32         slot             = 0;
         U32         present_count    = 0;
         bool        wait_idle        = false;
+        U64         oneshot_staging_bytes = 0;
     };
 
     std::mutex                      sPEDarwinSubmitTraceMutex;
@@ -986,6 +993,7 @@ namespace
     {
         PEDarwinSubmitTrace trace;
         trace.type             = peJobType(job);
+        trace.oneshot_source   = job.oneshot_source ? job.oneshot_source : "-";
         trace.result           = result;
         trace.command_buffer   = (U64)(uintptr_t)job.cmd;
         trace.fence            = (U64)(uintptr_t)job.fence;
@@ -995,6 +1003,7 @@ namespace
         trace.slot             = job.slot;
         trace.present_count    = (U32)job.presents.size();
         trace.wait_idle        = job.wait_idle;
+        trace.oneshot_staging_bytes = job.oneshot_staging_bytes;
 
         std::lock_guard<std::mutex> lk(sPEDarwinSubmitTraceMutex);
         constexpr size_t history_capacity = 16;
@@ -1023,6 +1032,8 @@ namespace
         for (const PEDarwinSubmitTrace& trace : history)
         {
             LL_WARNS("Vulkan") << "VKC-DEVLOST submit[" << index++ << "]: type=" << trace.type
+                               << " oneshot_source=" << trace.oneshot_source
+                               << " staging_bytes=" << trace.oneshot_staging_bytes
                                << " result=" << (S32)trace.result
                                << " timeline=" << trace.timeline_value
                                << " slot=" << trace.slot
@@ -4965,9 +4976,11 @@ static void           tickDeferredImageFreeQueue();
 static void           tickDeferredObjectFreeQueue();
 void                  tickMegaFreeQueue();
 static void           tickDeferredQueryReleaseQueue();
-static bool           submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation);
+static bool           submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation,
+                                      const char* source, U64 staging_bytes = 0);
 static bool           submitOneShotVkFromPool(VkCommandBuffer cmd, VkCommandPool pool, VkBuffer staging_buffer,
-                                              VmaAllocation staging_allocation, U32 staging_bytes);
+                                              VmaAllocation staging_allocation, U32 staging_bytes,
+                                              const char* source, U64 diagnostic_staging_bytes);
 static void           tickOneShotFreeQueue();
 static void           shutdownSurface();
 static bool           initSharedDynamicPersistentUBOs();
@@ -9052,9 +9065,11 @@ void tickDeferredBufferFreeQueue()
     purgePerDrawDeadHandles({}, dead_bufs);
 }
 
-bool submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation)
+bool submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation,
+                     const char* source, U64 staging_bytes)
 {
-    return submitOneShotVkFromPool(cmd, sCommandPool, staging_buffer, staging_allocation, 0);
+    return submitOneShotVkFromPool(cmd, sCommandPool, staging_buffer, staging_allocation, 0,
+                                   source, staging_bytes);
 }
 
 static VkCommandBuffer beginOneShotCommandBufferVk()
@@ -9077,8 +9092,13 @@ static VkCommandBuffer beginOneShotCommandBufferVk()
 }
 
 bool submitOneShotVkFromPool(VkCommandBuffer cmd, VkCommandPool pool, VkBuffer staging_buffer,
-                             VmaAllocation staging_allocation, U32 staging_bytes)
+                             VmaAllocation staging_allocation, U32 staging_bytes,
+                             const char* source, U64 diagnostic_staging_bytes)
 {
+#if !LL_DARWIN
+    (void)source;
+    (void)diagnostic_staging_bytes;
+#endif
     tickOneShotFreeQueue();
     const U64 byte_cap = 256ull << 20;
     for (U32 i = 0; i < 20; ++i)
@@ -9135,6 +9155,10 @@ bool submitOneShotVkFromPool(VkCommandBuffer cmd, VkCommandPool pool, VkBuffer s
         PEJob job;
         job.cmd        = cmd;
         job.is_oneshot = true;
+#if LL_DARWIN
+        job.oneshot_source        = source;
+        job.oneshot_staging_bytes = diagnostic_staging_bytes;
+#endif
         oneshot_value  = peEnqueue(std::move(job));
     }
 
@@ -10361,7 +10385,8 @@ bool uploadImageDataVk(VkImage     image,
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, staging_buffer, staging_allocation);
+    return submitOneShotVk(cmd, staging_buffer, staging_allocation,
+                           "image-upload-2d", data_size_bytes);
 }
 
 bool generateMipChainBlitVk(VkImage image, U32 base_w, U32 base_h, U32 mip_count, VkFormat format)
@@ -10463,7 +10488,7 @@ bool generateMipChainBlitVk(VkImage image, U32 base_w, U32 base_h, U32 mip_count
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE);
+    return submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE, "image-mip-blit");
 }
 
 bool downscaleImageVk(VkImage      src_image,
@@ -10568,7 +10593,7 @@ bool downscaleImageVk(VkImage      src_image,
 
     vkEndCommandBuffer(cmd);
 
-    if (!submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE))
+    if (!submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE, "image-downscale"))
     {
         destroyImageVk(new_image, new_view, new_alloc);
         return false;
@@ -10664,7 +10689,7 @@ bool blitCubeArrayVk(VkImage       src,
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE);
+    return submitOneShotVk(cmd, VK_NULL_HANDLE, VK_NULL_HANDLE, "cube-array-blit");
 }
 
 bool generateMipChainInFrameVk(VkImage        image,
@@ -10973,7 +10998,8 @@ bool uploadImageData3DVk(VkImage     image,
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, staging_buffer, staging_allocation);
+    return submitOneShotVk(cmd, staging_buffer, staging_allocation,
+                           "image-upload-3d", data_size_bytes);
 }
 
 bool uploadImageSubregionVk(VkImage     image,
@@ -11117,7 +11143,8 @@ bool uploadImageSubregionVk(VkImage     image,
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, staging_buffer, staging_allocation);
+    return submitOneShotVk(cmd, staging_buffer, staging_allocation,
+                           "image-subregion-upload", staging_size);
 }
 
 bool createCubeImageVk(U32          resolution,
@@ -11333,7 +11360,8 @@ bool uploadCubeImageDataVk(VkImage           image,
 
     vkEndCommandBuffer(cmd);
 
-    return submitOneShotVk(cmd, staging_buffer, staging_allocation);
+    return submitOneShotVk(cmd, staging_buffer, staging_allocation,
+                           "cube-upload", total_size);
 }
 
 bool createCubeArrayImageVk(U32          resolution,
@@ -12633,7 +12661,8 @@ void transitionImageLayoutVk(VkImage              image,
                              VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &oneshot_barrier);
         vkEndCommandBuffer(oneshot_cmd);
-        submitOneShotVk(oneshot_cmd, VK_NULL_HANDLE, VK_NULL_HANDLE);
+        submitOneShotVk(oneshot_cmd, VK_NULL_HANDLE, VK_NULL_HANDLE,
+                         "image-layout-transition");
         return;
     }
 

--- a/indra/llrender/llvkloader.cpp
+++ b/indra/llrender/llvkloader.cpp
@@ -751,7 +751,7 @@ namespace
         VkCommandPool   pool       = VK_NULL_HANDLE;
         VkBuffer        buffer     = VK_NULL_HANDLE;
         VmaAllocation   allocation = VK_NULL_HANDLE;
-        U32             staging_bytes = 0;
+        U64             staging_bytes = 0;
         uint64_t        timeline_value = 0;   // この submit の GPU 完了 = timeline >= この値
     };
     std::vector<PendingOneShotFree> sPendingOneShotFrees;
@@ -4979,7 +4979,7 @@ static void           tickDeferredQueryReleaseQueue();
 static bool           submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation,
                                       const char* source, U64 staging_bytes = 0);
 static bool           submitOneShotVkFromPool(VkCommandBuffer cmd, VkCommandPool pool, VkBuffer staging_buffer,
-                                              VmaAllocation staging_allocation, U32 staging_bytes,
+                                              VmaAllocation staging_allocation, U64 staging_bytes,
                                               const char* source, U64 diagnostic_staging_bytes);
 static void           tickOneShotFreeQueue();
 static void           shutdownSurface();
@@ -9068,7 +9068,7 @@ void tickDeferredBufferFreeQueue()
 bool submitOneShotVk(VkCommandBuffer cmd, VkBuffer staging_buffer, VmaAllocation staging_allocation,
                      const char* source, U64 staging_bytes)
 {
-    return submitOneShotVkFromPool(cmd, sCommandPool, staging_buffer, staging_allocation, 0,
+    return submitOneShotVkFromPool(cmd, sCommandPool, staging_buffer, staging_allocation, staging_bytes,
                                    source, staging_bytes);
 }
 
@@ -9092,7 +9092,7 @@ static VkCommandBuffer beginOneShotCommandBufferVk()
 }
 
 bool submitOneShotVkFromPool(VkCommandBuffer cmd, VkCommandPool pool, VkBuffer staging_buffer,
-                             VmaAllocation staging_allocation, U32 staging_bytes,
+                             VmaAllocation staging_allocation, U64 staging_bytes,
                              const char* source, U64 diagnostic_staging_bytes)
 {
 #if !LL_DARWIN

--- a/indra/llrender/llvkloader.cpp
+++ b/indra/llrender/llvkloader.cpp
@@ -935,6 +935,108 @@ namespace
     void                    recordAbandonedTimelineValue(uint64_t v);   // 定義は gpuTimelineValue 後
     std::atomic<bool>       sVkDeviceLost{false};
 
+#if LL_DARWIN
+    // MoltenVK does not expose device-fault or checkpoint extensions on the
+    // current Apple GPU path. Keep a small host-side submit history so a
+    // VK_ERROR_DEVICE_LOST report identifies the work that was in flight.
+    struct PEDarwinSubmitTrace
+    {
+        const char* type             = "unknown";
+        VkResult    result           = VK_ERROR_UNKNOWN;
+        U64         command_buffer   = 0;
+        U64         fence            = 0;
+        U64         wait_semaphore   = 0;
+        U64         signal_semaphore = 0;
+        uint64_t    timeline_value   = 0;
+        U32         slot             = 0;
+        U32         present_count    = 0;
+        bool        wait_idle        = false;
+    };
+
+    std::mutex                      sPEDarwinSubmitTraceMutex;
+    std::deque<PEDarwinSubmitTrace> sPEDarwinSubmitTrace;
+    std::atomic<bool>               sPEDarwinDeviceLostTraceDumped{false};
+
+    const char* peJobType(const PEJob& job)
+    {
+        if (job.is_frame)
+        {
+            return "frame";
+        }
+        if (job.is_async_producer)
+        {
+            return "async-producer";
+        }
+        if (job.is_oneshot)
+        {
+            return "one-shot";
+        }
+        if (job.sync != nullptr)
+        {
+            return "blocking";
+        }
+        if (!job.presents.empty())
+        {
+            return "aux-present";
+        }
+        return "producer";
+    }
+
+    void recordDarwinSubmitTrace(const PEJob& job, VkResult result)
+    {
+        PEDarwinSubmitTrace trace;
+        trace.type             = peJobType(job);
+        trace.result           = result;
+        trace.command_buffer   = (U64)(uintptr_t)job.cmd;
+        trace.fence            = (U64)(uintptr_t)job.fence;
+        trace.wait_semaphore   = (U64)(uintptr_t)job.wait_semaphore;
+        trace.signal_semaphore = (U64)(uintptr_t)job.signal_semaphore;
+        trace.timeline_value   = job.timeline_value;
+        trace.slot             = job.slot;
+        trace.present_count    = (U32)job.presents.size();
+        trace.wait_idle        = job.wait_idle;
+
+        std::lock_guard<std::mutex> lk(sPEDarwinSubmitTraceMutex);
+        constexpr size_t history_capacity = 16;
+        if (sPEDarwinSubmitTrace.size() == history_capacity)
+        {
+            sPEDarwinSubmitTrace.pop_front();
+        }
+        sPEDarwinSubmitTrace.push_back(trace);
+    }
+
+    void dumpDarwinSubmitTraceOnDeviceLost(const char* trigger)
+    {
+        if (sPEDarwinDeviceLostTraceDumped.exchange(true))
+        {
+            return;
+        }
+
+        std::deque<PEDarwinSubmitTrace> history;
+        {
+            std::lock_guard<std::mutex> lk(sPEDarwinSubmitTraceMutex);
+            history = sPEDarwinSubmitTrace;
+        }
+        LL_WARNS("Vulkan") << "VKC-DEVLOST trigger=" << trigger
+                           << " submit_history=" << history.size() << LL_ENDL;
+        U32 index = 0;
+        for (const PEDarwinSubmitTrace& trace : history)
+        {
+            LL_WARNS("Vulkan") << "VKC-DEVLOST submit[" << index++ << "]: type=" << trace.type
+                               << " result=" << (S32)trace.result
+                               << " timeline=" << trace.timeline_value
+                               << " slot=" << trace.slot
+                               << " presents=" << trace.present_count
+                               << " wait_idle=" << (trace.wait_idle ? 1 : 0)
+                               << " cmd=0x" << std::hex << trace.command_buffer
+                               << " fence=0x" << trace.fence
+                               << " wait_sem=0x" << trace.wait_semaphore
+                               << " signal_sem=0x" << trace.signal_semaphore
+                               << std::dec << LL_ENDL;
+        }
+    }
+#endif
+
     std::atomic<U64>        sPESubmitUs{0};
     std::atomic<U64>        sPEPresentUs{0};
     std::atomic<U64>        sPEPrsMainUs{0};
@@ -1089,6 +1191,9 @@ namespace
         }
         const auto t0 = std::chrono::steady_clock::now();
         VkResult sr = vkQueueSubmit(sGraphicsQueue, 1, &si, job.fence);
+#if LL_DARWIN
+        recordDarwinSubmitTrace(job, sr);
+#endif
         if (sr == VK_SUCCESS && job.wait_idle)
         {
             vkQueueWaitIdle(sGraphicsQueue);
@@ -1127,6 +1232,9 @@ namespace
                     dumpCheckpointsOnDeviceLost();
                     dumpDeviceFaultOnDeviceLost();
                 }
+#if LL_DARWIN
+                dumpDarwinSubmitTraceOnDeviceLost("queue-submit");
+#endif
                 sVkDeviceLost.store(true, std::memory_order_release);
             }
             LL_WARNS("Vulkan") << "PresentEngine submit failed sr=" << (S32)sr
@@ -1201,6 +1309,9 @@ namespace
                 }
                 else if (pr == VK_ERROR_DEVICE_LOST)
                 {
+#if LL_DARWIN
+                    dumpDarwinSubmitTraceOnDeviceLost("queue-present");
+#endif
                     sVkDeviceLost.store(true, std::memory_order_release);
                 }
                 else if (sPresentWaitEnabled && pr == VK_SUCCESS && this_present_id != 0)
@@ -1212,6 +1323,9 @@ namespace
                             std::chrono::steady_clock::now() - w0).count();
                     if (wr == VK_ERROR_DEVICE_LOST)
                     {
+#if LL_DARWIN
+                        dumpDarwinSubmitTraceOnDeviceLost("wait-for-present");
+#endif
                         sVkDeviceLost.store(true, std::memory_order_release);
                     }
                 }

--- a/indra/llrender/llvkloader.h
+++ b/indra/llrender/llvkloader.h
@@ -1245,6 +1245,16 @@ namespace LLVKLoader
                            U32         data_size_bytes,
                            U32         mip_level = 0);
 
+    bool canGenerateMipChainBlitVk(VkFormat format);
+
+    bool uploadImageDataAndGenerateMipChainVk(VkImage     image,
+                                              U32         width,
+                                              U32         height,
+                                              const void* data,
+                                              U32         data_size_bytes,
+                                              U32         mip_count,
+                                              VkFormat    format);
+
     bool generateMipChainBlitVk(VkImage image, U32 base_w, U32 base_h, U32 mip_count, VkFormat format);
 
     void setVkGeoWorkerStopHook(void (*fn)());

--- a/indra/llwindow/llwindowmacosx-objc.mm
+++ b/indra/llwindow/llwindowmacosx-objc.mm
@@ -33,6 +33,8 @@
 #include "llwindowmacosx-objc.h"
 #include "llappdelegate-objc.h"
 
+extern bool gHiDPISupport;
+
 /*
  * These functions are broken out into a separate file because the
  * objective-C typedef for 'BOOL' conflicts with the one in
@@ -242,15 +244,11 @@ MetalLayerRef createMetalLayerForWindow(NSWindowRef window)
     }
 
     CAMetalLayer *layer = [CAMetalLayer layer];
-    layer.contentsScale = [ns_window backingScaleFactor];
-    layer.frame = [view bounds];
     layer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
 
     [view setWantsLayer:YES];
     [[view layer] addSublayer:layer];
-
-    NSSize backing = [view convertSizeToBacking:[view bounds].size];
-    layer.drawableSize = CGSizeMake(backing.width, backing.height);
+    updateMetalLayerDrawableSize((MetalLayerRef)layer, window);
 
     return (MetalLayerRef)layer;
 }
@@ -264,10 +262,14 @@ void updateMetalLayerDrawableSize(MetalLayerRef layer_ref, NSWindowRef window)
     {
         return;
     }
-    layer.contentsScale = [ns_window backingScaleFactor];
+    const NSSize view_size = [view bounds].size;
+    // When RenderHiDPI is disabled, keep Metal in the legacy OpenGL 1x
+    // coordinate domain. Otherwise the swapchain is Retina-sized while the
+    // Viewer UI and mouse coordinates remain 1x-sized.
+    const NSSize drawable_size = gHiDPISupport ? [view convertSizeToBacking:view_size] : view_size;
+    layer.contentsScale = gHiDPISupport ? [ns_window backingScaleFactor] : 1.0;
     layer.frame = [view bounds];
-    NSSize backing = [view convertSizeToBacking:[view bounds].size];
-    layer.drawableSize = CGSizeMake(backing.width, backing.height);
+    layer.drawableSize = CGSizeMake(drawable_size.width, drawable_size.height);
 }
 
 GLViewRef createOpenGLView(NSWindowRef window, unsigned int samples, bool vsync)


### PR DESCRIPTION
## 概要

- Retina 設定時にログイン画面が 1/4 サイズとなる問題を修正
- Darwin/macOS 限定で device lost 時の直近 submit 履歴、one-shot 発生元、staging byte 数を記録
- auto-generated mip の upload と mip chain を単一 one-shot submit に統合
- mip blit の format feature 判定を `BLIT_SRC` / `BLIT_DST` / linear filter の全条件へ強化し、非対応 format は 1 mip へ安全に制限
- one-shot staging allocation の byte 会計を修正し、backpressure を実効化
- bindless descriptor を in-place 更新せず、新 slot の取得と旧 slot の GPU 完了後解放へ変更
- 実装・実機検証・受入条件を日本語の macOS 検証ガイドへ記録

## 診断と修正

再現時の `VKC-DEVLOST` は通常 frame submit / swapchain ではなく one-shot submit で `VK_ERROR_DEVICE_LOST` を検出しました。直近の再現では `image-upload-2d`（4,096 bytes）と `image-mip-blit` が交互に続いていました。

最後の upload submit 自体を直接原因とは断定していません。ただし、mip blit の Vulkan format feature 条件不足、upload と mip chain が別 submit である構造、bindless descriptor の pending command buffer に対する in-place 更新、staging backpressure 不全は、source 上で是正すべき問題として修正しました。

## 検証

- macOS arm64 の開発 app build 成功
- shader cache と pipeline cache を削除後、`AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` で起動
- Apple M2 Pro / Vulkan presentation surface / Login Screen を確認
- 約 1,069 秒（17分49秒）実行し、`device lost` / `VK_ERROR_DEVICE_LOST` / `VUID` / ログレベル ERROR は検出なし
- `#VkPerf#` の `shsite` に `mv.am=...` を確認。同一観測行で `rest.am` / `fb.*` はなく、alpha-mask の multiview 経路を維持
- 半透明オブジェクトの dither shadow は目視で OK。解消元は base `feature/ayastorm-r42-phase2` の `54e8559fba`（透明 shadow flicker 修正）であり、本 PR はその解消済み base を親としている
- 終盤の `FRAMETIME ms:` は p95 約 190--290 ms、p99 約 262--308 ms。安定性通過と性能受入は別管理
- HTTP 403 等の asset/network 系 WARNING は継続

## 残る受入条件

初回 run は実用検証を進める根拠ですが、GPU/driver 問題の恒久解決を証明するものではありません。最終受入は以下を満たしてからとします。

1. cache-cold run を少なくとも 3 回実施
2. 各 run を 10--30 分以上継続し、login、teleport、texture streaming、カメラ回転を含める
3. 各 run の log 全体から `device lost` / `VK_ERROR_DEVICE_LOST` / `VUID` / ERROR、`#VkPerf#`、`FRAMETIME ms:`、`recreateSwapchain` を記録
4. 共有 Vulkan TU の変更は、Linux / Windows 担当者が各自の build と Vulkan run で確認

## 範囲

- Darwin 限定の device-lost 診断は macOS のみです。Linux 向け同等診断は本 PR に含めません。
- 半透明 dither shadow の解消は最新 `feature/ayastorm-r42-phase2` 側の変更です。本 PR はその結果を確認・記録するだけで、半透明 shadow の追加修正は含めません。

## 主なコミット

- `e907a9f5f2` fix(Vulkan): combine texture upload and mip generation
- `2fdca3a929` fix(Vulkan): account one-shot staging allocations
- `b52ad0b416` fix(Vulkan): retire bindless descriptor slots safely
- `acbd4d88ae` docs(macOS): record device-lost repair validation
- `ece51583d0` docs(macOS): record dither shadow visual recovery
- `412b5519c5` docs(macOS): attribute dither shadow recovery to phase2