### PR TITLE
feat(macOS): add drawable display timing diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ indra/newview/exoflickrkeys.h
 indra/newview/fsdiscordkey.h
 indra/tools/vstool/obj/*/*.cache
 my_autobuild.xml
+my_autobuild-*.xml
 .vscode
 .vs
 *.srctrlbm

--- a/docs/build/building_ayastorm_macos.md
+++ b/docs/build/building_ayastorm_macos.md
@@ -170,6 +170,9 @@ FMOD、Vulkan SDK などのローカル installable を `my_autobuild.xml` に�
 ```bash
 cd "$REPO"
 
+test -f "$BASE_AUTOBUILD_CONFIG"
+test "$DEV_BUILD_DIR" != "$RELEASE_BUILD_DIR"
+
 cp "$BASE_AUTOBUILD_CONFIG" "$DEV_AUTOBUILD_CONFIG"
 cp "$BASE_AUTOBUILD_CONFIG" "$RELEASE_AUTOBUILD_CONFIG"
 
@@ -221,6 +224,7 @@ export AUTOBUILD_VARIABLES_FILE="$FS_BUILD_VARIABLES"
 export AUTOBUILD_CONFIG_FILE="$DEV_AUTOBUILD_CONFIG"
 export CLANG_MODULE_CACHE_PATH="$DEV_BUILD_DIR/ModuleCache"
 
+test "$DEV_BUILD_DIR" = "$REPO/build-darwin-dev"
 rm -rf "$DEV_BUILD_DIR"
 
 autobuild configure -A 64 -c ReleaseFS_open -- \
@@ -300,6 +304,7 @@ export CLANG_MODULE_CACHE_PATH="$RELEASE_BUILD_DIR/ModuleCache"
 
 ```bash
 cd "$REPO"
+test "$RELEASE_BUILD_DIR" = "$REPO/build-darwin-release"
 rm -rf "$RELEASE_BUILD_DIR"
 ```
 

--- a/docs/build/building_ayastorm_macos.md
+++ b/docs/build/building_ayastorm_macos.md
@@ -1,11 +1,11 @@
 # AYAstorm Mac版ビルド手順
 
-更新日: 2026-07-25
+更新日: 2026-08-14
 
 この文書は macOS arm64 向けのビルド手順である。用途を混同しないこと。
 
 - **ローカル開発 app**: 「R42: ローカル arm64 / MoltenVK 開発 app」を使う。DMG は作らない。
-- **配布用 DMG**: 「環境変数」以降の配布手順を使う。
+- **通常版 / 配布用 DMG**: 「通常版 / 配布用 DMG」以降の配布手順を使う。
 - **MoltenVK の通常起動仕様・失敗ログ**:
   [`docs/specs/ayastorm-r42-macos-moltenvk-runtime-bootstrap.md`](../specs/ayastorm-r42-macos-moltenvk-runtime-bootstrap.md)
 - **R42 shadow multiview の実機検証**:
@@ -14,6 +14,23 @@
 出力例: `Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-80834.dmg`
 
 この文書は AYAstorm の macOS arm64 におけるローカル開発 app と配布用 DMG の手順を扱う。Firestorm 本体の一般的な macOS ビルド要件は `doc/building_macos.md` も参照してください。
+
+## 開発版と通常版の分離基準
+
+macOS 実装はビルド時の `PACKAGE` 値ではなく、実行中の executable path に
+`/build-darwin-` が含まれるかで開発版を判定する。従って、配布用に構成した app でも
+build tree 内から直接起動すれば開発版の可変データを使う。通常版の動作確認は、DMG を
+mount してその中の app を起動するか、`/Applications` など build tree 外へインストールした
+app で行う。
+
+| 用途 | build tree | Configure / target | 起動場所 | Application Support | cache root |
+| --- | --- | --- | --- | --- | --- |
+| ローカル開発 | `build-darwin-dev` | `PACKAGE=OFF` / `ayastorm-bin` | build tree 内 | `~/Library/Application Support/AYAstorm-dev/` | `~/Library/Caches/AYAstorm-devOS_x64/` |
+| 通常版 / 配布 | `build-darwin-release` | `PACKAGE=ON` / `llpackage` | DMG 内またはインストール後 | `~/Library/Application Support/AYAstorm/` | `~/Library/Caches/AYAstormOS_x64/` |
+
+開発用と配布用で同じ CMake cache、package staging、DerivedData を共有しない。以下の手順では
+Autobuild 設定と build tree を用途別に分ける。なお `build-darwin-release` 内の staging app を
+直接起動した場合は、表の通常版ではなく開発版として動作する。
 
 ## 前提
 
@@ -35,6 +52,11 @@ export FS_BUILD_VARIABLES="$WORK/fs-build-variables/variables"
 export FMOD_REPO="$WORK/3p-fmodstudio"
 export TARGET_REF="feature/macos-arm64-build-on-latest"
 export AYA_BUILD_ID="80834"
+export BASE_AUTOBUILD_CONFIG="$REPO/my_autobuild.xml"
+export DEV_AUTOBUILD_CONFIG="$REPO/my_autobuild-dev.xml"
+export RELEASE_AUTOBUILD_CONFIG="$REPO/my_autobuild-release.xml"
+export DEV_BUILD_DIR="$REPO/build-darwin-dev"
+export RELEASE_BUILD_DIR="$REPO/build-darwin-release"
 ```
 
 `AYA_BUILD_ID` は Release ページの成果物名に含める autobuild build id です。Release 配布物では、git commit count ではなく CI / autobuild 側の build id を明示して揃えます。
@@ -137,13 +159,43 @@ AYAstorm Mac ビルド手順のデフォルトは Dullahan audio callback 経路
 -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=FALSE
 ```
 
-configure 後は `build-darwin-universal/CMakeCache.txt` で `LL_DULLAHAN_AUDIO_CALLBACK:BOOL=` の値を確認してください。
+configure 後は `$DEV_BUILD_DIR/CMakeCache.txt` と `$RELEASE_BUILD_DIR/CMakeCache.txt` で、
+用途ごとの `LL_DULLAHAN_AUDIO_CALLBACK:BOOL=` の値を確認してください。
+
+## Autobuild 設定と build tree の分離
+
+FMOD、Vulkan SDK などのローカル installable を `my_autobuild.xml` にすべて登録してから、
+開発用と配布用の設定を作る。`build_directory` は Autobuild 設定ファイルからの相対 path である。
+
+```bash
+cd "$REPO"
+
+cp "$BASE_AUTOBUILD_CONFIG" "$DEV_AUTOBUILD_CONFIG"
+cp "$BASE_AUTOBUILD_CONFIG" "$RELEASE_AUTOBUILD_CONFIG"
+
+autobuild edit platform --config-file "$DEV_AUTOBUILD_CONFIG" \
+  name=darwin64 build_directory=build-darwin-dev
+autobuild edit platform --config-file "$RELEASE_AUTOBUILD_CONFIG" \
+  name=darwin64 build_directory=build-darwin-release
+
+autobuild print --config-file "$DEV_AUTOBUILD_CONFIG" --json | \
+  rg '"build_directory": "build-darwin-dev"'
+autobuild print --config-file "$RELEASE_AUTOBUILD_CONFIG" --json | \
+  rg '"build_directory": "build-darwin-release"'
+```
+
+3 ファイルはいずれもローカル専用で git 管理しない。installable の URL / hash を変更した場合は
+`my_autobuild.xml` を正本として更新し、用途別の 2 ファイルを再生成する。
 
 ## R42: ローカル arm64 / MoltenVK 開発 app（DMGなし）
 
 Apple Silicon 用のローカル app は配布用 DMG の手順と分ける。これは Vulkan / MoltenVK の実行確認用であり、Release artifact や notarization の手順ではない。
 
-開発 app は executable path に `/build-darwin-` を含むため、可変データを `~/Library/Application Support/AYAstorm-dev/`、対応する cache / temp を `AYAstorm-dev` 名で作る。build tree 外へコピーした app は `~/Library/Application Support/AYAstorm/` を使う。既存の `Firestorm` profile は移動・削除しない。
+開発 app は executable path に `/build-darwin-` を含むため、可変データを
+`~/Library/Application Support/AYAstorm-dev/`、cache を
+`~/Library/Caches/AYAstorm-devOS_x64/`、temp を system temp 配下の `AYAstorm-dev` に作る。
+build tree 外の app は通常版の `AYAstorm` / `AYAstormOS_x64` を使う。既存の `Firestorm` profile
+および通常版の `AYAstorm` profile / cache は移動・削除しない。
 
 ### 実行前提
 
@@ -158,7 +210,7 @@ Apple Silicon 用のローカル app は配布用 DMG の手順と分ける。�
 
 ### Configure / Build
 
-既存の `build-darwin-universal` が別のコミットやバージョンから作られた場合は再利用しない。以下では package target を作らず、`ayastorm-bin` だけを arm64 でビルドする。
+既存の `build-darwin-dev` が別のコミットやバージョンから作られた場合は再利用しない。以下では package target を作らず、`ayastorm-bin` だけを arm64 でビルドする。
 
 ```bash
 cd "$REPO"
@@ -166,10 +218,10 @@ source .venv/bin/activate
 
 export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
 export AUTOBUILD_VARIABLES_FILE="$FS_BUILD_VARIABLES"
-export AUTOBUILD_CONFIG_FILE="my_autobuild.xml"
-export CLANG_MODULE_CACHE_PATH="$REPO/build-darwin-universal/ModuleCache"
+export AUTOBUILD_CONFIG_FILE="$DEV_AUTOBUILD_CONFIG"
+export CLANG_MODULE_CACHE_PATH="$DEV_BUILD_DIR/ModuleCache"
 
-rm -rf build-darwin-universal
+rm -rf "$DEV_BUILD_DIR"
 
 autobuild configure -A 64 -c ReleaseFS_open -- \
   --fmodstudio \
@@ -181,28 +233,28 @@ autobuild configure -A 64 -c ReleaseFS_open -- \
   -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
 
 rg -n 'CMAKE_BUILD_TYPE|CMAKE_OSX_ARCHITECTURES|VIEWER_CHANNEL|PACKAGE|USE_FMODSTUDIO|LL_DULLAHAN_AUDIO_CALLBACK' \
-  build-darwin-universal/CMakeCache.txt
+  "$DEV_BUILD_DIR/CMakeCache.txt"
 
 DEVELOPER_DIR="$DEVELOPER_DIR" \
 AUTOBUILD_VARIABLES_FILE="$AUTOBUILD_VARIABLES_FILE" \
 AUTOBUILD_CONFIG_FILE="$AUTOBUILD_CONFIG_FILE" \
 CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_PATH" \
 xcodebuild \
-  -project build-darwin-universal/Firestorm.xcodeproj \
+  -project "$DEV_BUILD_DIR/Firestorm.xcodeproj" \
   -scheme ayastorm-bin \
   -configuration Release \
-  -derivedDataPath build-darwin-universal/DerivedData \
+  -derivedDataPath "$DEV_BUILD_DIR/DerivedData" \
   ARCHS=arm64 \
   ONLY_ACTIVE_ARCH=YES \
   build
 ```
 
-期待値は `CMAKE_OSX_ARCHITECTURES:STRING=arm64`、`PACKAGE:BOOL=OFF`、および `build-darwin-universal/newview/Release/AYAstorm.app` である。`llpackage` / DMG はこの手順の対象外とする。
+期待値は `CMAKE_OSX_ARCHITECTURES:STRING=arm64`、`PACKAGE:BOOL=OFF`、および `build-darwin-dev/newview/Release/AYAstorm.app` である。`llpackage` / DMG はこの手順の対象外とする。
 
 ### ローカル app の検証
 
 ```bash
-export APP="$REPO/build-darwin-universal/newview/Release/AYAstorm.app"
+export APP="$DEV_BUILD_DIR/newview/Release/AYAstorm.app"
 
 lipo -archs "$APP/Contents/MacOS/AYAstorm"
 codesign --verify --deep --strict --verbose=2 "$APP"
@@ -215,7 +267,22 @@ test -f "$APP/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 
 通常起動後は `~/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log` を確認する。`initialized device=...`、`Vulkan presentation surface initialized`、`Initializing Login Screen` がこの順で記録され、ログイン画面が全面に描画されることを確認する。詳細な合格条件と cache 復旧ログは [r42 MoltenVK 実行時ブートストラップ仕様](../specs/ayastorm-r42-macos-moltenvk-runtime-bootstrap.md) に従う。
 
-## 環境変数
+```bash
+export DEV_LOG="$HOME/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log"
+
+test -d "$HOME/Library/Caches/AYAstorm-devOS_x64"
+rg 'setSoundCacheDir.*AYAstorm-devOS_x64' "$DEV_LOG"
+```
+
+ここで通常版の `~/Library/Application Support/AYAstorm/` や
+`~/Library/Caches/AYAstormOS_x64/` に新しいログ・cache が作られた場合は、開発版の分離確認を
+合格にしない。
+
+## 通常版 / 配布用 DMG
+
+ここからは開発用 build tree を使わず、配布専用の `build-darwin-release` を構成する。
+
+### 環境変数
 
 ```bash
 cd "$REPO"
@@ -223,17 +290,17 @@ cd "$REPO"
 export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer"
 export AUTOBUILD_BUILD_ID="$AYA_BUILD_ID"
 export AUTOBUILD_VARIABLES_FILE="$FS_BUILD_VARIABLES"
-export AUTOBUILD_CONFIG_FILE="my_autobuild.xml"
-export CLANG_MODULE_CACHE_PATH="$REPO/build-darwin-universal/ModuleCache"
+export AUTOBUILD_CONFIG_FILE="$RELEASE_AUTOBUILD_CONFIG"
+export CLANG_MODULE_CACHE_PATH="$RELEASE_BUILD_DIR/ModuleCache"
 ```
 
-## Configure
+### Configure
 
 クリーンに作り直す場合:
 
 ```bash
 cd "$REPO"
-rm -rf build-darwin-universal
+rm -rf "$RELEASE_BUILD_DIR"
 ```
 
 configure:
@@ -244,6 +311,7 @@ autobuild configure -A 64 -c ReleaseFS_open -- \
   --openal \
   --package \
   --chan AYAstorm-release \
+  -DCMAKE_OSX_ARCHITECTURES:STRING=arm64 \
   -DLL_TESTS:BOOL=FALSE \
   -DLL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
 ```
@@ -252,7 +320,7 @@ configure 後に主要な設定を確認します。
 
 ```bash
 rg -n 'CMAKE_BUILD_TYPE|ADDRESS_SIZE|CMAKE_OSX_ARCHITECTURES|VIEWER_CHANNEL|USE_FMODSTUDIO|USE_OPENAL|OPENSIM|PACKAGE|VIEWER_BINARY_NAME|LL_DULLAHAN_AUDIO_CALLBACK' \
-  build-darwin-universal/CMakeCache.txt
+  "$RELEASE_BUILD_DIR/CMakeCache.txt"
 ```
 
 期待値の例:
@@ -260,7 +328,7 @@ rg -n 'CMAKE_BUILD_TYPE|ADDRESS_SIZE|CMAKE_OSX_ARCHITECTURES|VIEWER_CHANNEL|USE_
 ```text
 ADDRESS_SIZE:STRING=64
 CMAKE_BUILD_TYPE:STRING=Release
-CMAKE_OSX_ARCHITECTURES:STRING=arm64;x86_64
+CMAKE_OSX_ARCHITECTURES:STRING=arm64
 OPENSIM:BOOL=ON
 PACKAGE:BOOL=ON
 USE_FMODSTUDIO:BOOL=ON
@@ -270,12 +338,12 @@ VIEWER_CHANNEL:STRING=Firestorm-AYAstorm-release
 LL_DULLAHAN_AUDIO_CALLBACK:BOOL=TRUE
 ```
 
-## Build / Package
+### Build / Package
 
 `llpackage` scheme を Release で実行します。
 
 ```bash
-cd "$REPO/build-darwin-universal"
+cd "$RELEASE_BUILD_DIR"
 
 DEVELOPER_DIR="$DEVELOPER_DIR" \
 AUTOBUILD_BUILD_ID="$AYA_BUILD_ID" \
@@ -287,18 +355,18 @@ xcodebuild \
   -project Firestorm.xcodeproj \
   -scheme llpackage \
   -configuration Release \
-  -derivedDataPath "$REPO/build-darwin-universal/DerivedData" \
+  -derivedDataPath "$RELEASE_BUILD_DIR/DerivedData" \
   CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_PATH" \
   build
 ```
 
 DMG 作成時に `hdiutil create` が `装置が構成されていません` で失敗する場合は、サンドボックスや権限の制約でディスクイメージ操作が止まっています。同じコマンドを通常の Terminal から実行してください。
 
-## 成果物
+### 成果物
 
 ```bash
-export DMG="$REPO/build-darwin-universal/newview/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-${AYA_BUILD_ID}.dmg"
-export APP="$REPO/build-darwin-universal/newview/Release/AYAstorm.app"
+export DMG="$RELEASE_BUILD_DIR/newview/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-${AYA_BUILD_ID}.dmg"
+export APP="$RELEASE_BUILD_DIR/newview/Release/AYAstorm.app"
 
 ls -lh "$DMG"
 ```
@@ -306,10 +374,10 @@ ls -lh "$DMG"
 成果物の例:
 
 ```text
-build-darwin-universal/newview/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-80834.dmg
+build-darwin-release/newview/Phoenix-FirestormOS-AYAstorm-release_arm64-7-2-4-80834.dmg
 ```
 
-## 検証
+### 検証
 
 ローカル app / DMG の基本検証:
 
@@ -321,6 +389,10 @@ lipo -archs "$APP/Contents/MacOS/AYAstorm"
 /usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist"
 ```
+
+ここで `$APP` は bundle 構成の静的検証にだけ使う。`$APP` の executable path は
+`/build-darwin-` を含むため、直接起動すると開発版 profile / cache を使う。通常版の runtime
+分離は、以下の DMG 内 app または `/Applications` へインストールした app で確認する。
 
 期待値:
 
@@ -371,7 +443,23 @@ find "$DMG_APP" \
 
 md5 "$DMG_MOUNT/.VolumeIcon.icns" \
   "$REPO/indra/newview/icons/ayastorm/ayastorm_icon.icns"
+```
 
+DMG 内の app を起動して通常版の runtime 分離を確認する。開発版のログや cache をこの確認の
+代用にしない。
+
+```bash
+"$DMG_APP/Contents/MacOS/AYAstorm"
+
+export NORMAL_LOG="$HOME/Library/Application Support/AYAstorm/logs/AYAstorm.log"
+test -f "$NORMAL_LOG"
+test -d "$HOME/Library/Caches/AYAstormOS_x64"
+rg 'setSoundCacheDir.*AYAstormOS_x64' "$NORMAL_LOG"
+```
+
+確認後、`hdiutil attach` の出力で得た device 名を指定して detach する。
+
+```bash
 hdiutil detach -force /dev/diskX
 ```
 

--- a/docs/guides/ayastorm-r42-display-completion-runtime-analysis.ja.md
+++ b/docs/guides/ayastorm-r42-display-completion-runtime-analysis.ja.md
@@ -1,0 +1,210 @@
+# AYAstorm R42 macOS: display timing 診断ログ分析
+
+## 結論
+
+2026-08-14 に arm64 開発版 AYAstorm で採取したログから、次のことを確認した。
+
+- 3D scene の更新を判定できた 159 区間では、Consumer と Present 成功は約 25.84 回/秒、
+  MoltenVK から回収した drawable 表示完了履歴も約 25.84 件/秒だった。
+- その表示完了履歴 20,764 件を現行コードの回収順で分類すると、`scene_id` が新しくなったものは
+  6,934 件（33.4%）、同じ scene は 13,830 件（66.6%）だった。fresh scene は約 8.63 件/秒である。
+- async Producer は約 8.56 回/秒であり、fresh scene の約 8.63 件/秒とほぼ一致した。
+  「Consumer / Present は進むが、3D scene はおおむね 3 回に 1 回しか新しくならない」ことを、
+  Present 受理回数だけでなく drawable 表示完了履歴まで対応付けて確認できた。
+- ただし、現在ログに出る `actual_display_fps`（159 区間平均 16.74）は、全表示完了件数の
+  cadence を正しく表す実装になっていない。この値を「ディスプレイ上の表示 FPS」として採用してはならない。
+- MoltenVK の履歴返却順と `actualPresentTime` の時系列順は同一とは限らず、現行コードは並べ替えずに
+  fresh / duplicate も判定している。従って 66.6% は繰り返し表示を示す強い証拠だが、時系列表示順での
+  最終値として確定するには診断コードの補強と再 run が必要である。
+- このログは、約 3 Consumer frame に 1 回しか新しい 3D scene が用意されない場所までを絞り込んだ。
+  Producer 内部のどの処理が約 3 frame を必要としているかは、まだ分離できていない。
+
+ここでいう表示完了は API 上の drawable 表示完了である。この文書は物理パネルの発光時刻を対象にしない。
+
+## 1. 対象と証拠範囲
+
+| 項目 | 確認結果 |
+| --- | --- |
+| 原本 | `~/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log` |
+| SHA-256 | `614afc31cb18365e713ddc53e5442ed8ac3d44fca5883b9c1f5f4cf3da1c0b01` |
+| 実行時刻 | 2026-08-14 04:28:08Z--04:42:33Z |
+| Viewer run time | 859.185 秒 |
+| 実行環境 | Apple M2 Pro / macOS 15.7.7 / MoltenVK 1.4.2 |
+| app 実行形式 | Mach-O 64-bit arm64（`file` と `lipo -archs` で再確認） |
+| 診断初期化 | `display_timing diagnostic requested=1 extension=1 enabled=1` |
+| 終了 | `status: stopped` |
+
+ログは開発版用の Application Support root `AYAstorm-dev` と cache root
+`AYAstorm-devOS_x64` を使用していた。cache root の末尾はこの run のログに記録された名称であり、
+実行バイナリ自体は上表のとおり arm64 である。
+
+診断を request するコード上の条件は `AYASTORM_VKC=1` かつ数値として
+`AYASTORM_PERF_LOG>0` である。ログは環境変数の文字列値そのものを残さないため、値 `5` はログ単独では
+再確認できない。一方、`requested=1 extension=1 enabled=1` と全区間の
+`display_timing_available=1` は、診断が有効だった直接の実行証拠である。
+
+この run では main / non-main display の別、表示モード、解像度を診断メタデータとして記録していない。
+したがって、本書はメイン画面指定の影響を比較する資料ではない。
+
+## 2. 何をどう集計したか
+
+約 5 秒ごとに同じ `endFrame` から出る次の 3 行を一つの同期区間として扱った。
+
+1. `uiscene consumer_fps=... producer_fps=...`
+2. `frames=... cadence ... present_ok_fps=...`
+3. `display_timing_available=... actual_display_count=... fresh_scene_display_count=...`
+
+対応付けられた区間は 169/169 だった。最初の 10 区間（04:28:18Z--04:29:03Z）は
+`fresh_scene_display_fps=n/a` で、3D scene 世代の比較開始前を含むため、主集計から除外した。
+主集計は、Producer と fresh scene の両方を観測できた残り 159 区間
+（04:29:08Z--04:42:27Z、換算 803.628 秒）である。
+
+cadence は、区間件数を合計し、同じ区間の `frames / consumer_fps` から求めた時間合計で割った。
+これにより、区間ごとの fps を単純平均した値と、完了件数全体から求めた値を混同しない。
+fresh / duplicate 比率も区間平均ではなく件数合計から求めた。
+
+## 3. 診断経路は正常に動作したか
+
+| 項目 | 全 169 区間の結果 | 判定 |
+| --- | ---: | --- |
+| `display_timing_available=1` | 169 / 169 | 利用可能 |
+| `display_timing_source=VK_GOOGLE_display_timing` | 169 / 169 | MoltenVK の表示履歴を使用 |
+| `actual_display_count` 合計 | 26,113 | 表示完了履歴を回収 |
+| `display_timing_history_query_errors` | 0 | 履歴照会エラーなし |
+| `timing_map_drop` | 0 | 対応表からの破棄なし |
+| `unknown_present_count` | 1 | 最初の区間だけ。主集計 159 区間では 0 |
+| `timing_map_pending` | 最大 5 | 少数の履歴が次区間へ遅れて到着 |
+| `present_wait_used` | 全区間 0 | `VK_KHR_present_wait` は未使用 |
+
+`fresh + duplicate + unknown = actual` は主集計の全 159 区間で成立した。
+従って、現行の回収順で得た 66.6% という duplicate 比率を mapping drop や unknown で説明することは
+できない。ただし、後述する callback 回収順と実時刻順の問題は別に残る。
+
+## 4. 3D scene を判定できた 159 区間
+
+### 4.1 同じ時間窓での件数と cadence
+
+| 観測点 | 合計件数 | 同期区間の件数 cadence | 意味 |
+| --- | ---: | ---: | --- |
+| Consumer frame | 20,765 | 25.839 回/秒 | UI と直近の front scene を合成する更新 |
+| Present 成功 | 20,765 相当 | 25.839 回/秒 | `vkQueuePresentKHR()` が成功 |
+| drawable 表示完了履歴 | 20,764 | 25.838 件/秒 | `actualPresentTime` を持つ履歴を回収 |
+| fresh scene 表示完了 | 6,934 | 8.628 件/秒 | 直前と異なる `scene_id` |
+| duplicate scene 表示完了 | 13,830 | 17.209 件/秒 | 直前と同じ `scene_id` |
+| async Producer | 6,877 | 8.557 回/秒 | front 候補となる scene の生成側 |
+
+Consumer frame と drawable 表示完了履歴は全区間合計で 1 件しか違わない。これに対し、現行の回収順では
+fresh scene は drawable 表示完了履歴の 33.4%、duplicate scene は 66.6% だった。従って、本 run の
+主な乖離が「Present した frame が完了履歴から大量に消えた」ためではないことは確かである。また、
+Producer cadence との一致から、同じ 3D scene の再利用が主因である可能性は高い。
+
+最後の 10 区間（約 50.276 秒）に限定しても、Consumer は 32.58 回/秒、drawable 表示完了履歴は
+32.56 件/秒、fresh scene は 10.84 件/秒、duplicate は 66.71% だった。run 全体の平均だけで生じた
+見かけの関係ではない。
+
+### 4.2 最後の同期区間の例
+
+04:42:27Z の同一 `endFrame` では、次の値が並んでいる。
+
+```text
+consumer_fps=31.4349 producer_fps=10.4783
+frames=159 ... present_ok_fps=31.4349
+actual_display_count=159 actual_display_fps=18.38
+fresh_scene_display_count=53 fresh_scene_display_fps=10.46
+duplicate_scene_count=106 unknown_present_count=0 duplicate_ratio=66.7%
+```
+
+同じ時間窓で Consumer 159 frame、表示完了履歴 159 件、回収順で fresh 53 件、duplicate 106 件である。
+この区間だけでも、3 件の完了履歴に対して fresh 判定がほぼ 1 件という関係を確認できる。
+
+## 5. `actual_display_fps` を表示 FPS として採用できない理由
+
+上の例では、約 5 秒の同じ時間窓に Consumer 159 frame と表示完了履歴 159 件があるにもかかわらず、
+ログの `actual_display_fps` は 18.38 になっている。これは単なる丸め差ではない。
+
+現在の集計実装（`indra/llrender/llvkpresent.cpp`）は、履歴 1 件ごとに
+`actual_display_count` を加算する一方、fps の分子
+`actual_interval_count` と分母 `actual_interval_ns` は、`actualPresentTime` がそれまでの最大値を
+上回った場合だけ加算する。つまり、この field が測るのは全表示完了履歴の cadence ではなく、
+**取得順に見て時刻の最大値を更新した履歴だけの cadence** である。
+
+`indra/llrender/llvkloader.cpp` は、この限定された分子と分母から `actual_display_fps` を作るが、
+分子・分母そのものはログに出していない。
+
+さらに、同梱 MoltenVK の固定コミットを確認すると、`MTLDrawable` の presented callback が
+`actualPresentTime` を履歴リングへ追加し、`vkGetPastPresentationTimingGOOGLE()` はリングの先頭から
+追加順に履歴を返す。AYAstorm は取得した配列を `actualPresentTime` 順に並べ替えていない。
+callback の呼び出し順と drawable の実時刻順が異なれば、次の二つが同時に影響を受ける。
+
+1. 最大時刻を更新した履歴だけを使う `actual_display_fps`
+2. 取得順に直前の `scene_id` と比較する fresh / duplicate 分類
+
+`VK_GOOGLE_display_timing` の履歴が複数件まとめて返る場合、現在のログには次の値がない。
+
+- `actual_interval_count`
+- `actual_interval_ns`
+- 回収配列内で `actualPresentTime` が時系列順だったか
+- 前区間から持ち越した履歴がどれだけあったか
+
+そのため、ログに記録された 159 区間の `actual_display_fps` 平均 16.74、中央値 17.12 を
+ディスプレイの実表示率とは結論できない。本書では、すべての完了履歴を数える
+`actual_display_count` と同期区間時間から求めた 25.838 件/秒を、現在利用できる整合性確認値として使う。
+これは集計窓あたりの完了履歴回収率であり、物理リフレッシュレートを意味しない。
+
+`fresh_scene_display_fps` も同種の時刻差分集計を使うため、主結論では 8.64 というログ field の
+区間平均ではなく、fresh 件数 6,934 / 同期区間 803.628 秒 = 8.628 件/秒を使用した。
+ただし、この fresh 件数自体も callback 回収順で分類した値である。時系列表示順での確定値を得るには、
+履歴を `actualPresentTime` で整列してから scene freshness を再判定する必要がある。
+
+## 6. `presentMargin` の読み方
+
+主集計 159 区間の `present_margin_ms_p50/p95/max` をさらに区間間で要約すると、次のようになる。
+
+| ログ内の区間要約値 | 区間値の中央値 | 区間値の平均 | 観測最大 |
+| --- | ---: | ---: | ---: |
+| `present_margin_ms_p50` | 11.894 ms | 12.597 ms | 21.016 ms |
+| `present_margin_ms_p95` | 26.219 ms | 26.346 ms | 47.951 ms |
+| `present_margin_ms_max` | 31.985 ms | 36.214 ms | 417.592 ms |
+
+これは raw 履歴全件の percentile ではなく、各約 5 秒区間で作った要約値を再度要約したものだ。
+また MoltenVK は Metal で直接得られない情報を補うため `presentMargin` を推定している。
+従って、417.592 ms の単発値だけから compositor や GPU を原因と断定しない。
+
+## 7. 確定事項と未確定事項
+
+### VERIFIED
+
+1. 診断 extension は有効で、169 区間すべてで履歴照会に成功した。
+2. 主集計では Consumer / Present 成功と drawable 表示完了履歴の回収件数 cadence は約 25.84 で一致した。
+3. 現行の callback 回収順では、表示完了履歴の 66.6% が同じ `scene_id` に分類された。
+4. その fresh 判定の件数 cadence 約 8.63 は async Producer の約 8.56 とほぼ一致した。
+5. 現行 `actual_display_fps` field は全完了履歴を分子に使っておらず、値 16--17 を表示 FPS として
+   採用できない。
+
+### OPEN
+
+- Producer が次の front scene を用意するまでに約 3 Consumer frame を必要とする内部原因。
+- CPU command buffer recording、GPU timeline 完了、shadow、asset load などのどこが支配的か。
+- main / non-main display、present mode、WindowServer の条件差。今回のログに比較条件がない。
+- 回収された timing 履歴の時刻順と、現行 `actual_display_fps` が件数 cadence から外れる正確な内訳。
+- `actualPresentTime` 順に分類し直したときの fresh / duplicate 比率。
+
+## 8. 次の調査
+
+1. 診断集計を補強し、`actual_interval_count`、`actual_interval_ns`、時刻の逆行件数をログに出す。
+   複数履歴は `actualPresentTime` 順に並べ、cadence と scene freshness を計算し直してから、
+   `actual_display_count / 区間時間` と照合する。
+2. 同一 scene・同一視点で main / non-main display を明記した対照 run を採り、Consumer、完了履歴件数、
+   fresh、duplicate、margin を同じ時間窓で比較する。
+3. `scene_id` を Producer submit、GPU timeline signal、front 切替、Consumer snapshot まで追跡し、
+   Producer 内部の CPU recording と GPU 完了待ちを分離する。
+4. per-layer 独立 primary command buffer (`ONE_TIME_SUBMIT`) と prefill の変更を行う場合は、変更前後で
+   Producer / fresh scene cadence が改善したかを同じ診断で比較する。
+
+## 参照
+
+- [VkPastPresentationTimingGOOGLE](https://registry.khronos.org/vulkan/specs/latest/man/html/VkPastPresentationTimingGOOGLE.html)
+- [MoltenVK `MVKImage.mm`（ローカル package provenance が示す固定 commit）](https://github.com/KhronosGroup/MoltenVK/blob/4b715bdcb1f108f2003fffe126c389ad0cca1c90/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm)
+- [MoltenVK `MVKSwapchain.mm`（同 commit）](https://github.com/KhronosGroup/MoltenVK/blob/4b715bdcb1f108f2003fffe126c389ad0cca1c90/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm)
+- [表示完了・3D scene freshness 診断の必要性](../specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md)
+- [macOS: Viewer FPS と見た目の FPS が乖離する事象の調査記録](ayastorm-r42-macos-fps-divergence-investigation.ja.md)

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -42,13 +42,22 @@ test -f "$APP/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
 用いてはならない。
 
 ```bash
-export AYA_DEV_PROFILE="$HOME/Library/Application Support/AYAstorm-dev"
-rm -rf "$AYA_DEV_PROFILE/cache/shader_cache"
-rm -f "$AYA_DEV_PROFILE/cache/pipeline_cache.bin"
+export AYA_VK_CACHE="$HOME/Library/Caches/AYAstorm-devOS_x64"
+rm -rf "$AYA_VK_CACHE/shader_cache"
+rm -f "$AYA_VK_CACHE/pipeline_cache.bin"
 ```
 
-削除対象は上記 2 項目だけである。`AYAstorm-dev` profile 全体、通常版の
-`AYAstorm` profile、または他の cache を削除しない。
+開発 app の既定 cache は `AYAstorm-devOS_x64` であり、`AYAstorm-dev` profile と同じく通常版から
+分離されるべきである。`~/Library/Application Support/AYAstorm-dev/cache/` は本検証の shader /
+pipeline cache 削除先ではない。削除対象は上記 2 項目だけである。
+
+> **VERIFIED（2026-08-11）**: `lldir_mac.cpp` は
+> profile 別に作成した cache root を `mDefaultCacheDir` に設定する。これにより開発 app の
+> `LL_PATH_CACHE` は `AYAstorm-devOS_x64`、通常版は `AYAstormOS_x64` になる。arm64 Release build は
+> 成功している。修正済み開発 app を起動し、`AYAstorm.log` の `setSoundCacheDir` が
+> `~/Library/Caches/AYAstorm-devOS_x64` を出力したこと、shader cache 初期化、Vulkan login screen
+> の成立を確認した。以後の cache-cold run はこの開発用 root の `shader_cache` と
+> `pipeline_cache.bin` を削除して開始する。
 
 ## 3. 診断起動とログ採取
 
@@ -60,7 +69,7 @@ export REPO="/path/to/phoenix-firestorm-mayatonton"
 export APP="$REPO/build-darwin-universal/newview/Release/AYAstorm.app"
 export AYA_DEV_PROFILE="$HOME/Library/Application Support/AYAstorm-dev"
 
-AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
+AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
 ```
 
 ログは次に出力される。
@@ -72,6 +81,30 @@ rg '#VkPerf#|FRAMETIME ms:|recreateSwapchain|WARNING|ERROR|VUID|device lost' "$L
 
 `AYASTORM_PERF_LOG=5` は `#VkPerf#` を約 5 秒周期で出す。P0 の `FRAMETIME ms:`
 は 10 秒周期で、平均値・p95・p99・最大値を記録する。
+
+### Viewer 処理 cadence と present cadence の比較
+
+`#VkPerf#` の `fps` は Vulkan frame を開始した回数であり、実際に画面へ出た回数そのものではない。
+同じ行の `cadence` 欄を必ず残す。
+
+```text
+cadence acq_fps=... present_call_fps=... present_ok_fps=...
+present_done_fps=... present_wait_avail=0|1 present_wait_used=0|1
+wait_attempts=... wait_timeout=... wait_error=...
+```
+
+- `acq_fps`: main swapchain image を取得できた回数。compositor が image を再利用可能にした cadence の近似値。
+- `present_call_fps`: `vkQueuePresentKHR()` 呼び出し回数。
+- `present_ok_fps`: WSI が present を受理した回数。
+- `present_wait_avail`: `VK_KHR_present_wait` を利用可能として初期化できたか。
+- `present_wait_used` と `wait_attempts`: この観測区間で実際に `vkWaitForPresentKHR()` を呼んだか・呼んだ回数。
+- `present_done_fps`: 呼び出しを行った区間（`present_wait_used=1`）だけで有効な present 完了回数。
+- `present_wait_avail=0` または `present_wait_used=0` かつ `present_done_fps=n/a`: 物理的な走査線への表示回数は
+  Vulkan ログだけでは確定できない。`acq_fps` と `present_ok_fps` を WSI 側の近似値として扱う。
+
+`fps` が `acq_fps` / `present_ok_fps` より継続して高い場合、Viewer が作成する frame と
+表示系の cadence が乖離している。UI scene async が有効な run では、併せて
+`uiscene consumer_fps` / `producer_fps` も記録する。
 
 ## 4. `shsite` による shadow 経路判定
 
@@ -570,3 +603,57 @@ AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
    `FRAMETIME ms:`、`recreateSwapchain` を記録する。
 4. macOS の結果を Linux / Windows の実行証拠とみなさず、共有 Vulkan TU に触れる本修正は各
    プラットフォーム担当者が build と Vulkan run を別途確認する。
+
+## 13. 未受入 run — 開発用 cache 分離不成立（2026-08-10）
+
+### 実行条件
+
+本 run の起動前に、次の 2 項目が存在することを確認した後、両方を削除し、削除後に不在であることを
+確認した。
+
+```text
+~/Library/Caches/AYAstormOS_x64/shader_cache/
+~/Library/Caches/AYAstormOS_x64/pipeline_cache.bin
+```
+
+開発 app は次の環境変数で起動した。Vulkan Loader / ICD / DYLD 系の追加 override は使用していない。
+
+```bash
+AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
+```
+
+原本は次のログである。
+
+```text
+~/Library/Application Support/AYAstorm-dev/logs/AYAstorm.log
+```
+
+### 観測結果と無効化理由
+
+削除した `AYAstormOS_x64` は、この build が実際に使用した `LL_PATH_CACHE` である。従って shader /
+pipeline cache は実使用先から cold start した。しかし同じ実行で user settings / logs は
+`~/Library/Application Support/AYAstorm-dev/` を使う一方、texturecache、shader cache、pipeline cache
+は通常版側の `AYAstormOS_x64` を使った。開発 app の cache 分離が成立していないため、下表の runtime
+観測は残すが、この run を **cache-cold 受入走行 1/3 として数えない**。
+
+| 確認項目 | 実測結果 | 判定 |
+| --- | --- | --- |
+| cache root | `AYAstorm-devOS_x64` ではなく `AYAstormOS_x64` を使用。 | FAIL: 開発 profile 分離不成立 |
+| 起動 | `initialized device=Apple M2 Pro` (15:41:27Z)、`Vulkan presentation surface initialized` (15:41:29Z)、`Initializing Login Screen` (15:41:40Z) を順に確認。 | VERIFIED |
+| 実行時間 | `Run time: 675.428 seconds`（約 11 分 15 秒）。ユーザー操作による終了後に `status: stopped`。 | VERIFIED |
+| device lost / VUID / ERROR | `device lost`、`VK_ERROR_DEVICE_LOST`、`VUID`、ログレベル `ERROR` はいずれも 0 件。 | VERIFIED |
+| swapchain | `recreateSwapchain` は 0 件。 | VERIFIED |
+| shadow 経路 | `#VkPerf#` 266 行中、`shsite` を含む 82 行すべてで `mv.am` を確認。`rest.am` 非ゼロ、`fb.*`、`fb_view_aux` は 0 件。 | VERIFIED: multiview フル経路 |
+| P0 | `FRAMETIME ms:` は 41 行。各 10 秒窓の p95 は 146.74--239.72 ms（平均 207.83 ms）、p99 は 154.10--257.42 ms（平均 219.42 ms）。終了直前は 9--13 fps であり、性能受入は未達。 | VERIFIED: 安定性と性能を分離 |
+
+WARNING は 997 件ある。HTTP 403 等の asset / network 系警告は継続している。加えて UUID
+`21dba3bc-4afa-2856-afa6-d312a7af56b5` は 6 回、`LLImageBase::allocateData called with bad
+dimensions: 4x4x0` に続いて decode failed となった。表示上の
+`# textures discarded due to insufficient memory` はこの allocation-error カウンタによるもので、
+本ログから物理メモリ枯渇は確認できない。対象は当該 UUID の decoded texture data と texturecache
+entry であり、ログだけではオブジェクトまたは face は特定できない。
+
+次の受入 run は、開発 app が `AYAstorm-devOS_x64` を使用する修正後に、shader cache と
+`pipeline_cache.bin` を同 root から消去して行う。10--30 分以上、login、teleport、texture streaming、
+カメラ回転を含め、視覚チェックリストも同一 run の証拠として記録する。3 走行完了までは最終受入を
+**OPEN** とする。

--- a/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-arm64-moltenvk-validation.ja.md
@@ -5,7 +5,7 @@
 `feature/ayastorm-r42-phase2` を起点にした開発用 app で、MoltenVK の shadow
 multiview 経路、描画品質、および P0 の性能・安定性計器を再現可能な形で確認する。
 
-- 対象 app: `build-darwin-universal/newview/Release/AYAstorm.app`
+- 対象 app: `build-darwin-dev/newview/Release/AYAstorm.app`
 - 対象環境: Apple Silicon（arm64）の macOS
 - 開発用 profile: `~/Library/Application Support/AYAstorm-dev/`
 - 対象外: DMG 配布物、Intel Mac、OpenGL fallback
@@ -22,7 +22,8 @@ multiview 経路、描画品質、および P0 の性能・安定性計器を再
 
 ```bash
 export REPO="/path/to/phoenix-firestorm-mayatonton"
-export APP="$REPO/build-darwin-universal/newview/Release/AYAstorm.app"
+export DEV_BUILD_DIR="$REPO/build-darwin-dev"
+export APP="$DEV_BUILD_DIR/newview/Release/AYAstorm.app"
 
 test -x "$APP/Contents/MacOS/AYAstorm"
 lipo -archs "$APP/Contents/MacOS/AYAstorm"
@@ -66,7 +67,8 @@ pipeline cache 削除先ではない。削除対象は上記 2 項目だけで�
 
 ```bash
 export REPO="/path/to/phoenix-firestorm-mayatonton"
-export APP="$REPO/build-darwin-universal/newview/Release/AYAstorm.app"
+export DEV_BUILD_DIR="$REPO/build-darwin-dev"
+export APP="$DEV_BUILD_DIR/newview/Release/AYAstorm.app"
 export AYA_DEV_PROFILE="$HOME/Library/Application Support/AYAstorm-dev"
 
 AYASTORM_VKC=1 AYASTORM_PERF_LOG=5 "$APP/Contents/MacOS/AYAstorm"
@@ -399,15 +401,20 @@ PresentEngine: device lost — all further submits skipped (first skipped: is_fr
 GPU device lost (VK_ERROR_DEVICE_LOST) — requesting graceful shutdown.
 ```
 
-### shader / pipeline cache が空の状態での再現 — 2026-08-09
+### shader / pipeline cache が空と判断した再現（後日無効化）— 2026-08-09
 
-同じ開発用 profile で、起動前に次の 2 項目を確認した。両方とも既に存在せず、profile 内に
-別位置の同名項目もなかったため、cache が空の状態であることを確認してから起動した。
+同じ開発用 profile で、起動前に当時の手順が示していた次の 2 項目を確認した。両方とも既に
+存在せず、profile 内に別位置の同名項目もなかったため、当時は cache が空の状態と判断した。
 
 ```text
 ~/Library/Application Support/AYAstorm-dev/cache/shader_cache/
 ~/Library/Application Support/AYAstorm-dev/cache/pipeline_cache.bin
 ```
+
+後日の cache root 調査により、この場所は `LL_PATH_CACHE` の既定値ではないことが判明した。
+この run では実使用 cache root の削除を証明できないため、cache-cold の証拠としては無効である。
+device lost の再現記録としてだけ扱う。現在の開発 app で削除する正しい場所は
+`~/Library/Caches/AYAstorm-devOS_x64/` である。
 
 起動には再び `AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` を用いた。`15:12:02Z` に Vulkan
 presentation surface / `2560x1387` swapchain の成立を確認したが、run time 約 68 秒後の
@@ -419,9 +426,9 @@ presentation surface / `2560x1387` swapchain の成立を確認したが、run t
   max 310.23, n 75`。
 - この場合も `requestQuit` を経由して `status: stopped` まで cleanup した。
 
-したがって shader cache / pipeline cache の残存は、この device lost の必要条件ではない。
-ただし cache を消しても device lost を防げないことを示すだけで、one-shot command buffer 内の
-どの操作が GPU 異常を引き起こしたかは未確定である。
+この再現から確認できるのは device lost が再発したことまでであり、shader cache / pipeline cache
+の残存との関係は判定できない。一方、失敗した one-shot submit と直前履歴の診断は cache-cold
+判定に依存しないため、one-shot command buffer 内の操作を追跡する根拠として残す。
 
 ### 現時点の切り分け
 

--- a/docs/guides/ayastorm-r42-macos-fps-divergence-investigation.ja.md
+++ b/docs/guides/ayastorm-r42-macos-fps-divergence-investigation.ja.md
@@ -1,0 +1,94 @@
+# AYAstorm R42 macOS: Viewer FPS と見た目の FPS が乖離する事象の調査記録
+
+## 結論
+
+macOS のメイン画面で「Viewer の FPS 表示は高いが、3D scene は低い FPS に見える」事象は、
+従来ログだけでは最終原因を確定できない。
+
+今回の実行で確認できたのは、Viewer が数える `consumer_fps` が約 38 fps だった一方、async scene command
+buffer の `producer_fps`、すなわち PE への submit cadence が約 13 fps だったことまでである。
+`producer_fps` は GPU 完了、front 切替、ディスプレイへの表示完了のいずれも数えていない。
+
+従って、同じ scene の再表示は有力な仮説だが、3D scene が実際に約 13 fps で表示されたとはまだ証明できない。
+FPS 表示が壊れているとも、macOS のメイン画面切替が原因だとも、このログだけからは結論づけない。
+
+## 1. 用語
+
+| 用語 | この調査での意味 |
+| --- | --- |
+| consumer | swapchain に UI と、直近で完成した 3D scene を合成して present する側。Viewer の `FPS` と `#VkPerf# fps` はこれを数える。 |
+| producer | 3D world scene を別の render target へ描画して、consumer が表示できる状態にする側。 |
+| `consumer_fps` | consumer が画面を合成した回数/秒。古い scene を再表示しても増える。 |
+| `producer_fps` | async scene command buffer を PE へ submit した回数/秒。GPU 完了回数や scene 表示回数ではない。 |
+| `ready1st` | submit 後の最初の完了確認で ready だった回数 / 後続確認を含めて ready を検出した総数。 |
+
+## 2. 今回の実測
+
+開発 app を `AYASTORM_VKC=1 AYASTORM_PERF_LOG=5` で起動したログでは、次を確認した。
+
+```text
+uiscene consumer_fps=38.20 producer_fps=12.67 ready1st=0/65
+frames=193 fps=38.20 avg_ms=26.18
+cadence acq_fps=38.20 present_call_fps=38.39 present_ok_fps=38.39
+present_done_fps=n/a present_wait_avail=1 present_wait_used=0
+```
+
+この値は次のように読む。
+
+1. consumer は 1 秒に約 38 回、UI と直近の scene を swapchain へ送っている。
+2. producer は 1 秒に約 13 回、async scene command buffer を submit している。
+3. `ready1st=0/65` のため、ready を検出した 65 件のいずれも submit 後の最初の完了確認では ready でなかった。
+4. consumer が同じ front scene を複数回合成した可能性は高いが、実際に表示完了した回数と、その各回の
+   `scene_id` が無いため、重複表示回数と見た目の 3D FPSは未確定である。
+
+この run では `FRAMETIME ms:` の p95 が約 70--111 ms、`SLOWFRAME` では
+`M:beg=80` ms 前後も連続していた。ただし `M:beg` は `beginFrame()` 全体の集計であり、既存ログだけでは
+frame timeline、producer slot、async record slot、acquire のどこで時間を使ったか分離できない。
+
+## 3. メイン画面との関係
+
+**VERIFIED:** 現在の UI scene async の有効/無効を、macOS の「メイン画面」フラグで切り替える
+コードはない。`sUISceneSplit` と `sUISceneAsync` はどちらも `true` に固定されている。
+
+**VERIFIED:** 今回の main display は 5K の外部画面だが、Vulkan が実際に作成した swapchain は
+`2560x1387` だった。従って、この実測だけから「5K の 4 倍の描画ピクセル数が直接原因」とは
+結論づけない。
+
+**OPEN:** メイン画面にした run と、メイン画面ではない run の表示完了 cadence および fresh scene cadence の
+差は未計測である。メイン画面化が原因、または単なる顕在化条件だという解釈はいずれもまだ仮説である。
+
+## 4. 物理的なモニター FPS について
+
+この run の present mode は `IMMEDIATE (vsync OFF)` だった。
+`VK_KHR_present_wait` は利用可能として初期化されているが、present 完了待機は FIFO mode のときだけ
+呼ぶ実装なので、この run では `present_wait_used=0`、`present_done_fps=n/a` になる。
+
+したがって、次の 2 点は分けて扱う。
+
+- **VERIFIED:** Viewer 内の consumer cadence と async producer submit cadence は約 3:1 に乖離している。
+- **OPEN:** Metal drawable が実際に表示完了した cadence と、そのうち新しい `scene_id` を表示した cadence。
+
+`acq_fps` と `present_ok_fps` は WSI が image を取得・受理した回数であり、物理走査線への表示完了を
+証明する値ではない。
+
+## 5. 実装上の根拠
+
+- [`llvkloader.cpp`](../../indra/llrender/llvkloader.cpp) は UI scene split / async を常時有効にする。
+- [`llviewerdisplay.cpp`](../../indra/newview/llviewerdisplay.cpp) は producer の timeline 完了時だけ
+  `mScenePresentFront` を更新する。未完了なら consumer は前の scene を表示する。
+- [`llvkpresent.cpp`](../../indra/llrender/llvkpresent.cpp) は FIFO present のときだけ present ID と
+  `vkWaitForPresentKHR()` を使用する。
+
+## 6. 次の調査境界
+
+性能修正を選ぶ前に、表示完了と scene freshness を同じ run で取得する。
+
+1. `VK_GOOGLE_display_timing` の `actualPresentTime` から drawable 表示完了 cadence を測る。
+2. 各 Present の `presentID` と consumer enqueue 時点の `scene_id` を対応付け、fresh / duplicate / unknownを
+   分離する。
+3. 実表示は高いが fresh scene 表示だけが低い場合に、初めて producer内部の完了待ち、GPU実行時間、
+   shadow per-layer command bufferを次の調査対象とする。
+
+表示完了診断を入れる理由と受入条件は
+[`ayastorm-r42-display-completion-diagnostics-rationale.ja.md`](../specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md)
+に分離した。診断コードのbuildは完了したが、実機runの値はまだOPENである。

--- a/docs/specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md
+++ b/docs/specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md
@@ -1,0 +1,231 @@
+# AYAstorm R42 表示完了・3D scene freshness 診断の必要性
+
+## 1. 結論
+
+AYAstorm の内部 FPS と、ディスプレイ上で新しい 3D scene が表示される FPS が一致しているかを判定するには、
+**Metal drawable の表示完了時刻と、その表示に使用した 3D scene の世代を対応付ける診断が必要**である。
+
+従来のログは、Viewer の frame loop、3D scene producer の submit、swapchain image の acquire、
+`vkQueuePresentKHR()` の受理までを観測できる。しかし、次の 2 点を観測できない。
+
+1. Present した drawable が macOS の表示系で実際に表示完了した時刻
+2. その表示が新しい 3D scene だったか、直前の scene の再表示だったか
+
+この 2 点が無いままでは、内部 FPS が高いときに、実際の 3D 表示も同じ FPS で更新されているとは証明できない。
+
+2026-08-14 時点で診断コードの実装と Viewer build は完了している。ただし、以下の実測値はまだ得ていないため、
+実機 run と `AYAstorm.log` の確認までは OPEN とする。本書は、その診断を入れる理由、証拠の境界、ログの判定方法を定める。
+
+## 2. 解決したい問い
+
+最終的に確認したいのは、単なる Present 要求数ではなく、次の一致である。
+
+```text
+Viewer の内部 frame cadence
+    ≒ 実際に表示完了した drawable cadence
+    ≒ 新しい 3D scene が表示完了した cadence
+```
+
+たとえば、内部 frame が 30 fps でも、3D scene が 10 fps でしか更新されず、同じ scene を 3 回ずつ
+Present している場合、画面の動きは 10 fps 相当になる。Present 要求を 30 回受理したという情報だけでは、
+この重複を判定できない。
+
+## 3. 区別しなければならない 4 つの cadence
+
+| cadence | 代表指標 | 意味 | 証拠範囲 |
+| --- | --- | --- | --- |
+| Consumer | `fps` / `consumer_fps` | UI 合成と Present 用 frame loop の回数 | 観測可能 |
+| 3D Producer | `producer_fps` | async scene command buffer を PE へ投入した回数 | submit 回数のみ観測可能 |
+| WSI Present | `present_call_fps` / `present_ok_fps` | `vkQueuePresentKHR()` の呼出・受理回数 | 観測可能 |
+| 実表示 | `actual_display_fps` | Metal drawable が実際に表示完了した回数と時刻 | 今回の診断有効 run で観測する |
+
+`producer_fps` は GPU 完了回数、front 反映回数、実表示回数ではない。現在は
+`sAsyncProducerSubmitCount` の増分を数えているため、名称だけから「新しい scene の完成 FPS」と解釈してはならない。
+
+`present_ok_fps` も実表示 FPS ではない。これは Vulkan/MoltenVK が Present 要求を受理したことを示すが、
+drawable の表示完了を示さない。
+
+## 4. 従来の診断だけでは原因を決定できない理由
+
+従来の値から、Consumer と Producer の submit cadence が乖離していること、および acquire / Present 受理が
+Consumer cadence に追従していることまでは確認できる。しかし、次の異なる状態が同じようなログになる。
+
+### 状態 A: 同じ scene の再表示
+
+```text
+Consumer 30 fps / Present 受理 30 fps / 新しい 3D scene 10 fps
+```
+
+同じ scene を複数回表示している。内部 FPS は高いが、3D の動きは低い。
+
+### 状態 B: Present 後の表示経路も低下
+
+```text
+Consumer 30 fps / Present 受理 30 fps / drawable 表示完了 10 fps
+```
+
+AYAstorm は Present を要求しているが、Metal/macOS の表示完了 cadence が低い。
+
+### 状態 C: 全 cadence が一致
+
+```text
+Consumer 30 fps / drawable 表示完了 30 fps / 新しい 3D scene 表示完了 30 fps
+```
+
+内部処理と新しい 3D 表示が一致している。目標とする状態である。
+
+従来のログは A、B、C を分離できないため、性能修正の対象を決める最終証拠にならない。
+
+## 5. Metal 表示完了を取得する経路
+
+AYAstorm は `CAMetalDrawable` を直接所有しない。drawable の取得と Present は MoltenVK が管理しているため、
+AYAstorm 側から直接 `addPresentedHandler` を登録する設計にはしない。
+
+同梱 MoltenVK 1.4.2 は、内部で `MTLDrawable.addPresentedHandler` を使用し、
+`MTLDrawable.presentedTime` を取得している。この結果は `VK_GOOGLE_display_timing` を通して Vulkan アプリへ
+公開される。
+
+AYAstorm は次の正式な Vulkan 境界を使用する。
+
+1. device extension 列挙で `VK_GOOGLE_display_timing` の利用可否を確認する。
+2. 利用可能な診断起動でのみ extension を有効化する。
+3. main swapchain の各 Present に一意な `presentID` を付ける。
+4. `vkGetPastPresentationTimingGOOGLE()` から `actualPresentTime` を回収する。
+5. `presentID` と、その Present が使用した `scene_id` を対応付ける。
+
+MoltenVK の改造や private API への依存は必要ない。
+
+## 6. `scene_id` が必要な理由
+
+Metal の表示完了回数だけを数えても、3D scene の滑らかさは証明できない。同じ front image を 30 回表示した場合も、
+drawable の表示完了は 30 回になるためである。
+
+新しい async Producer が GPU 完了し、front の scene render target が切り替わった時だけ、単調増加する
+`scene_id` を更新する。各 Present は使用した `scene_id` を保持する。
+
+表示完了履歴を回収したとき、直前に表示完了した `scene_id` と比較する。
+
+- `scene_id` が変化した: 新しい 3D scene の表示完了
+- `scene_id` が同じ: 直前の 3D scene の再表示
+- 対応表に存在しない: 証拠不足として unknown。新しい scene と推測しない
+
+この対応により、「実表示 FPS」と「新しい 3D scene の実表示 FPS」を別々に測定できる。
+
+## 7. 必須のログ項目
+
+診断ログは既存の `AYASTORM_PERF_LOG` 集計区間に合わせ、少なくとも次を出力する。
+
+```text
+display_timing_available
+display_timing_source
+actual_display_fps
+fresh_scene_display_fps
+duplicate_scene_count
+duplicate_ratio
+unknown_present_count
+display_timing_history_query_errors
+display_timing_history_last_result
+present_margin_ms_p50
+present_margin_ms_p95
+present_margin_ms_max
+```
+
+比較のため、同じ区間の既存値も併記または隣接行で参照できるようにする。
+
+```text
+fps                  # Consumer cadence の既存キー
+producer_fps         # Producer submit cadence の既存キー
+present_ok_fps
+```
+
+`fresh_scene_display_fps` は、実表示完了履歴のうち `scene_id` が変化した回数だけから算出する。
+`duplicate_ratio` の分母は、`scene_id` を確定できた fresh と duplicate の合計とする。unknown は分母へ入れず、
+別項目で残す。
+
+`actual_display_fps` は、連続する `actualPresentTime` の差分から算出する。present margin の分位値には、
+MoltenVK が同じ timing 経路で返す `presentMargin` を使用する。AYAstorm の `steady_clock` と
+`actualPresentTime` を直接減算してはならない。両者が同じ clock domain であることを
+Vulkan API は保証しないためである。
+
+## 8. 診断の有効条件
+
+表示完了診断は通常動作へ影響させない。次の両方が指定された起動だけで有効化する。
+
+```text
+AYASTORM_VKC=1
+AYASTORM_PERF_LOG=<正の秒数>
+```
+
+通常起動では、表示 timing extension の有効化、Present ID 対応表、履歴照会、追加ログ出力を行わない。
+
+この条件が制御するのは、今回追加する**表示完了診断**である。`AYASTORM_PERF_LOG` だけで既に出ている
+従来の性能ログまで `AYASTORM_VKC` 必須へ変更するものではない。両方を指定した診断 run では、
+表示完了の集計も通常の Viewer ログである `AYAstorm.log` へ記録する。
+
+extension、関数ポインタ、swapchain のいずれかが利用できない場合は、次のように明示する。
+
+```text
+display_timing_available=0
+actual_display_fps=n/a
+fresh_scene_display_fps=n/a
+```
+
+`vkQueuePresentKHR()` の成功回数から実表示完了を推定してはならない。
+
+## 9. 実装上の不変条件
+
+1. main swapchain だけを対象とし、aux window の Present を混ぜない。
+2. `presentID` と `scene_id` は単調 ID とし、wrap と再利用を安全に扱う。
+3. swapchain 再生成時に古い対応表を誤って新 swapchain の履歴へ結び付けない。
+4. 表示完了履歴は非同期に遅れて到着する前提で扱う。
+5. 対応表は有界とし、履歴が返らない場合も無制限に増やさない。
+6. 表示完了を待つ blocking wait を追加しない。PE thread から返却済み履歴だけを poll する。
+7. `actualPresentTime` が返った履歴だけを実表示完了として数える。
+8. 同じ `scene_id` の再表示を fresh scene に数えない。
+9. 既存の `VK_KHR_present_wait` 診断と共存させる。
+10. 診断値は性能制御、pacing、Present 分岐に使用しない。
+
+## 10. 診断コード導入後の判定表
+
+| Consumer | 実表示 | fresh 3D 表示 | 判定 |
+| --- | --- | --- | --- |
+| 高い | 高い | 低い | 同じ 3D scene を再表示。Producer または scene 更新制御を調査する。 |
+| 高い | 低い | 低い | Present 後の Metal/macOS 表示経路を調査する。 |
+| 低い | 低い | 低い | Viewer frame loop または Producer 待機を調査する。 |
+| 高い | 高い | 高い | 内部処理、新しい 3D scene、実表示が一致している。 |
+
+この判定を得た後に、Producer の直列記録、shadow per-layer command buffer、GPU 実行時間、
+Present pacing のどこを修正対象にするか決める。
+
+## 11. 受入条件
+
+### VERIFIED とできる条件
+
+- 診断無効起動で追加の extension、履歴照会、追加ログが動かない。
+- 診断有効起動で利用可否と timing source が明示される。
+- `actual_display_fps` は `actualPresentTime` を持つ履歴だけから算出される。
+- present margin の p50 / p95 / max は履歴の `presentMargin` から算出され、異なる clock domain の時刻を直接減算しない。
+- `fresh_scene_display_fps` は `presentID → scene_id` の対応と scene 変化だけから算出される。
+- duplicate と unknown が別集計され、unknown を fresh と推定しない。
+- swapchain 再生成と終了時に対応表が安全に処理される。
+- aux window の値が main window の表示 FPS に混入しない。
+
+### OPEN のまま残すもの
+
+- 計測前の実際の `actual_display_fps` と `fresh_scene_display_fps`
+- Producer が次の consumer frame までに完成しない内部ボトルネック
+- shadow per-layer record 並列化が Producer FPS を改善する量
+- ディスプレイパネルの発光を外部センサーで測る物理計測
+
+## 12. 非目標
+
+この診断コードは性能修正ではない。次は本診断の範囲外である。
+
+- UI/scene async の有効・無効を変更すること
+- `FRAMES_IN_FLIGHT` や 1-in-flight 制御を変更すること
+- shadow per-layer command buffer を実装すること
+- Present mode や VSync 設定を変更すること
+- macOS のメイン画面設定を原因と断定すること
+
+診断の目的は、修正を先に決めることではなく、内部 FPS、新しい 3D scene、実表示のどこで cadence が
+分岐しているかを、推測ではなく同一 run の一次情報で確定することである。

--- a/docs/specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md
+++ b/docs/specs/ayastorm-r42-display-completion-diagnostics-rationale.ja.md
@@ -215,7 +215,6 @@ Present pacing のどこを修正対象にするか決める。
 - 計測前の実際の `actual_display_fps` と `fresh_scene_display_fps`
 - Producer が次の consumer frame までに完成しない内部ボトルネック
 - shadow per-layer record 並列化が Producer FPS を改善する量
-- ディスプレイパネルの発光を外部センサーで測る物理計測
 
 ## 12. 非目標
 

--- a/indra/llfilesystem/lldir_mac.cpp
+++ b/indra/llfilesystem/lldir_mac.cpp
@@ -153,6 +153,8 @@ LLDir_Mac::LLDir_Mac()
   #endif
 #endif // OPENSIM
             CreateDirectory(mOSCacheDir, FSCacheDirName, NULL);
+            // Keep LL_PATH_CACHE on the same profile-specific root.
+            mDefaultCacheDir = add(mOSCacheDir, FSCacheDirName);
             //</FS:TS>
         }
 

--- a/indra/llrender/llvkdevice.cpp
+++ b/indra/llrender/llvkdevice.cpp
@@ -579,6 +579,20 @@ namespace LLVKLoaderInternal
         bool checkpoints_supported = false;
         bool present_id_supported = false;
         bool present_wait_supported = false;
+        bool display_timing_supported = false;
+        const bool display_timing_requested = []() -> bool {
+            const char* vkc = getenv("AYASTORM_VKC");
+            const char* perf = getenv("AYASTORM_PERF_LOG");
+            if (vkc == nullptr || std::strcmp(vkc, "1") != 0 || perf == nullptr)
+            {
+                return false;
+            }
+            char* end = nullptr;
+            const F64 interval = strtod(perf, &end);
+            return end != perf && end != nullptr && *end == '\0' && interval > 0.0;
+        }();
+        sDisplayTimingRequested = display_timing_requested;
+        sDisplayTimingEnabled = false;
         {
             U32 ext_count = 0;
             vkEnumerateDeviceExtensionProperties(sPhysicalDevice, nullptr, &ext_count, nullptr);
@@ -605,6 +619,10 @@ namespace LLVKLoaderInternal
                 else if (std::strcmp(e.extensionName, "VK_KHR_present_wait") == 0)
                 {
                     present_wait_supported = true;
+                }
+                else if (std::strcmp(e.extensionName, VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME) == 0)
+                {
+                    display_timing_supported = true;
                 }
             }
         }
@@ -654,6 +672,11 @@ namespace LLVKLoaderInternal
                 present_wait_features_enable.presentWait = VK_TRUE;
                 sPresentWaitEnabled = true;
             }
+        }
+        if (display_timing_requested && display_timing_supported)
+        {
+            device_extensions.push_back(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME);
+            sDisplayTimingEnabled = true;
         }
 
         VkPhysicalDeviceProvokingVertexFeaturesEXT pv_features_enable = {};
@@ -871,9 +894,20 @@ namespace LLVKLoaderInternal
         {
             sDeviceFaultEnabled = false;
         }
+        if (sDisplayTimingEnabled && vkGetPastPresentationTimingGOOGLE == nullptr)
+        {
+            LL_WARNS("Vulkan") << "display_timing extension was enabled but vkGetPastPresentationTimingGOOGLE is unavailable; disabling diagnostic" << LL_ENDL;
+            sDisplayTimingEnabled = false;
+        }
         LL_INFOS("Vulkan") << "GPU breadcrumb checkpoints enabled=" << (sCheckpointsEnabled ? 1 : 0)
                            << " device_fault enabled=" << (sDeviceFaultEnabled ? 1 : 0) << LL_ENDL;
         LL_INFOS("Vulkan") << "present_wait (vsync sleep) enabled=" << (sPresentWaitEnabled ? 1 : 0) << LL_ENDL;
+        if (display_timing_requested)
+        {
+            LL_INFOS("Vulkan") << "display_timing diagnostic requested=1"
+                               << " extension=" << (display_timing_supported ? 1 : 0)
+                               << " enabled=" << (sDisplayTimingEnabled ? 1 : 0) << LL_ENDL;
+        }
         vkGetDeviceQueue(sDevice, sGraphicsQueueFamily, 0, &sGraphicsQueue);
 
 

--- a/indra/llrender/llvkloader.cpp
+++ b/indra/llrender/llvkloader.cpp
@@ -384,6 +384,13 @@ namespace LLVKLoaderInternal
     std::atomic<U64>        sPEPrsLockUs{0};
     std::atomic<U64>        sPEPwMainUs{0};
     std::atomic<U64>        sPEPwAuxUs{0};
+    std::atomic<U64>        sMainSwapchainAcquireCount{0};
+    std::atomic<U64>        sMainPresentCallCount{0};
+    std::atomic<U64>        sMainPresentAcceptedCount{0};
+    std::atomic<U64>        sMainPresentWaitAttemptCount{0};
+    std::atomic<U64>        sMainPresentDoneCount{0};
+    std::atomic<U64>        sMainPresentWaitTimeoutCount{0};
+    std::atomic<U64>        sMainPresentWaitErrorCount{0};
     std::atomic<U64>        sAuxBeginFenceUs{0};
     std::atomic<U64>        sAuxBeginAcqUs{0};
     std::atomic<U64>        sProdEnqToSubUs{0};
@@ -396,14 +403,29 @@ namespace
     std::atomic<U32>        sProdCheckFirstReady{0};
     std::atomic<U32>        sProdCheckTotalReady{0};
     std::atomic<U32>        sProdChecksSinceSubmit{0};
+    // Starts at one so the initial scene has a stable tag before the first
+    // asynchronous front flip. This tag is read by the PE thread.
+    std::atomic<U64>        sDisplayTimingSceneId{1};
 } // namespace
 
 namespace LLVKLoaderInternal
 {
     bool                    sPresentWaitEnabled = false;
+    bool                    sDisplayTimingRequested = false;
+    bool                    sDisplayTimingEnabled = false;
     VkPresentModeKHR        sActivePresentMode = VK_PRESENT_MODE_FIFO_KHR;
     std::atomic<bool>       sVsyncEnabled{true};
     std::unordered_map<U64, ViewDeathInfo> sViewDeathLedger;
+
+    U64 currentDisplayTimingSceneId()
+    {
+        return sDisplayTimingSceneId.load(std::memory_order_relaxed);
+    }
+
+    void advanceDisplayTimingSceneId()
+    {
+        sDisplayTimingSceneId.fetch_add(1, std::memory_order_relaxed);
+    }
 } // namespace LLVKLoaderInternal
 
 static void           endSwapchainRendering();
@@ -1174,6 +1196,14 @@ bool asyncFrameEngaged()
     return sAsyncFrameEngaged;
 }
 
+void noteAsyncSceneFrontPresented()
+{
+    if (sDisplayTimingEnabled)
+    {
+        advanceDisplayTimingSceneId();
+    }
+}
+
 bool isSwapchainImageAcquired()
 {
     return sImageAcquired;
@@ -1333,6 +1363,7 @@ bool beginFrame(bool acquire_swapchain)
         if (acquire_res == VK_SUCCESS || acquire_res == VK_SUBOPTIMAL_KHR)
         {
             sImageAcquired = true;
+            sMainSwapchainAcquireCount.fetch_add(1, std::memory_order_relaxed);
             if (acquire_res == VK_SUBOPTIMAL_KHR)
             {
                 sRecreateReasonMask.fetch_or(RECREATE_REASON_ACQ_SUBOPTIMAL);
@@ -1447,6 +1478,19 @@ bool endFrame()
             const U32 frames = sMonotonicFrameCount - s_last_frame;
             if (frames > 0)
             {
+                // `frames` is the Vulkan frame cadence, whereas acquire/present show
+                // the WSI cadence. `present_done` is reported only when the driver
+                // exposes VK_KHR_present_wait; Vulkan otherwise has no scanout signal.
+                const U64 acquire_count = sMainSwapchainAcquireCount.exchange(0);
+                const U64 present_calls = sMainPresentCallCount.exchange(0);
+                const U64 present_ok    = sMainPresentAcceptedCount.exchange(0);
+                const U64 wait_attempt  = sMainPresentWaitAttemptCount.exchange(0);
+                const U64 present_done  = sMainPresentDoneCount.exchange(0);
+                const U64 wait_timeout  = sMainPresentWaitTimeoutCount.exchange(0);
+                const U64 wait_error    = sMainPresentWaitErrorCount.exchange(0);
+                const std::string present_done_fps = wait_attempt > 0
+                    ? llformat("%.2f", (F64)present_done / elapsed)
+                    : "n/a";
                 if (isUISceneAsync())
                 {
                     static U32 s_last_prod = 0;
@@ -1471,6 +1515,15 @@ bool endFrame()
                 LL_INFOS("VkPerf") << "frames=" << frames
                                    << " fps=" << ((F64)frames / elapsed)
                                    << " avg_ms=" << (elapsed * 1000.0 / (F64)frames)
+                                   << " | cadence acq_fps=" << ((F64)acquire_count / elapsed)
+                                   << " present_call_fps=" << ((F64)present_calls / elapsed)
+                                   << " present_ok_fps=" << ((F64)present_ok / elapsed)
+                                   << " present_done_fps=" << present_done_fps
+                                   << " present_wait_avail=" << (sPresentWaitEnabled ? 1 : 0)
+                                   << " present_wait_used=" << (wait_attempt > 0 ? 1 : 0)
+                                   << " wait_attempts=" << wait_attempt
+                                   << " wait_timeout=" << wait_timeout
+                                   << " wait_error=" << wait_error
                                    << " draws/f=" << (draws / frames)
                                    << " | emit/skip: pipe " << gVkPerf.pipe_bind.load() << "/" << gVkPerf.pipe_skip.load()
                                    << " desc " << gVkPerf.desc_bind.load() << "/" << gVkPerf.desc_skip.load()
@@ -1788,6 +1841,57 @@ bool endFrame()
                                    << " mt=" << (sPEThreaded ? 1 : 0)
                                    << " rw=" << recordWorkerCount()
                                    << LL_ENDL;
+                if (sDisplayTimingRequested)
+                {
+                    DisplayTimingIntervalStats display_timing = collectDisplayTimingIntervalStats();
+                    const std::string actual_display_fps = display_timing.actual_interval_count > 0 &&
+                                                           display_timing.actual_interval_ns > 0
+                        ? llformat("%.2f", (F64)display_timing.actual_interval_count * 1.0e9 /
+                                             (F64)display_timing.actual_interval_ns)
+                        : "n/a";
+                    const std::string fresh_scene_display_fps = display_timing.fresh_interval_count > 0 &&
+                                                                display_timing.fresh_interval_ns > 0
+                        ? llformat("%.2f", (F64)display_timing.fresh_interval_count * 1.0e9 /
+                                             (F64)display_timing.fresh_interval_ns)
+                        : "n/a";
+                    std::string margin_p50 = "n/a";
+                    std::string margin_p95 = "n/a";
+                    std::string margin_max = "n/a";
+                    if (!display_timing.present_margin_ns.empty())
+                    {
+                        std::sort(display_timing.present_margin_ns.begin(), display_timing.present_margin_ns.end());
+                        const size_t n = display_timing.present_margin_ns.size();
+                        const auto percentile = [&](F64 q) -> U64 {
+                            return display_timing.present_margin_ns[(size_t)(q * (F64)(n - 1) + 0.5)];
+                        };
+                        margin_p50 = llformat("%.3f", (F64)percentile(0.50) / 1.0e6);
+                        margin_p95 = llformat("%.3f", (F64)percentile(0.95) / 1.0e6);
+                        margin_max = llformat("%.3f", (F64)display_timing.present_margin_ns.back() / 1.0e6);
+                    }
+                    const std::string duplicate_ratio =
+                        (display_timing.fresh_count + display_timing.duplicate_count) > 0
+                        ? llformat("%.1f%%", 100.0 * (F64)display_timing.duplicate_count /
+                                                (F64)(display_timing.fresh_count + display_timing.duplicate_count))
+                        : "n/a";
+                    LL_INFOS("VkPerf") << "display_timing_available=" << (display_timing.enabled ? 1 : 0)
+                                       << " display_timing_source=" << (display_timing.enabled
+                                           ? "VK_GOOGLE_display_timing" : "n/a")
+                                       << " actual_display_count=" << display_timing.actual_count
+                                       << " actual_display_fps=" << actual_display_fps
+                                       << " fresh_scene_display_count=" << display_timing.fresh_count
+                                       << " fresh_scene_display_fps=" << fresh_scene_display_fps
+                                       << " duplicate_scene_count=" << display_timing.duplicate_count
+                                       << " unknown_present_count=" << display_timing.unknown_scene_count
+                                       << " duplicate_ratio=" << duplicate_ratio
+                                       << " present_margin_ms_p50=" << margin_p50
+                                       << " present_margin_ms_p95=" << margin_p95
+                                       << " present_margin_ms_max=" << margin_max
+                                       << " timing_map_pending=" << display_timing.pending_mappings
+                                       << " timing_map_drop=" << display_timing.mapping_dropped
+                                       << " display_timing_history_query_errors=" << display_timing.history_query_errors
+                                       << " display_timing_history_last_result=" << display_timing.last_history_query_result
+                                       << LL_ENDL;
+                }
             }
             gVkPerf.reset();
 #if LL_LINUX
@@ -1909,6 +2013,10 @@ bool endFrame()
                 target.swapchain      = sSwapchain;
                 target.image_index    = sAcquiredImageIndex;
                 target.wait_semaphore = sRenderFinishedSemaphores[sFrameIndex];
+                if (sDisplayTimingEnabled)
+                {
+                    target.scene_id = currentDisplayTimingSceneId();
+                }
                 cjob.presents.push_back(target);
             }
         }
@@ -1955,6 +2063,10 @@ bool endFrame()
                 target.swapchain      = sSwapchain;
                 target.image_index    = sAcquiredImageIndex;
                 target.wait_semaphore = sRenderFinishedSemaphores[sFrameIndex];
+                if (sDisplayTimingEnabled)
+                {
+                    target.scene_id = currentDisplayTimingSceneId();
+                }
                 job.presents.push_back(target);
             }
         }

--- a/indra/llrender/llvkloader.h
+++ b/indra/llrender/llvkloader.h
@@ -59,6 +59,9 @@ namespace LLVKLoader
     bool asyncShouldRenderScene();
     void setAsyncFrameEngaged(bool on);
     bool asyncFrameEngaged();
+    // Diagnostic-only scene generation tag. A new value denotes a completed
+    // async scene becoming the front image, not a UI-only consumer frame.
+    void noteAsyncSceneFrontPresented();
     bool isSwapchainImageAcquired();
     void asyncProducerBeginScene(U32 back_index);
     void setProducerPresentActive(bool on);

--- a/indra/llrender/llvkloaderinternal.h
+++ b/indra/llrender/llvkloaderinternal.h
@@ -450,6 +450,27 @@ void dumpDeviceFaultOnDeviceLost();
         VkSwapchainKHR swapchain      = VK_NULL_HANDLE;
         U32            image_index    = 0;
         VkSemaphore    wait_semaphore = VK_NULL_HANDLE;
+        // Captured when the consumer command buffer is queued, rather than
+        // when the PE thread eventually calls vkQueuePresentKHR.
+        U64            scene_id       = 0;
+    };
+
+    struct DisplayTimingIntervalStats
+    {
+        bool enabled = false;
+        U64 actual_count = 0;
+        U64 actual_interval_count = 0;
+        U64 actual_interval_ns = 0;
+        U64 fresh_count = 0;
+        U64 fresh_interval_count = 0;
+        U64 fresh_interval_ns = 0;
+        U64 duplicate_count = 0;
+        U64 unknown_scene_count = 0;
+        U64 mapping_dropped = 0;
+        U64 history_query_errors = 0;
+        S32 last_history_query_result = VK_SUCCESS;
+        U32 pending_mappings = 0;
+        std::vector<U64> present_margin_ns;
     };
 
     struct PESyncPoint
@@ -501,6 +522,16 @@ extern std::atomic<U64> sPEPrsAuxUs;
 extern std::atomic<U64> sPEPrsLockUs;
 extern std::atomic<U64> sPEPwMainUs;
 extern std::atomic<U64> sPEPwAuxUs;
+// Per AYASTORM_PERF_LOG interval. `done` is meaningful only while
+// VK_KHR_present_wait is enabled; otherwise Vulkan cannot report scanout.
+extern std::atomic<U64> sMainSwapchainAcquireCount;
+extern std::atomic<U64> sMainPresentCallCount;
+extern std::atomic<U64> sMainPresentAcceptedCount;
+// Present-wait availability is negotiated separately. These count actual calls.
+extern std::atomic<U64> sMainPresentWaitAttemptCount;
+extern std::atomic<U64> sMainPresentDoneCount;
+extern std::atomic<U64> sMainPresentWaitTimeoutCount;
+extern std::atomic<U64> sMainPresentWaitErrorCount;
 extern std::atomic<U64> sAuxBeginFenceUs;
 extern std::atomic<U64> sAuxBeginAcqUs;
 extern std::atomic<U64> sProdEnqToSubUs;
@@ -508,8 +539,14 @@ extern std::atomic<U32> sProdSubCount;
 extern std::atomic<U64> sProdEnqMonoUs;
 U64 vkMonoUs();
 extern bool sPresentWaitEnabled;
+extern bool sDisplayTimingRequested;
+extern bool sDisplayTimingEnabled;
 extern VkPresentModeKHR sActivePresentMode;
 extern std::atomic<bool> sVsyncEnabled;
+U64 currentDisplayTimingSceneId();
+void advanceDisplayTimingSceneId();
+void resetDisplayTimingHistory();
+DisplayTimingIntervalStats collectDisplayTimingIntervalStats();
 uint64_t gpuTimelineValue();
 void waitTimeline(uint64_t v);
 uint64_t peEnqueue(PEJob&& job);

--- a/indra/llrender/llvkpresent.cpp
+++ b/indra/llrender/llvkpresent.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <list>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -112,6 +113,185 @@ namespace LLVKLoaderInternal
 namespace
 {
     std::atomic<U64>        sPresentIdCounter{0};
+
+    constexpr size_t DISPLAY_TIMING_MAPPING_LIMIT = 4096;
+
+    struct DisplayTimingPresentMapping
+    {
+        U64 scene_id = 0;
+    };
+
+    std::mutex sDisplayTimingMutex;
+    std::unordered_map<U32, DisplayTimingPresentMapping> sDisplayTimingMappings;
+    std::unordered_set<U32> sDisplayTimingCompletedIds;
+    U64 sDisplayTimingLastActualTime = 0;
+    U64 sDisplayTimingLastFreshTime = 0;
+    U64 sDisplayTimingLastSceneId = 0;
+    bool sDisplayTimingLastSceneValid = false;
+    bool sDisplayTimingIdExhausted = false;
+    LLVKLoaderInternal::DisplayTimingIntervalStats sDisplayTimingIntervalStats;
+
+    U32 nextDisplayTimingPresentId()
+    {
+        // `0` is reserved by VK_GOOGLE_display_timing. Do not recycle a
+        // 32-bit wire ID: on wrap, stop tagging rather than risk mapping a
+        // delayed completion to a different scene.
+        if (sDisplayTimingIdExhausted)
+        {
+            return 0;
+        }
+        const U64 serial = sPresentIdCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (serial > (U64)std::numeric_limits<U32>::max())
+        {
+            sDisplayTimingIdExhausted = true;
+            return 0;
+        }
+        return (U32)serial;
+    }
+
+    void rememberDisplayTimingPresent(U32 present_id, U64 scene_id)
+    {
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        if (sDisplayTimingMappings.size() >= DISPLAY_TIMING_MAPPING_LIMIT ||
+            sDisplayTimingMappings.find(present_id) != sDisplayTimingMappings.end())
+        {
+            ++sDisplayTimingIntervalStats.mapping_dropped;
+            return;
+        }
+        sDisplayTimingMappings.emplace(present_id, DisplayTimingPresentMapping{scene_id});
+    }
+
+    void forgetDisplayTimingPresent(U32 present_id)
+    {
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        sDisplayTimingMappings.erase(present_id);
+    }
+
+    void noteDisplayTimingQueryError(VkResult result)
+    {
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        ++sDisplayTimingIntervalStats.history_query_errors;
+        sDisplayTimingIntervalStats.last_history_query_result = (S32)result;
+    }
+
+    void pollDisplayTimingLocked(VkSwapchainKHR swapchain)
+    {
+        if (!sDisplayTimingEnabled || vkGetPastPresentationTimingGOOGLE == nullptr ||
+            swapchain == VK_NULL_HANDLE)
+        {
+            return;
+        }
+        U32 count = 0;
+        VkResult result = vkGetPastPresentationTimingGOOGLE(sDevice, swapchain, &count, nullptr);
+        if (result != VK_SUCCESS)
+        {
+            noteDisplayTimingQueryError(result);
+            return;
+        }
+        if (count == 0)
+        {
+            return;
+        }
+        std::vector<VkPastPresentationTimingGOOGLE> timings(count);
+        result = vkGetPastPresentationTimingGOOGLE(sDevice, swapchain, &count, timings.data());
+        if (result != VK_SUCCESS)
+        {
+            noteDisplayTimingQueryError(result);
+            return;
+        }
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        for (U32 i = 0; i < count; ++i)
+        {
+            const VkPastPresentationTimingGOOGLE& timing = timings[i];
+            if (timing.presentID == 0 || timing.actualPresentTime == 0 ||
+                !sDisplayTimingCompletedIds.insert(timing.presentID).second)
+            {
+                continue;
+            }
+            if (sDisplayTimingCompletedIds.size() > DISPLAY_TIMING_MAPPING_LIMIT)
+            {
+                // This set only suppresses duplicate history delivery. If an
+                // old entry is seen again after reset it has no mapping and is
+                // therefore counted as unknown, never as fresh/duplicate.
+                sDisplayTimingCompletedIds.clear();
+            }
+
+            ++sDisplayTimingIntervalStats.actual_count;
+            sDisplayTimingIntervalStats.present_margin_ns.push_back(timing.presentMargin);
+            if (sDisplayTimingLastActualTime != 0 && timing.actualPresentTime > sDisplayTimingLastActualTime)
+            {
+                ++sDisplayTimingIntervalStats.actual_interval_count;
+                sDisplayTimingIntervalStats.actual_interval_ns += timing.actualPresentTime - sDisplayTimingLastActualTime;
+            }
+            if (timing.actualPresentTime > sDisplayTimingLastActualTime)
+            {
+                sDisplayTimingLastActualTime = timing.actualPresentTime;
+            }
+
+            const auto it = sDisplayTimingMappings.find(timing.presentID);
+            if (it == sDisplayTimingMappings.end())
+            {
+                ++sDisplayTimingIntervalStats.unknown_scene_count;
+                sDisplayTimingLastSceneValid = false;
+                continue;
+            }
+            const U64 scene_id = it->second.scene_id;
+            sDisplayTimingMappings.erase(it);
+            if (!sDisplayTimingLastSceneValid)
+            {
+                ++sDisplayTimingIntervalStats.unknown_scene_count;
+                sDisplayTimingLastSceneId = scene_id;
+                sDisplayTimingLastSceneValid = true;
+                continue;
+            }
+            if (scene_id == sDisplayTimingLastSceneId)
+            {
+                ++sDisplayTimingIntervalStats.duplicate_count;
+                continue;
+            }
+            ++sDisplayTimingIntervalStats.fresh_count;
+            if (sDisplayTimingLastFreshTime != 0 && timing.actualPresentTime > sDisplayTimingLastFreshTime)
+            {
+                ++sDisplayTimingIntervalStats.fresh_interval_count;
+                sDisplayTimingIntervalStats.fresh_interval_ns += timing.actualPresentTime - sDisplayTimingLastFreshTime;
+            }
+            if (timing.actualPresentTime > sDisplayTimingLastFreshTime)
+            {
+                sDisplayTimingLastFreshTime = timing.actualPresentTime;
+            }
+            sDisplayTimingLastSceneId = scene_id;
+        }
+    }
+
+} // namespace
+
+namespace LLVKLoaderInternal
+{
+    void resetDisplayTimingHistory()
+    {
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        sDisplayTimingMappings.clear();
+        sDisplayTimingCompletedIds.clear();
+        sDisplayTimingLastActualTime = 0;
+        sDisplayTimingLastFreshTime = 0;
+        sDisplayTimingLastSceneId = 0;
+        sDisplayTimingLastSceneValid = false;
+        sDisplayTimingIntervalStats = DisplayTimingIntervalStats{};
+    }
+
+    DisplayTimingIntervalStats collectDisplayTimingIntervalStats()
+    {
+        std::lock_guard<std::mutex> guard(sDisplayTimingMutex);
+        DisplayTimingIntervalStats stats = std::move(sDisplayTimingIntervalStats);
+        stats.enabled = sDisplayTimingEnabled;
+        stats.pending_mappings = (U32)sDisplayTimingMappings.size();
+        sDisplayTimingIntervalStats = DisplayTimingIntervalStats{};
+        return stats;
+    }
+} // namespace LLVKLoaderInternal
+
+namespace
+{
 
     struct PEJobReleaser
     {
@@ -325,18 +505,47 @@ namespace
                 //     macOS does not busy-wait either.
                 // Do NOT ship a platform that busy-waits vsync — return the core.
                 // ============================================================================
+                const bool prs_aux = (t.swapchain != sSwapchain);
                 VkPresentIdKHR present_id_info = {};
+                VkPresentTimeGOOGLE present_time = {};
+                VkPresentTimesInfoGOOGLE display_timing_info = {};
                 uint64_t this_present_id = 0;
-                if (sPresentWaitEnabled && sActivePresentMode == VK_PRESENT_MODE_FIFO_KHR)
+                U32 display_timing_present_id = 0;
+                const bool present_wait_active = sPresentWaitEnabled &&
+                                                 sActivePresentMode == VK_PRESENT_MODE_FIFO_KHR;
+                if (!prs_aux && sDisplayTimingEnabled)
+                {
+                    display_timing_present_id = nextDisplayTimingPresentId();
+                    if (present_wait_active)
+                    {
+                        this_present_id = display_timing_present_id;
+                    }
+                    if (display_timing_present_id != 0)
+                    {
+                        present_time.presentID = display_timing_present_id;
+                        // Zero asks the implementation to choose its normal
+                        // presentation time. The returned actualPresentTime is
+                        // the only signal counted as display completion.
+                        present_time.desiredPresentTime = 0;
+                        display_timing_info.sType = VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE;
+                        display_timing_info.swapchainCount = 1;
+                        display_timing_info.pTimes = &present_time;
+                        display_timing_info.pNext = present_info.pNext;
+                        present_info.pNext = &display_timing_info;
+                    }
+                }
+                if (this_present_id == 0 && present_wait_active)
                 {
                     this_present_id = sPresentIdCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+                }
+                if (present_wait_active && this_present_id != 0)
+                {
                     present_id_info.sType          = VK_STRUCTURE_TYPE_PRESENT_ID_KHR;
                     present_id_info.swapchainCount = 1;
                     present_id_info.pPresentIds    = &this_present_id;
                     present_id_info.pNext          = present_info.pNext;
                     present_info.pNext             = &present_id_info;
                 }
-                const bool prs_aux = (t.swapchain != sSwapchain);
                 const auto p0 = std::chrono::steady_clock::now();
                 VkResult pr;
                 {
@@ -344,12 +553,36 @@ namespace
                     const auto p1 = std::chrono::steady_clock::now();
                     sPEPrsLockUs += (U64)std::chrono::duration_cast<std::chrono::microseconds>(p1 - p0).count();
                     pr = vkQueuePresentKHR(sGraphicsQueue, &present_info);
+                    if (!prs_aux && display_timing_present_id != 0 &&
+                        (pr == VK_SUCCESS || pr == VK_SUBOPTIMAL_KHR))
+                    {
+                        rememberDisplayTimingPresent(display_timing_present_id, t.scene_id);
+                    }
+                    else if (!prs_aux && display_timing_present_id != 0)
+                    {
+                        forgetDisplayTimingPresent(display_timing_present_id);
+                    }
+                    if (!prs_aux && sDisplayTimingEnabled)
+                    {
+                        // Keep this query under the same main-swapchain lock
+                        // as vkQueuePresentKHR so recreate cannot invalidate
+                        // the handle while MoltenVK returns delayed history.
+                        pollDisplayTimingLocked(t.swapchain);
+                    }
                     (prs_aux ? sPEPrsAuxUs : sPEPrsMainUs) +=
                         (U64)std::chrono::duration_cast<std::chrono::microseconds>(
                             std::chrono::steady_clock::now() - p1).count();
                 }
                 sPEPresentUs += (U64)std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::steady_clock::now() - p0).count();
+                if (!prs_aux)
+                {
+                    sMainPresentCallCount.fetch_add(1, std::memory_order_relaxed);
+                    if (pr == VK_SUCCESS || pr == VK_SUBOPTIMAL_KHR)
+                    {
+                        sMainPresentAcceptedCount.fetch_add(1, std::memory_order_relaxed);
+                    }
+                }
                 if (pr == VK_ERROR_OUT_OF_DATE_KHR || pr == VK_SUBOPTIMAL_KHR)
                 {
                     sRecreateReasonMask.fetch_or((pr == VK_SUBOPTIMAL_KHR)
@@ -364,13 +597,29 @@ namespace
 #endif
                     sVkDeviceLost.store(true, std::memory_order_release);
                 }
-                else if (sPresentWaitEnabled && pr == VK_SUCCESS && this_present_id != 0)
+                else if (present_wait_active && pr == VK_SUCCESS && this_present_id != 0)
                 {
+                    sMainPresentWaitAttemptCount.fetch_add(1, std::memory_order_relaxed);
                     const auto w0 = std::chrono::steady_clock::now();
                     VkResult wr = vkWaitForPresentKHR(sDevice, t.swapchain, this_present_id, 100000000ull);
                     (prs_aux ? sPEPwAuxUs : sPEPwMainUs) +=
                         (U64)std::chrono::duration_cast<std::chrono::microseconds>(
                             std::chrono::steady_clock::now() - w0).count();
+                    if (!prs_aux)
+                    {
+                        if (wr == VK_SUCCESS)
+                        {
+                            sMainPresentDoneCount.fetch_add(1, std::memory_order_relaxed);
+                        }
+                        else if (wr == VK_TIMEOUT)
+                        {
+                            sMainPresentWaitTimeoutCount.fetch_add(1, std::memory_order_relaxed);
+                        }
+                        else
+                        {
+                            sMainPresentWaitErrorCount.fetch_add(1, std::memory_order_relaxed);
+                        }
+                    }
                     if (wr == VK_ERROR_DEVICE_LOST)
                     {
 #if LL_DARWIN

--- a/indra/llrender/llvkswapchain.cpp
+++ b/indra/llrender/llvkswapchain.cpp
@@ -428,6 +428,7 @@ namespace LLVKLoaderInternal
 
     void destroySwapchain()
     {
+        resetDisplayTimingHistory();
         if (sDevice == VK_NULL_HANDLE)
         {
             sSwapchainImageViews.clear();
@@ -489,6 +490,9 @@ namespace LLVKLoaderInternal
         const auto drain_t1 = std::chrono::steady_clock::now();
         vkDeviceWaitIdle(sDevice);
         const auto drain_t2 = std::chrono::steady_clock::now();
+        // History entries are swapchain-scoped. Do not carry delayed old
+        // entries across this handle change.
+        resetDisplayTimingHistory();
         for (VkImageView& view : sSwapchainImageViews)
         {
             if (view != VK_NULL_HANDLE)

--- a/indra/newview/llviewerdisplay.cpp
+++ b/indra/newview/llviewerdisplay.cpp
@@ -576,6 +576,7 @@ void display(bool rebuild, F32 zoom_factor, int subfield, bool for_snapshot)
     if (aya_async_frame && LLVKLoader::asyncProducerTryComplete())
     {
         gPipeline.mScenePresentFront = LLVKLoader::asyncProducerBackIndex();
+        LLVKLoader::noteAsyncSceneFrontPresented();
     }
 
     if (LLPipelineFrameContext::getInstance().isRenderingDeferred())


### PR DESCRIPTION
## 概要

macOS/MoltenVK環境で、Viewer内部のframe cadenceと、Metal drawableの実表示cadence、新しい3D sceneが実際に表示されたcadenceを分離して観測できる診断を追加します。

あわせて、開発版AYAstormのcache rootを通常版から分離し、macOS arm64検証手順とFPS乖離の証拠境界を日本語文書へ記録します。

## 背景と原因調査上の問題

従来のログで観測できたのは、Consumer frame、async Producerのsubmit、swapchain acquire、`vkQueuePresentKHR()`の受理まででした。

そのため、次の2状態を区別できませんでした。

- 同じ3D sceneを複数回Presentしている
- Present受理後のMetal/macOS表示経路でcadenceが低下している

また、`producer_fps`はasync scene command bufferのsubmit回数であり、GPU完了回数や新しいsceneの実表示FPSではありません。

## 変更内容

- `AYASTORM_VKC=1`かつ数値として`AYASTORM_PERF_LOG>0`の場合だけ`VK_GOOGLE_display_timing`を有効化
- main swapchainのPresentへ一意な`presentID`を付与し、aux swapchainを除外
- async Producer完了後のfront切替で`scene_id`を進め、Consumer CB enqueue時点のsceneをPresentへ固定
- `vkGetPastPresentationTimingGOOGLE()`の`actualPresentTime`から実表示FPSを算出
- `presentID -> scene_id`対応からfresh scene、duplicate scene、unknownを分離
- `presentMargin`からp50/p95/maxを算出し、異なるclock domainの時刻を直接減算しない
- mappingを4096件に制限し、履歴遅延、ID wrap、swapchain再生成、照会エラーをfail-closedで処理
- 診断無効時はextension有効化、履歴poll、専用ログを追加しない
- main swapchainのacquire / Present受理 / present-wait cadenceも`#VkPerf#`へ追加
- 開発版の`LL_PATH_CACHE`を`AYAstorm-devOS_x64`へ分離
- 検証手順、FPS乖離調査、表示完了診断の必要性を日本語文書化

## 追加ログ

診断有効時は`AYAstorm.log`へ次を出力します。

- `display_timing_available`
- `display_timing_source`
- `actual_display_fps`
- `fresh_scene_display_fps`
- `duplicate_scene_count` / `duplicate_ratio`
- `unknown_present_count`
- `present_margin_ms_p50/p95/max`
- mapping dropおよび履歴照会エラー

## 実機確認

Apple M2 Pro / macOS / bundled MoltenVK 1.4.2で、約859秒の診断runを実施しました。

- `display_timing_available=1`
- `display_timing_source=VK_GOOGLE_display_timing`
- 表示完了診断を169区間で取得
- `timing_map_drop=0`
- `display_timing_history_query_errors=0`
- 正常終了

終了直前の代表区間:

```text
Consumer / Present受理:   約31.43 fps
Metal drawable実表示:     18.38 fps
新しい3D scene実表示:     10.46 fps
duplicate ratio:          66.7%
unknown:                  0
```

この値は原因修正の結論ではなく、従来分離できなかったConsumer、実表示、fresh scene表示のcadenceが同一runで観測可能になったことを示します。

## 検証

- `git diff --check`
- arm64 `llrender` build: `BUILD SUCCEEDED`
- Viewer全体build: exit code 0 / `BUILD SUCCEEDED`
- 実機run: 約859秒、正常終了

## OPEN

- Producerが次のConsumer frameまでに完了しない内部ボトルネック
- shadow per-layer command buffer変更による改善量
- メイン画面・非メイン画面条件間の再計測比較

## 非目標

このPRは診断とcache分離を対象とし、UI/scene async、`FRAMES_IN_FLIGHT`、Present mode、VSync、shadow recording方式などの性能制御は変更しません。
